### PR TITLE
fix: temporary solution to remove dark theme form picking app

### DIFF
--- a/libs/template/presets/src/features/fulfillment/app.ts
+++ b/libs/template/presets/src/features/fulfillment/app.ts
@@ -1,0 +1,22 @@
+import { cartFeature } from '@spryker-oryx/cart';
+import { AppFeature, coreFeature, Resources } from '@spryker-oryx/core';
+import { fulfillmentTheme as theme } from '@spryker-oryx/themes';
+import { uiFeature } from '@spryker-oryx/ui';
+import { resourceGraphics } from '../../resources';
+
+export const fulfillmentResources: Resources = {
+  graphics: {
+    ...resourceGraphics,
+  },
+};
+
+export const fulfillmentFeatures: AppFeature[] = [
+  uiFeature,
+  cartFeature,
+  coreFeature,
+  {
+    resources: fulfillmentResources,
+  },
+];
+
+export const fulfillmentTheme = { ...theme };

--- a/libs/template/presets/src/features/fulfillment/index.ts
+++ b/libs/template/presets/src/features/fulfillment/index.ts
@@ -1,0 +1,1 @@
+export * from '../fulfillment/app';

--- a/libs/template/presets/src/features/index.ts
+++ b/libs/template/presets/src/features/index.ts
@@ -1,3 +1,4 @@
 export * from './b2c';
 export * from './backoffice';
 export * from './backoffice-ng';
+export * from './fulfillment';

--- a/libs/template/presets/src/features/index.ts
+++ b/libs/template/presets/src/features/index.ts
@@ -1,4 +1,5 @@
 export * from './b2c';
 export * from './backoffice';
 export * from './backoffice-ng';
+// TODO: This should be dropped after HRZ-2239
 export * from './fulfillment';

--- a/libs/template/themes/design-tokens/src/backoffice/index.ts
+++ b/libs/template/themes/design-tokens/src/backoffice/index.ts
@@ -46,3 +46,31 @@ export const backofficeTokens: DesignToken[] = [
     ...layoutMdTokens,
   },
 ];
+
+export const backofficeTokensWithoutDarkMode: DesignToken[] = [
+  {
+    color,
+    ...tokens,
+    ...typographyTokens,
+  },
+  {
+    media: {
+      screen: Size.Lg,
+    },
+    ...layoutTokens,
+  },
+  {
+    media: {
+      screen: Size.Sm,
+    },
+    ...typographySmallTokens,
+    ...layoutSmTokens,
+  },
+  {
+    media: {
+      screen: Size.Md,
+    },
+    ...typographyMediumTokens,
+    ...layoutMdTokens,
+  },
+];

--- a/libs/template/themes/design-tokens/src/backoffice/index.ts
+++ b/libs/template/themes/design-tokens/src/backoffice/index.ts
@@ -47,6 +47,7 @@ export const backofficeTokens: DesignToken[] = [
   },
 ];
 
+// TODO: This should be dropped after HRZ-2239
 export const backofficeTokensWithoutDarkMode: DesignToken[] = [
   {
     color,

--- a/libs/template/themes/src/fulfillment.theme.ts
+++ b/libs/template/themes/src/fulfillment.theme.ts
@@ -2,6 +2,7 @@ import { Theme } from '@spryker-oryx/core';
 import { defaultBreakpoints } from '@spryker-oryx/themes/breakpoints';
 import { backofficeNgIcons } from '@spryker-oryx/themes/icons';
 
+// TODO: This should be dropped after HRZ-2239
 export const fulfillmentTheme: Theme = {
   name: 'backoffice-ng',
   breakpoints: defaultBreakpoints,

--- a/libs/template/themes/src/fulfillment.theme.ts
+++ b/libs/template/themes/src/fulfillment.theme.ts
@@ -1,0 +1,13 @@
+import { Theme } from '@spryker-oryx/core';
+import { defaultBreakpoints } from '@spryker-oryx/themes/breakpoints';
+import { backofficeNgIcons } from '@spryker-oryx/themes/icons';
+
+export const fulfillmentTheme: Theme = {
+  name: 'backoffice-ng',
+  breakpoints: defaultBreakpoints,
+  icons: backofficeNgIcons,
+  designTokens: () =>
+    import('../design-tokens/src/backoffice').then(
+      (s) => s.backofficeTokensWithoutDarkMode
+    ),
+};

--- a/libs/template/themes/src/index.ts
+++ b/libs/template/themes/src/index.ts
@@ -1,3 +1,4 @@
 export * from './backoffice-ng.theme';
 export * from './backoffice.theme';
+export * from './fulfillment.theme';
 export * from './storefront.theme';


### PR DESCRIPTION
Temporary solution to remove dark mode from fulfillment/picking app.
Change's are being done on https://spryker.atlassian.net/browse/HRZ-2239, that will revert this change later on.

Close [HRZ-2333](https://spryker.atlassian.net/browse/HRZ-2333)

[HRZ-2333]: https://spryker.atlassian.net/browse/HRZ-2333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ