### PR TITLE
feat: optional STORE

### DIFF
--- a/apps/storefront/.env.template
+++ b/apps/storefront/.env.template
@@ -1,6 +1,9 @@
 FES_CONTENT_BACKEND_URL=
 SCOS_BASE_URL=
-STORE=DE
+
+# The STORE env variable is optional and can be used to initialise the application to use a 
+# specific store. When this variable is not provided, the first store from the backend would be used. 
+# STORE=DE
 
 # The Cloudinary ID is not on a paid plan, which means that it cannot be heavily used. If you like to copy
 # this implementation for you production usage, make sure that you provide a reliable Cloudinary account.

--- a/libs/domain/site/src/mocks/src/mock-store.service.ts
+++ b/libs/domain/site/src/mocks/src/mock-store.service.ts
@@ -60,7 +60,7 @@ export class MockStoreService implements Partial<StoreService> {
     timeZone: 'Europe/Berlin',
   };
 
-  get(): Observable<Store | null> {
+  get(): Observable<Store | undefined> {
     return of(MockStoreService.mockStore);
   }
 }

--- a/libs/domain/site/src/services/country/default-country.service.ts
+++ b/libs/domain/site/src/services/country/default-country.service.ts
@@ -11,7 +11,7 @@ export class DefaultCountryService implements CountryService {
 
   getAll(): Observable<Country[]> {
     return this.storeService.get().pipe(
-      filter(<Store>(response: Store | null): response is Store => !!response),
+      filter(Boolean),
       map((response) => response.countries)
     );
   }

--- a/libs/domain/site/src/services/currency/default-currency.service.ts
+++ b/libs/domain/site/src/services/currency/default-currency.service.ts
@@ -28,10 +28,6 @@ export class DefaultCurrencyService implements CurrencyService {
   }
 
   protected loadStore(): Observable<Store> {
-    return this.storeService
-      .get()
-      .pipe(
-        filter(<Store>(response: Store | null): response is Store => !!response)
-      );
+    return this.storeService.get().pipe(filter(Boolean));
   }
 }

--- a/libs/domain/site/src/services/locale/default-locale.service.ts
+++ b/libs/domain/site/src/services/locale/default-locale.service.ts
@@ -11,7 +11,7 @@ export class DefaultLocaleService implements LocaleService {
 
   getAll(): Observable<Locale[]> {
     return this.storeService.get().pipe(
-      filter(<Store>(response: Store | null): response is Store => !!response),
+      filter(Boolean),
       map((response) => response.locales)
     );
   }

--- a/libs/domain/site/src/services/store/default-store.service.spec.ts
+++ b/libs/domain/site/src/services/store/default-store.service.spec.ts
@@ -63,4 +63,15 @@ describe('DefaultStoreService', () => {
       expect(callback).toHaveBeenCalledWith(mockStores[0]);
     });
   });
+
+  describe('set active store', () => {
+    it('should set active store', () => {
+      service.set('AT');
+      service.get().subscribe(callback);
+      expect(callback).toHaveBeenCalledWith(undefined);
+      service.set('DE');
+      service.get().subscribe(callback);
+      expect(callback).toHaveBeenCalledWith(mockStores[0]);
+    });
+  });
 });

--- a/libs/domain/site/src/services/store/default-store.service.ts
+++ b/libs/domain/site/src/services/store/default-store.service.ts
@@ -31,10 +31,14 @@ export class DefaultStoreService implements StoreService {
       switchMap((store) =>
         !store
           ? this.getAll().pipe(
-              map(
-                (stores) =>
-                  stores.find((store) => store.id === this.store) ?? null
-              )
+              map((stores) => {
+                const store = !this.store
+                  ? stores?.[0]
+                  : stores.find((store) => store.id === this.store) ??
+                    stores?.[0];
+                this.store$.next(store);
+                return this.store$.value;
+              })
             )
           : of(store)
       )

--- a/libs/domain/site/src/services/store/default-store.service.ts
+++ b/libs/domain/site/src/services/store/default-store.service.ts
@@ -14,11 +14,10 @@ export class DefaultStoreService implements StoreService {
   protected activeStore$ = new BehaviorSubject<string | undefined>(this.store);
   protected stores$ = this.adapter.get().pipe(shareReplay(1));
   protected store$ = combineLatest([this.stores$, this.activeStore$]).pipe(
-    map(
-      ([stores, activeStore]) =>
-        (activeStore
-          ? stores?.find((store) => store.id === activeStore)
-          : undefined) ?? stores?.[0]
+    map(([stores, activeStore]) =>
+      activeStore
+        ? stores?.find((store) => store.id === activeStore)
+        : stores?.[0]
     ),
     shareReplay(1)
   );

--- a/libs/domain/site/src/services/store/default-store.service.ts
+++ b/libs/domain/site/src/services/store/default-store.service.ts
@@ -19,7 +19,7 @@ export class DefaultStoreService implements StoreService {
         ? stores?.find((store) => store.id === activeStore)
         : stores?.[0]
     ),
-    shareReplay({refCount: true, bufferSize: 1})
+    shareReplay({ refCount: true, bufferSize: 1 })
   );
 
   constructor(

--- a/libs/domain/site/src/services/store/default-store.service.ts
+++ b/libs/domain/site/src/services/store/default-store.service.ts
@@ -1,16 +1,24 @@
 import { inject } from '@spryker-oryx/di';
-import { map, Observable, shareReplay } from 'rxjs';
+import {
+  BehaviorSubject,
+  combineLatest,
+  map,
+  Observable,
+  shareReplay,
+} from 'rxjs';
 import { Store } from '../../models';
 import { StoreAdapter } from '../adapter';
 import { StoreService } from './store.service';
 
 export class DefaultStoreService implements StoreService {
+  protected activeStore$ = new BehaviorSubject<string | undefined>(this.store);
   protected stores$ = this.adapter.get().pipe(shareReplay(1));
-  protected store$ = this.stores$.pipe(
+  protected store$ = combineLatest([this.stores$, this.activeStore$]).pipe(
     map(
-      (stores) =>
-        (this.store && stores.find((store) => store.id === this.store)) ??
-        stores?.[0]
+      ([stores, activeStore]) =>
+        (activeStore
+          ? stores?.find((store) => store.id === activeStore)
+          : undefined) ?? stores?.[0]
     ),
     shareReplay(1)
   );
@@ -26,5 +34,9 @@ export class DefaultStoreService implements StoreService {
 
   get(): Observable<Store | undefined> {
     return this.store$;
+  }
+
+  set(storeId: string): void {
+    this.activeStore$.next(storeId);
   }
 }

--- a/libs/domain/site/src/services/store/default-store.service.ts
+++ b/libs/domain/site/src/services/store/default-store.service.ts
@@ -19,7 +19,7 @@ export class DefaultStoreService implements StoreService {
         ? stores?.find((store) => store.id === activeStore)
         : stores?.[0]
     ),
-    shareReplay(1)
+    shareReplay({refCount: true, bufferSize: 1})
   );
 
   constructor(

--- a/libs/domain/site/src/services/store/store.service.ts
+++ b/libs/domain/site/src/services/store/store.service.ts
@@ -5,7 +5,7 @@ export const StoreService = 'oryx.StoreService';
 
 export interface StoreService {
   getAll(): Observable<Store[]>;
-  get(): Observable<Store | null>;
+  get(): Observable<Store | undefined>;
 }
 
 declare global {


### PR DESCRIPTION
We make the `STORE` environment variable optional. 

When there’s no var available, we’ll default to the first available store from the store response. 

closes [HRZ-2404](https://spryker.atlassian.net/browse/HRZ-2404)

[HRZ-2404]: https://spryker.atlassian.net/browse/HRZ-2404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ