### PR TITLE
feat: locale selector

### DIFF
--- a/libs/base/ui/overlays/dropdown/src/styles/base.styles.ts
+++ b/libs/base/ui/overlays/dropdown/src/styles/base.styles.ts
@@ -10,6 +10,7 @@ export const dropdownBaseStyles = css`
 
     position: relative;
     display: inline-flex;
+    z-index: 100;
   }
 
   oryx-popover {

--- a/libs/domain/site/locale-selector/index.ts
+++ b/libs/domain/site/locale-selector/index.ts
@@ -1,0 +1,1 @@
+export * from './src';

--- a/libs/domain/site/locale-selector/src/index.ts
+++ b/libs/domain/site/locale-selector/src/index.ts
@@ -1,0 +1,3 @@
+export * from './locale-selector.component';
+export * from './locale-selector.model';
+export * from './locale-selector.styles';

--- a/libs/domain/site/locale-selector/src/locale-selector.component.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.component.ts
@@ -1,0 +1,72 @@
+import { resolve } from '@spryker-oryx/di';
+import { ContentMixin } from '@spryker-oryx/experience';
+import { LocaleService } from '@spryker-oryx/site';
+import { ButtonType } from '@spryker-oryx/ui/button';
+import { asyncState, valueType } from '@spryker-oryx/utilities';
+import { LitElement, TemplateResult } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
+import { html } from 'lit/static-html.js';
+import { SiteLocaleSelectorOptions } from './locale-selector.model';
+import { localeSelectorStyles } from './locale-selector.styles';
+
+export class SiteLocaleSelectorComponent extends ContentMixin<SiteLocaleSelectorOptions>(
+  LitElement
+) {
+  static styles = [localeSelectorStyles];
+
+  protected service = resolve(LocaleService);
+
+  @asyncState()
+  protected locales = valueType(this.service.getAll());
+
+  @asyncState()
+  protected current = valueType(this.service.get());
+
+  protected override render(): TemplateResult | void {
+    if (!this.current || !this.locales?.length || this.locales.length < 2)
+      return;
+
+    return html`
+      <oryx-dropdown vertical-align position="start">
+        <oryx-button type=${ButtonType.Text} slot="trigger">
+          <button>
+            ${this.getCode(this.current)}
+            <oryx-icon type="dropdown"></oryx-icon>
+          </button>
+        </oryx-button>
+        ${repeat(
+          this.locales ?? [],
+          (locale) => locale.code,
+          (locale) =>
+            html` <oryx-option
+              close-popover
+              value=${locale.code}
+              ?active=${locale.name === this.current}
+              @click=${() => this.onClick(locale.code)}
+            >
+              ${this.getLabel(locale.code)}
+            </oryx-option>`
+        )}
+      </oryx-dropdown>
+    `;
+  }
+
+  protected onClick(locale: string): void {
+    this.service.set(locale);
+  }
+
+  protected getLabel(isoCode: string): string {
+    const lang = this.getCode(isoCode);
+    const languageNames = new Intl.DisplayNames(
+      [this.current?.replace('_', '-') ?? 'en-US'],
+      {
+        type: 'language',
+      }
+    );
+    return languageNames.of(lang) ?? lang;
+  }
+
+  protected getCode(isoCode: string): string {
+    return isoCode.split('_')[0];
+  }
+}

--- a/libs/domain/site/locale-selector/src/locale-selector.component.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.component.ts
@@ -30,7 +30,7 @@ export class SiteLocaleSelectorComponent extends ContentMixin<SiteLocaleSelector
       <oryx-dropdown vertical-align position="start">
         <oryx-button type=${ButtonType.Text} slot="trigger">
           <button>
-            ${this.getCode(this.current)}
+            ${this.current}
             <oryx-icon type="dropdown"></oryx-icon>
           </button>
         </oryx-button>
@@ -41,7 +41,7 @@ export class SiteLocaleSelectorComponent extends ContentMixin<SiteLocaleSelector
             html` <oryx-option
               close-popover
               value=${locale.code}
-              ?active=${locale.name === this.current}
+              ?active=${locale.code === this.current}
               @click=${() => this.onClick(locale.code)}
             >
               ${this.getLabel(locale.code)}
@@ -55,15 +55,11 @@ export class SiteLocaleSelectorComponent extends ContentMixin<SiteLocaleSelector
     this.service.set(locale);
   }
 
-  protected getLabel(isoCode: string): string {
-    const lang = this.getCode(isoCode);
-    const languageNames = new Intl.DisplayNames(
-      [this.current?.replace('_', '-') ?? 'en-US'],
-      {
-        type: 'language',
-      }
-    );
-    return languageNames.of(lang) ?? lang;
+  protected getLabel(code: string): string {
+    const languageNames = new Intl.DisplayNames([this.current ?? 'en'], {
+      type: 'language',
+    });
+    return languageNames.of(code) ?? code;
   }
 
   protected getCode(isoCode: string): string {

--- a/libs/domain/site/locale-selector/src/locale-selector.component.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.component.ts
@@ -7,12 +7,12 @@ import { LitElement, TemplateResult } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 import { html } from 'lit/static-html.js';
 import { SiteLocaleSelectorOptions } from './locale-selector.model';
-import { localeSelectorStyles } from './locale-selector.styles';
+import { siteLocaleSelectorStyles } from './locale-selector.styles';
 
 export class SiteLocaleSelectorComponent extends ContentMixin<SiteLocaleSelectorOptions>(
   LitElement
 ) {
-  static styles = [localeSelectorStyles];
+  static styles = [siteLocaleSelectorStyles];
 
   protected service = resolve(LocaleService);
 

--- a/libs/domain/site/locale-selector/src/locale-selector.def.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.def.ts
@@ -1,12 +1,12 @@
 import { componentDef } from '@spryker-oryx/core';
 
-export const localeSelectorComponent = componentDef({
+export const siteLocaleSelectorComponent = componentDef({
   name: 'oryx-site-locale-selector',
   impl: () =>
     import('./locale-selector.component').then(
       (m) => m.SiteLocaleSelectorComponent
     ),
   schema: import('./locale-selector.schema').then(
-    (m) => m.localeSelectorSchema
+    (m) => m.siteLocaleSelectorSchema
   ),
 });

--- a/libs/domain/site/locale-selector/src/locale-selector.def.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.def.ts
@@ -1,0 +1,12 @@
+import { componentDef } from '@spryker-oryx/core';
+
+export const localeSelectorComponent = componentDef({
+  name: 'oryx-locale-selector',
+  impl: () =>
+    import('./locale-selector.component').then(
+      (m) => m.SiteLocaleSelectorComponent
+    ),
+  schema: import('./locale-selector.schema').then(
+    (m) => m.localeSelectorSchema
+  ),
+});

--- a/libs/domain/site/locale-selector/src/locale-selector.def.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.def.ts
@@ -1,7 +1,7 @@
 import { componentDef } from '@spryker-oryx/core';
 
 export const localeSelectorComponent = componentDef({
-  name: 'oryx-locale-selector',
+  name: 'oryx-site-locale-selector',
   impl: () =>
     import('./locale-selector.component').then(
       (m) => m.SiteLocaleSelectorComponent

--- a/libs/domain/site/locale-selector/src/locale-selector.model.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.model.ts
@@ -1,0 +1,3 @@
+export interface SiteLocaleSelectorOptions {
+  empty?: boolean;
+}

--- a/libs/domain/site/locale-selector/src/locale-selector.schema.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.schema.ts
@@ -1,7 +1,7 @@
 import { ContentComponentSchema } from '@spryker-oryx/experience';
 import { SiteLocaleSelectorComponent } from './locale-selector.component';
 
-export const localeSelectorSchema: ContentComponentSchema<SiteLocaleSelectorComponent> =
+export const siteLocaleSelectorSchema: ContentComponentSchema<SiteLocaleSelectorComponent> =
   {
     name: 'Locale selector',
     group: 'Site',

--- a/libs/domain/site/locale-selector/src/locale-selector.schema.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.schema.ts
@@ -1,0 +1,9 @@
+import { ContentComponentSchema } from '@spryker-oryx/experience';
+import { SiteLocaleSelectorComponent } from './locale-selector.component';
+
+export const localeSelectorSchema: ContentComponentSchema<SiteLocaleSelectorComponent> =
+  {
+    name: 'Locale selector',
+    group: 'Site',
+    options: {},
+  };

--- a/libs/domain/site/locale-selector/src/locale-selector.styles.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.styles.ts
@@ -1,6 +1,6 @@
 import { css } from 'lit';
 
-export const localeSelectorStyles = css`
+export const siteLocaleSelectorStyles = css`
   button {
     --oryx-icon-color: white;
 

--- a/libs/domain/site/locale-selector/src/locale-selector.styles.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.styles.ts
@@ -1,0 +1,10 @@
+import { css } from 'lit';
+
+export const localeSelectorStyles = css`
+  button {
+    --oryx-icon-color: white;
+
+    color: white;
+    text-transform: uppercase;
+  }
+`;

--- a/libs/domain/site/src/components.ts
+++ b/libs/domain/site/src/components.ts
@@ -1,1 +1,2 @@
+export * from '../locale-selector/src/locale-selector.def';
 export * from '../notification-center/src/notification-center.def';

--- a/libs/template/presets/src/features/b2c/experience/footer.ts
+++ b/libs/template/presets/src/features/b2c/experience/footer.ts
@@ -6,6 +6,9 @@ export const FooterTemplate: StaticComponent = {
   meta: { title: 'Footer', route: '/_footer' },
   components: [
     {
+      type: 'oryx-site-notification-center',
+    },
+    {
       type: 'experience-composition',
       components: [
         {

--- a/libs/template/presets/src/features/b2c/experience/header.ts
+++ b/libs/template/presets/src/features/b2c/experience/header.ts
@@ -20,7 +20,8 @@ export const HeaderTemplate: StaticComponent = {
           },
         },
         {
-          type: 'oryx-site-notification-center',
+          type: 'oryx-locale-selector',
+          options: { data: { rules: [{ margin: '0 0 0 auto' }] } },
         },
       ],
       options: {

--- a/libs/template/presets/src/features/b2c/experience/header.ts
+++ b/libs/template/presets/src/features/b2c/experience/header.ts
@@ -20,7 +20,7 @@ export const HeaderTemplate: StaticComponent = {
           },
         },
         {
-          type: 'oryx-locale-selector',
+          type: 'oryx-site-locale-selector',
           options: { data: { rules: [{ margin: '0 0 0 auto' }] } },
         },
       ],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -134,6 +134,9 @@
       ],
       "@spryker-oryx/search/sort": ["libs/domain/search/sort/index.ts"],
       "@spryker-oryx/site": ["libs/domain/site/src/index.ts"],
+      "@spryker-oryx/site/locale-selector": [
+        "libs/domain/site/locale-selector/index.ts"
+      ],
       "@spryker-oryx/site/mocks": ["libs/domain/site/src/mocks/index.ts"],
       "@spryker-oryx/site/notification-center": [
         "libs/domain/site/notification-center/index.ts"


### PR DESCRIPTION
MVP version of the locale selector. The local selector allows to change the current locale of the site, so that all content and labels will react. 

Missing pieces: 
- no integration with the a configurable URL pattern (e.g. myshop.com/de vs mygermanshop.com vs de.myshop.com)
- no icon integration

closes [HRZ-2016](https://spryker.atlassian.net/browse/HRZ-2016)

[HRZ-2016]: https://spryker.atlassian.net/browse/HRZ-2016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ