### PR TITLE
fix: issue with e2e run

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "sf:e2e:open": "npx concurrently --kill-others --success first \"npx nx run storefront:serve-prod\" \"wait-on -i=2000 http://localhost:3001 && npx nx run storefront-e2e:e2e\"",
     "sf:e2e:headless": "npx concurrently --kill-others --success first \"npx nx run storefront:serve-ssr\" \"wait-on -i=2000 http://localhost:3001 && npx nx run storefront-e2e:e2e:headless\"",
     "sf:e2e:headless:ci": "npx concurrently --kill-others --success first \"npx nx run storefront:serve-prod\" \"wait-on -i=2000 http://localhost:3001 && npx nx run storefront-e2e:e2e:headless-ci\"",
-    "sf:e2e:headless:ci:affected": "npx nx print-affected --select=projects | grep -E 'storefront' && npm run sf:e2e:headless:ci || echo 'nothing changed, skip'",
+    "sf:e2e:headless:ci:affected": "npx nx print-affected --select=projects | grep -E -v 'storefront' && echo 'nothing changed, skip' || npm run sf:e2e:headless:ci",
     "release": "run-s release:*",
     "release:libs": "cd libs && npm run release",
     "release-from-tag": "run-s release-from-tag:*",


### PR DESCRIPTION
SF E2E tests are green even if some checks fail (e.g. here - https://github.com/spryker/oryx/actions/runs/4357191998/jobs/7616202041)

It is caused by another issue in the test execution command

This PR fixes it so that:
1. If tests are not run -> exit code is 0 (green)
2. If tests are run:
    - and they fail -> exit code is > 0 (red)
    - and they pass -> exit code is 0 (green)