### PR TITLE
feat: skip visual regression testing for dependabot PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
           affectedCmd: npx nx affected:test
           isDev: ${{ env.IS_DEV }}
   test-visual:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We don't have to run 300+ visual regressions on each package update.
Unit tests are enough, so this PR disables visual tests if the bot creates PRs

When merged -> we have to remove a key from [here](https://github.com/spryker/oryx/settings/secrets/dependabot)