### PR TITLE
chore: locale and currency selector unit test coverage

### DIFF
--- a/libs/domain/site/currency-selector/src/currency-selector.component.spec.ts
+++ b/libs/domain/site/currency-selector/src/currency-selector.component.spec.ts
@@ -1,0 +1,193 @@
+import { fixture } from '@open-wc/testing-helpers';
+import { useComponent } from '@spryker-oryx/core/utilities';
+import { createInjector, destroyInjector } from '@spryker-oryx/di';
+import { LocaleService } from '@spryker-oryx/i18n';
+import {
+  Currency,
+  CurrencyService,
+  siteCurrencySelectorComponent,
+} from '@spryker-oryx/site';
+import { html } from 'lit';
+import { of } from 'rxjs';
+import { SiteCurrencySelectorComponent } from './currency-selector.component';
+
+class MockCurrencyService implements Partial<CurrencyService> {
+  get = vi.fn().mockReturnValue('EUR');
+  getAll = vi.fn().mockReturnValue([]);
+  set = vi.fn();
+}
+
+class MockLocaleService implements Partial<LocaleService> {
+  get = vi.fn().mockReturnValue(of('en'));
+}
+
+describe('SiteCurrencySelectorComponent', () => {
+  let element: SiteCurrencySelectorComponent;
+  let currencyService: MockCurrencyService;
+  let localeService: MockLocaleService;
+
+  beforeAll(async () => {
+    await useComponent([siteCurrencySelectorComponent]);
+  });
+
+  beforeEach(async () => {
+    const injector = createInjector({
+      providers: [
+        {
+          provide: CurrencyService,
+          useClass: MockCurrencyService,
+        },
+        {
+          provide: LocaleService,
+          useClass: MockLocaleService,
+        },
+      ],
+    });
+    currencyService = injector.inject(
+      CurrencyService
+    ) as unknown as MockCurrencyService;
+
+    localeService = injector.inject(
+      LocaleService
+    ) as unknown as MockLocaleService;
+  });
+
+  afterEach(() => {
+    destroyInjector();
+    vi.clearAllMocks();
+  });
+
+  describe('when the component is initialised', () => {
+    beforeEach(async () => {
+      element = await fixture(
+        html`<oryx-site-currency-selector></oryx-site-currency-selector>`
+      );
+    });
+    it('is defined', () => {
+      expect(element).toBeInstanceOf(SiteCurrencySelectorComponent);
+    });
+  });
+
+  describe('when there are no currencies', () => {
+    beforeEach(async () => {
+      currencyService.getAll.mockReturnValue(of([]));
+      element = await fixture(
+        html`<oryx-site-currency-selector></oryx-site-currency-selector>`
+      );
+    });
+
+    it('should not render the currency selector', () => {
+      expect(element).not.toContainElement('button');
+    });
+  });
+
+  describe('when there is only one currency', () => {
+    beforeEach(async () => {
+      currencyService.getAll.mockReturnValue(of([{ code: 'EUR' } as Currency]));
+      element = await fixture(
+        html`<oryx-site-currency-selector></oryx-site-currency-selector>`
+      );
+    });
+
+    it('should not show the currency selector', () => {
+      expect(element).not.toContainElement('button');
+    });
+  });
+
+  describe('when there are more than one currencies', () => {
+    beforeEach(async () => {
+      currencyService.getAll.mockReturnValue(
+        of([{ code: 'EUR' }, { code: 'USD' }, { code: 'GBP' }] as Currency[])
+      );
+      element = await fixture(
+        html`<oryx-site-currency-selector></oryx-site-currency-selector>`
+      );
+    });
+
+    it('should show the currency selector', () => {
+      expect(element).toContainElement('button');
+    });
+
+    describe('and a currency is selected', () => {
+      beforeEach(async () => {
+        element = await fixture(
+          html`<oryx-site-currency-selector></oryx-site-currency-selector>`
+        );
+        const usdOption = element.shadowRoot?.querySelector(
+          'oryx-option[value=USD]'
+        );
+        usdOption?.dispatchEvent(new Event('click'));
+      });
+
+      it('should change set the currency', () => {
+        expect(currencyService.set).toHaveBeenCalledWith('USD');
+      });
+    });
+
+    describe('and the language is Spanish', () => {
+      beforeEach(async () => {
+        localeService.get.mockReturnValue(of('es'));
+        element = await fixture(
+          html`<oryx-site-currency-selector></oryx-site-currency-selector>`
+        );
+      });
+
+      it('should render the currency selector', () => {
+        const button = element.shadowRoot?.querySelector('button');
+        expect(button).toBeDefined();
+        expect(button?.textContent).toContain('EUR');
+      });
+
+      it('should render the EUR option', () => {
+        const eur = element.shadowRoot?.querySelector('oryx-option[value=EUR]');
+        expect(eur).toBeDefined();
+        expect(eur?.textContent).toContain('euro');
+      });
+
+      it('should render the USD option', () => {
+        const eur = element.shadowRoot?.querySelector('oryx-option[value=USD]');
+        expect(eur).toBeDefined();
+        expect(eur?.textContent).toContain('dólar estadounidense');
+      });
+
+      it('should render the GBP option', () => {
+        const eur = element.shadowRoot?.querySelector('oryx-option[value=GBP]');
+        expect(eur).toBeDefined();
+        expect(eur?.textContent).toContain('libra esterlina');
+      });
+    });
+
+    describe('and the language is German', () => {
+      beforeEach(async () => {
+        localeService.get.mockReturnValue(of('de'));
+        element = await fixture(
+          html`<oryx-site-currency-selector></oryx-site-currency-selector>`
+        );
+      });
+
+      it('should render the currency selector', () => {
+        const button = element.shadowRoot?.querySelector('button');
+        expect(button).toBeDefined();
+        expect(button?.textContent).toContain('EUR');
+      });
+
+      it('should render the EUR option', () => {
+        const eur = element.shadowRoot?.querySelector('oryx-option[value=EUR]');
+        expect(eur).toBeDefined();
+        expect(eur?.textContent).toContain('Euro');
+      });
+
+      it('should render the USD option', () => {
+        const eur = element.shadowRoot?.querySelector('oryx-option[value=USD]');
+        expect(eur).toBeDefined();
+        expect(eur?.textContent).toContain('US-Dollar');
+      });
+
+      it('should render the GBP option', () => {
+        const eur = element.shadowRoot?.querySelector('oryx-option[value=GBP]');
+        expect(eur).toBeDefined();
+        expect(eur?.textContent).toContain('Britisches Pfund');
+      });
+    });
+  });
+});

--- a/libs/domain/site/currency-selector/src/currency-selector.component.spec.ts
+++ b/libs/domain/site/currency-selector/src/currency-selector.component.spec.ts
@@ -156,38 +156,5 @@ describe('SiteCurrencySelectorComponent', () => {
         expect(eur?.textContent).toContain('libra esterlina');
       });
     });
-
-    describe('and the language is German', () => {
-      beforeEach(async () => {
-        localeService.get.mockReturnValue(of('de'));
-        element = await fixture(
-          html`<oryx-site-currency-selector></oryx-site-currency-selector>`
-        );
-      });
-
-      it('should render the currency selector', () => {
-        const button = element.shadowRoot?.querySelector('button');
-        expect(button).toBeDefined();
-        expect(button?.textContent).toContain('EUR');
-      });
-
-      it('should render the EUR option', () => {
-        const eur = element.shadowRoot?.querySelector('oryx-option[value=EUR]');
-        expect(eur).toBeDefined();
-        expect(eur?.textContent).toContain('Euro');
-      });
-
-      it('should render the USD option', () => {
-        const eur = element.shadowRoot?.querySelector('oryx-option[value=USD]');
-        expect(eur).toBeDefined();
-        expect(eur?.textContent).toContain('US-Dollar');
-      });
-
-      it('should render the GBP option', () => {
-        const eur = element.shadowRoot?.querySelector('oryx-option[value=GBP]');
-        expect(eur).toBeDefined();
-        expect(eur?.textContent).toContain('Britisches Pfund');
-      });
-    });
   });
 });

--- a/libs/domain/site/locale-selector/src/locale-selector.component.spec.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.component.spec.ts
@@ -98,11 +98,11 @@ describe('SiteLocaleSelectorComponent', () => {
       );
     });
 
-    it('should show the locale selector', () => {
+    it('should render the locale selector', () => {
       expect(element).toContainElement('button');
     });
 
-    it('should show the options', () => {
+    it('should render the options', () => {
       expect(element).toContainElement('oryx-option[value=en');
       expect(element).toContainElement('oryx-option[value=de');
       expect(element).toContainElement('oryx-option[value=es');
@@ -110,12 +110,6 @@ describe('SiteLocaleSelectorComponent', () => {
 
     describe('and when a locale is selected', () => {
       beforeEach(async () => {
-        service.getAll.mockReturnValue(
-          of([{ code: 'en' }, { code: 'de' }, { code: 'es' }] as Locale[])
-        );
-        element = await fixture(
-          html`<oryx-site-locale-selector></oryx-site-locale-selector>`
-        );
         const de = element.shadowRoot?.querySelector('oryx-option[value=de]');
         de?.dispatchEvent(new Event('click'));
       });

--- a/libs/domain/site/locale-selector/src/locale-selector.component.spec.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.component.spec.ts
@@ -75,7 +75,7 @@ describe('SiteLocaleSelectorComponent', () => {
     });
   });
 
-  describe('when there multiple only one locales', () => {
+  describe('when there is only one locale', () => {
     beforeEach(async () => {
       service.getAll.mockReturnValue(of([{ code: 'en' } as Locale]));
       element = await fixture(
@@ -88,7 +88,7 @@ describe('SiteLocaleSelectorComponent', () => {
     });
   });
 
-  describe('when there are more only one locales', () => {
+  describe('when there are more then one locale', () => {
     beforeEach(async () => {
       service.getAll.mockReturnValue(
         of([{ code: 'en' }, { code: 'de' }, { code: 'es' }] as Locale[])

--- a/libs/domain/site/locale-selector/src/locale-selector.component.spec.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.component.spec.ts
@@ -1,0 +1,128 @@
+import { fixture } from '@open-wc/testing-helpers';
+import { useComponent } from '@spryker-oryx/core/utilities';
+import { createInjector, destroyInjector } from '@spryker-oryx/di';
+import { Locale, LocaleService } from '@spryker-oryx/i18n';
+import { siteLocaleSelectorComponent } from '@spryker-oryx/site';
+import { html } from 'lit';
+import { of } from 'rxjs';
+import { SiteLocaleSelectorComponent } from './locale-selector.component';
+
+class MockLocaleService implements Partial<LocaleService> {
+  get = vi.fn().mockReturnValue(of('en'));
+  getAll = vi.fn().mockReturnValue([]);
+  set = vi.fn();
+}
+
+describe('SiteLocaleSelectorComponent', () => {
+  let element: SiteLocaleSelectorComponent;
+  let service: MockLocaleService;
+
+  beforeAll(async () => {
+    await useComponent([siteLocaleSelectorComponent]);
+  });
+
+  beforeEach(async () => {
+    const injector = createInjector({
+      providers: [
+        {
+          provide: LocaleService,
+          useClass: MockLocaleService,
+        },
+      ],
+    });
+    service = injector.inject(LocaleService) as unknown as MockLocaleService;
+  });
+
+  afterEach(() => {
+    destroyInjector();
+    vi.clearAllMocks();
+  });
+
+  describe('when the component is initialised', () => {
+    beforeEach(async () => {
+      element = await fixture(
+        html`<oryx-site-locale-selector></oryx-site-locale-selector>`
+      );
+    });
+    it('is defined', () => {
+      expect(element).toBeInstanceOf(SiteLocaleSelectorComponent);
+    });
+  });
+
+  describe('when there are no locales', () => {
+    beforeEach(async () => {
+      service.getAll.mockReturnValue(of([]));
+      element = await fixture(
+        html`<oryx-site-locale-selector></oryx-site-locale-selector>`
+      );
+    });
+
+    it('should not render the locale selector', () => {
+      expect(element).not.toContainElement('button');
+    });
+  });
+
+  describe('when there is only one locales', () => {
+    beforeEach(async () => {
+      service.getAll.mockReturnValue(of([{ code: 'en' } as Locale]));
+      element = await fixture(
+        html`<oryx-site-locale-selector></oryx-site-locale-selector>`
+      );
+    });
+
+    it('should not show the locale selector', () => {
+      expect(element).not.toContainElement('button');
+    });
+  });
+
+  describe('when there multiple only one locales', () => {
+    beforeEach(async () => {
+      service.getAll.mockReturnValue(of([{ code: 'en' } as Locale]));
+      element = await fixture(
+        html`<oryx-site-locale-selector></oryx-site-locale-selector>`
+      );
+    });
+
+    it('should not show the locale selector', () => {
+      expect(element).not.toContainElement('button');
+    });
+  });
+
+  describe('when there are more only one locales', () => {
+    beforeEach(async () => {
+      service.getAll.mockReturnValue(
+        of([{ code: 'en' }, { code: 'de' }, { code: 'es' }] as Locale[])
+      );
+      element = await fixture(
+        html`<oryx-site-locale-selector></oryx-site-locale-selector>`
+      );
+    });
+
+    it('should show the locale selector', () => {
+      expect(element).toContainElement('button');
+    });
+
+    it('should show the options', () => {
+      expect(element).toContainElement('oryx-option[value=en');
+      expect(element).toContainElement('oryx-option[value=de');
+      expect(element).toContainElement('oryx-option[value=es');
+    });
+
+    describe('and when a locale is selected', () => {
+      beforeEach(async () => {
+        service.getAll.mockReturnValue(
+          of([{ code: 'en' }, { code: 'de' }, { code: 'es' }] as Locale[])
+        );
+        element = await fixture(
+          html`<oryx-site-locale-selector></oryx-site-locale-selector>`
+        );
+        const de = element.shadowRoot?.querySelector('oryx-option[value=de]');
+        de?.dispatchEvent(new Event('click'));
+      });
+
+      it('should change set the locale', () => {
+        expect(service.set).toHaveBeenCalledWith('de');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Unit tests added for context selectors. 

closes [HRZ-2490](https://spryker.atlassian.net/browse/HRZ-2490), [HRZ-2494](https://spryker.atlassian.net/browse/HRZ-2494)


[HRZ-2490]: https://spryker.atlassian.net/browse/HRZ-2490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HRZ-2494]: https://spryker.atlassian.net/browse/HRZ-2494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ