### PR TITLE
fix: address edit error handling

### DIFF
--- a/libs/domain/user/address-edit/src/address-edit.component.spec.ts
+++ b/libs/domain/user/address-edit/src/address-edit.component.spec.ts
@@ -147,29 +147,4 @@ describe('AddressEditComponent', () => {
       });
     });
   });
-
-  describe('when submit throws an error', () => {
-    const callback = vi.fn();
-
-    beforeEach(async () => {
-      addressService.addAddress = vi.fn().mockImplementation(() => {
-        throw new Error('test: address storing is failed');
-      });
-      element = await fixture(
-        html`<oryx-user-address-edit
-          @oryx.success=${callback}
-        ></oryx-user-address-edit>`
-      );
-      form = element.renderRoot.querySelector(
-        'oryx-address-form'
-      ) as AddressFormComponent;
-      form.dispatchEvent(
-        new CustomEvent('oryx.submit', { detail: { values: {} } })
-      );
-    });
-
-    it('should not dispatch oryx.success event', () => {
-      expect(callback).not.toHaveBeenCalled();
-    });
-  });
 });

--- a/libs/domain/user/address-edit/src/address-edit.component.ts
+++ b/libs/domain/user/address-edit/src/address-edit.component.ts
@@ -5,7 +5,7 @@ import { AddressFormComponent } from '@spryker-oryx/user/address-form';
 import { hydratable, i18n } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
 import { createRef, Ref, ref } from 'lit/directives/ref.js';
-import { catchError, tap, throwError } from 'rxjs';
+import { tap } from 'rxjs';
 import { BACK_EVENT, SUCCESS_EVENT } from './address-edit.model';
 import { styles } from './address-edit.styles';
 
@@ -34,10 +34,7 @@ export class AddressEditComponent extends AddressMixin(
     this.addressService[this.addressId ? 'updateAddress' : 'addAddress'](
       this.ensureAddress(e.detail.values as Address)
     )
-      .pipe(
-        catchError((e) => throwError(() => e)),
-        tap(() => this.emitEvent(SUCCESS_EVENT))
-      )
+      .pipe(tap(() => this.emitEvent(SUCCESS_EVENT)))
       .subscribe();
   }
 


### PR DESCRIPTION
In terms of we don't have a proper solution for handling BE error for form data current temporary error handling inside address edit component is useless, due to our global error interceptor doing the same. 

closes to [HRZ-2277](https://spryker.atlassian.net/browse/HRZ-2277)
