### PR TITLE
feat: currency selector

### DIFF
--- a/libs/domain/site/currency-selector/src/currency-selector.component.ts
+++ b/libs/domain/site/currency-selector/src/currency-selector.component.ts
@@ -2,13 +2,14 @@ import { resolve } from '@spryker-oryx/di';
 import { ContentMixin } from '@spryker-oryx/experience';
 import { CurrencyService } from '@spryker-oryx/site';
 import { ButtonType } from '@spryker-oryx/ui/button';
-import { asyncState, valueType } from '@spryker-oryx/utilities';
+import { asyncState, hydratable, valueType } from '@spryker-oryx/utilities';
 import { LitElement, TemplateResult } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 import { html } from 'lit/static-html.js';
 import { SiteCurrencySelectorOptions } from './currency-selector.model';
 import { siteLocaleSelectorStyles } from './currency-selector.styles';
 
+@hydratable(['mouseover', 'focusin'])
 export class SiteCurrencySelectorComponent extends ContentMixin<SiteCurrencySelectorOptions>(
   LitElement
 ) {

--- a/libs/domain/site/currency-selector/src/currency-selector.component.ts
+++ b/libs/domain/site/currency-selector/src/currency-selector.component.ts
@@ -1,6 +1,6 @@
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin } from '@spryker-oryx/experience';
-import { CurrencyService } from '@spryker-oryx/site';
+import { CurrencyService, LocaleService } from '@spryker-oryx/site';
 import { ButtonType } from '@spryker-oryx/ui/button';
 import { asyncState, hydratable, valueType } from '@spryker-oryx/utilities';
 import { LitElement, TemplateResult } from 'lit';
@@ -23,10 +23,18 @@ export class SiteCurrencySelectorComponent extends ContentMixin<SiteCurrencySele
   @asyncState()
   protected current = valueType(this.currencyService.get());
 
+  @asyncState()
+  protected currentLocale = valueType(resolve(LocaleService).get());
+
   protected override render(): TemplateResult | void {
-    if (!this.current || !this.currencies?.length || this.currencies.length < 2)
+    if (
+      !this.current ||
+      !this.currencies?.length ||
+      this.currencies.length < 2
+    ) {
       return;
-    console.log(this.currencies);
+    }
+
     return html`
       <oryx-dropdown vertical-align position="start">
         <oryx-button type=${ButtonType.Text} slot="trigger">
@@ -57,7 +65,7 @@ export class SiteCurrencySelectorComponent extends ContentMixin<SiteCurrencySele
   }
 
   protected getLabel(code: string): string {
-    const languageNames = new Intl.DisplayNames([this.current ?? 'en'], {
+    const languageNames = new Intl.DisplayNames([this.currentLocale ?? 'en'], {
       type: 'currency',
     });
     return languageNames.of(code) ?? code;

--- a/libs/domain/site/currency-selector/src/currency-selector.component.ts
+++ b/libs/domain/site/currency-selector/src/currency-selector.component.ts
@@ -1,31 +1,31 @@
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin } from '@spryker-oryx/experience';
-import { LocaleService } from '@spryker-oryx/site';
+import { CurrencyService } from '@spryker-oryx/site';
 import { ButtonType } from '@spryker-oryx/ui/button';
 import { asyncState, valueType } from '@spryker-oryx/utilities';
 import { LitElement, TemplateResult } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 import { html } from 'lit/static-html.js';
-import { SiteLocaleSelectorOptions } from './locale-selector.model';
-import { siteLocaleSelectorStyles } from './locale-selector.styles';
+import { SiteCurrencySelectorOptions } from './currency-selector.model';
+import { siteLocaleSelectorStyles } from './currency-selector.styles';
 
-export class SiteLocaleSelectorComponent extends ContentMixin<SiteLocaleSelectorOptions>(
+export class SiteCurrencySelectorComponent extends ContentMixin<SiteCurrencySelectorOptions>(
   LitElement
 ) {
   static styles = [siteLocaleSelectorStyles];
 
-  protected localeService = resolve(LocaleService);
+  protected currencyService = resolve(CurrencyService);
 
   @asyncState()
-  protected locales = valueType(this.localeService.getAll());
+  protected currencies = valueType(this.currencyService.getAll());
 
   @asyncState()
-  protected current = valueType(this.localeService.get());
+  protected current = valueType(this.currencyService.get());
 
   protected override render(): TemplateResult | void {
-    if (!this.current || !this.locales?.length || this.locales.length < 2)
+    if (!this.current || !this.currencies?.length || this.currencies.length < 2)
       return;
-
+    console.log(this.currencies);
     return html`
       <oryx-dropdown vertical-align position="start">
         <oryx-button type=${ButtonType.Text} slot="trigger">
@@ -35,7 +35,7 @@ export class SiteLocaleSelectorComponent extends ContentMixin<SiteLocaleSelector
           </button>
         </oryx-button>
         ${repeat(
-          this.locales ?? [],
+          this.currencies ?? [],
           (locale) => locale.code,
           (locale) =>
             html` <oryx-option
@@ -52,12 +52,12 @@ export class SiteLocaleSelectorComponent extends ContentMixin<SiteLocaleSelector
   }
 
   protected onClick(locale: string): void {
-    this.localeService.set(locale);
+    this.currencyService.set(locale);
   }
 
   protected getLabel(code: string): string {
     const languageNames = new Intl.DisplayNames([this.current ?? 'en'], {
-      type: 'language',
+      type: 'currency',
     });
     return languageNames.of(code) ?? code;
   }

--- a/libs/domain/site/currency-selector/src/currency-selector.def.ts
+++ b/libs/domain/site/currency-selector/src/currency-selector.def.ts
@@ -1,0 +1,12 @@
+import { componentDef } from '@spryker-oryx/core';
+
+export const siteCurrencySelectorComponent = componentDef({
+  name: 'oryx-site-currency-selector',
+  impl: () =>
+    import('./currency-selector.component').then(
+      (m) => m.SiteCurrencySelectorComponent
+    ),
+  schema: import('./currency-selector.schema').then(
+    (m) => m.siteCurrencySelectorSchema
+  ),
+});

--- a/libs/domain/site/currency-selector/src/currency-selector.model.ts
+++ b/libs/domain/site/currency-selector/src/currency-selector.model.ts
@@ -1,3 +1,2 @@
-export interface SiteCurrencySelectorOptions {
-  empty?: boolean;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface SiteCurrencySelectorOptions {}

--- a/libs/domain/site/currency-selector/src/currency-selector.model.ts
+++ b/libs/domain/site/currency-selector/src/currency-selector.model.ts
@@ -1,0 +1,3 @@
+export interface SiteCurrencySelectorOptions {
+  empty?: boolean;
+}

--- a/libs/domain/site/currency-selector/src/currency-selector.schema.ts
+++ b/libs/domain/site/currency-selector/src/currency-selector.schema.ts
@@ -1,0 +1,9 @@
+import { ContentComponentSchema } from '@spryker-oryx/experience';
+import { SiteCurrencySelectorComponent } from './currency-selector.component';
+
+export const siteCurrencySelectorSchema: ContentComponentSchema<SiteCurrencySelectorComponent> =
+  {
+    name: 'Currency selector',
+    group: 'Site',
+    options: {},
+  };

--- a/libs/domain/site/currency-selector/src/currency-selector.styles.ts
+++ b/libs/domain/site/currency-selector/src/currency-selector.styles.ts
@@ -1,0 +1,10 @@
+import { css } from 'lit';
+
+export const siteLocaleSelectorStyles = css`
+  button {
+    --oryx-icon-color: white;
+
+    color: white;
+    text-transform: uppercase;
+  }
+`;

--- a/libs/domain/site/currency-selector/src/index.ts
+++ b/libs/domain/site/currency-selector/src/index.ts
@@ -1,0 +1,3 @@
+export * from './currency-selector.component';
+export * from './currency-selector.model';
+export * from './currency-selector.styles';

--- a/libs/domain/site/locale-selector/src/locale-selector.component.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.component.ts
@@ -24,8 +24,9 @@ export class SiteLocaleSelectorComponent extends ContentMixin<SiteLocaleSelector
   protected current = valueType(this.localeService.get());
 
   protected override render(): TemplateResult | void {
-    if (!this.current || !this.locales?.length || this.locales.length < 2)
+    if (!this.current || !this.locales?.length || this.locales.length < 2) {
       return;
+    }
 
     return html`
       <oryx-dropdown vertical-align position="start">

--- a/libs/domain/site/locale-selector/src/locale-selector.component.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.component.ts
@@ -2,13 +2,14 @@ import { resolve } from '@spryker-oryx/di';
 import { ContentMixin } from '@spryker-oryx/experience';
 import { LocaleService } from '@spryker-oryx/site';
 import { ButtonType } from '@spryker-oryx/ui/button';
-import { asyncState, valueType } from '@spryker-oryx/utilities';
+import { asyncState, hydratable, valueType } from '@spryker-oryx/utilities';
 import { LitElement, TemplateResult } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 import { html } from 'lit/static-html.js';
 import { SiteLocaleSelectorOptions } from './locale-selector.model';
 import { siteLocaleSelectorStyles } from './locale-selector.styles';
 
+@hydratable(['mouseover', 'focusin'])
 export class SiteLocaleSelectorComponent extends ContentMixin<SiteLocaleSelectorOptions>(
   LitElement
 ) {

--- a/libs/domain/site/locale-selector/src/locale-selector.model.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.model.ts
@@ -1,3 +1,2 @@
-export interface SiteLocaleSelectorOptions {
-  empty?: boolean;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface SiteLocaleSelectorOptions {}

--- a/libs/domain/site/src/components.ts
+++ b/libs/domain/site/src/components.ts
@@ -1,2 +1,3 @@
+export * from '../currency-selector/src/currency-selector.def';
 export * from '../locale-selector/src/locale-selector.def';
 export * from '../notification-center/src/notification-center.def';

--- a/libs/domain/site/src/services/pricing/default-pricing.service.ts
+++ b/libs/domain/site/src/services/pricing/default-pricing.service.ts
@@ -12,9 +12,7 @@ export class DefaultPricingService implements PricingService {
       this.currencyService.get(),
       this.localeService.get(),
     ]).pipe(
-      map(([currency, locale]) =>
-        this.formatPrice(price, currency, locale.replace('_', '-'))
-      )
+      map(([currency, locale]) => this.formatPrice(price, currency, locale))
     );
   }
 

--- a/libs/template/presets/src/features/b2c/experience/header.ts
+++ b/libs/template/presets/src/features/b2c/experience/header.ts
@@ -20,21 +20,21 @@ export const HeaderTemplate: StaticComponent = {
           },
         },
         {
-          type: 'oryx-site-locale-selector',
+          type: 'oryx-site-currency-selector',
           options: { data: { rules: [{ margin: '0 0 0 auto' }] } },
         },
+        { type: 'oryx-site-locale-selector' },
       ],
       options: {
         data: {
           rules: [
             {
-              layout: 'column',
-              container: true,
-              fullWidth: true,
+              layout: 'flex',
               background: 'var(--oryx-color-primary-500)',
-              gap: '40px',
+              container: true,
               maxWidth: true,
               padding: '10px 0',
+              gap: '10px',
             },
           ],
         },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -134,6 +134,9 @@
       ],
       "@spryker-oryx/search/sort": ["libs/domain/search/sort/index.ts"],
       "@spryker-oryx/site": ["libs/domain/site/src/index.ts"],
+      "@spryker-oryx/site/currency-selector": [
+        "libs/domain/site/currency-selector/index.ts"
+      ],
       "@spryker-oryx/site/locale-selector": [
         "libs/domain/site/locale-selector/index.ts"
       ],


### PR DESCRIPTION
Add currency selector that lists all available currencies for the store and sets the current currency when the user change it. 

Exclusions:
- it doesn't change the URL
- no storybook integration
- no tests yet

closes [HRZ-2430](https://spryker.atlassian.net/browse/HRZ-2430)

[HRZ-2430]: https://spryker.atlassian.net/browse/HRZ-2430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ