### PR TITLE
fix: github action env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   GITHUB_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
-  IS_DEV: ${{ github.event_name != 'pull_request' && github.ref == 'development' }}
+  IS_DEV: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/development' }}
 
 jobs:
   test-format:


### PR DESCRIPTION
development branch detection in GitHub Action was broken, that's why we skipped all checks in the dev branch (and we might have issues in current PRs)