### PR TITLE
fix: cancel running workflow if new one appeared

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   GITHUB_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
   IS_DEV: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/development' }}


### PR DESCRIPTION
Now we run workflows on each commit in PR, even if the commit is not relevant anymore.
This PR will change the workflow so that if new commit appears -> old one will be stopped and new one will be triggered

This will improve CI speed and reduce costs (theoretically)