### PR TITLE
fix: populate isocode from name

### DIFF
--- a/libs/domain/site/src/services/adapter/normalizers/store/store.normalizer.ts
+++ b/libs/domain/site/src/services/adapter/normalizers/store/store.normalizer.ts
@@ -6,6 +6,17 @@ import { DeserializedStores } from '../model';
 export const StoreNormalizer = 'oryx.StoreNormalizer*';
 
 export function storeAttributesNormalizer(data: DeserializedStores): Store[] {
+  // TODO: drop this when the backend is healthy again; current dynamic
+  // multi-store backend is exposing numbers rather than the locale isocode.
+  data.map((store) =>
+    store.locales.map((locale) => {
+      if (!isNaN(Number(locale.code))) {
+        locale.code = locale.name.split(/_|-/)?.[0];
+      }
+      return locale;
+    })
+  );
+
   return data;
 }
 


### PR DESCRIPTION
Current dynamic multi-store backend is exposing numbers rather than the locale isocode. We take the iscode from the name as a temporary solution. 

fixes [HRZ-2468](https://spryker.atlassian.net/browse/HRZ-2468)

[HRZ-2468]: https://spryker.atlassian.net/browse/HRZ-2468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ