### PR TITLE
fix: github action PR/branch check

### DIFF
--- a/.github/actions/run-optimal/action.yml
+++ b/.github/actions/run-optimal/action.yml
@@ -14,8 +14,8 @@ runs:
   using: 'composite'
   steps:
     - run: ${{ inputs.cmd }}
-      if: ${{ inputs.isDev }}
+      if: ${{ inputs.isDev == 'true' }}
       shell: bash
     - run: ${{ inputs.affectedCmd }}
-      if: ${{ inputs.isDev != true }}
+      if: ${{ inputs.isDev == 'false' }}
       shell: bash


### PR DESCRIPTION
GitHub actions are always executed as they are run in the development branch and not the PR

This causes issues with visual regression testing (all changes are approved automatically, which should not happen) and all jobs are run against all projects in the repo, even if only 1 project was changed.

Issue details are described in 
https://github.com/actions/runner/issues/1173