### PR TITLE
feat: translate local in its own language

### DIFF
--- a/libs/domain/site/locale-selector/src/locale-selector.component.spec.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.component.spec.ts
@@ -102,10 +102,19 @@ describe('SiteLocaleSelectorComponent', () => {
       expect(element).toContainElement('button');
     });
 
-    it('should render the options', () => {
-      expect(element).toContainElement('oryx-option[value=en');
-      expect(element).toContainElement('oryx-option[value=de');
-      expect(element).toContainElement('oryx-option[value=es');
+    it('should render the english option in its native locale', () => {
+      const en = element.shadowRoot?.querySelector('oryx-option[value=en');
+      expect(en?.textContent).toContain('English');
+    });
+
+    it('should render the Deutch option in its native locale', () => {
+      const en = element.shadowRoot?.querySelector('oryx-option[value=de');
+      expect(en?.textContent).toContain('Deutsch');
+    });
+
+    it('should render the Spanish option in its native locale', () => {
+      const en = element.shadowRoot?.querySelector('oryx-option[value=es');
+      expect(en?.textContent).toContain('español');
     });
 
     describe('and when a locale is selected', () => {

--- a/libs/domain/site/locale-selector/src/locale-selector.component.spec.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.component.spec.ts
@@ -103,17 +103,17 @@ describe('SiteLocaleSelectorComponent', () => {
     });
 
     it('should render the english option in its native locale', () => {
-      const en = element.shadowRoot?.querySelector('oryx-option[value=en');
+      const en = element.shadowRoot?.querySelector('oryx-option[value=en]');
       expect(en?.textContent).toContain('English');
     });
 
     it('should render the Deutch option in its native locale', () => {
-      const en = element.shadowRoot?.querySelector('oryx-option[value=de');
+      const en = element.shadowRoot?.querySelector('oryx-option[value=de]');
       expect(en?.textContent).toContain('Deutsch');
     });
 
     it('should render the Spanish option in its native locale', () => {
-      const en = element.shadowRoot?.querySelector('oryx-option[value=es');
+      const en = element.shadowRoot?.querySelector('oryx-option[value=es]');
       expect(en?.textContent).toContain('español');
     });
 

--- a/libs/domain/site/locale-selector/src/locale-selector.component.ts
+++ b/libs/domain/site/locale-selector/src/locale-selector.component.ts
@@ -58,7 +58,7 @@ export class SiteLocaleSelectorComponent extends ContentMixin<SiteLocaleSelector
   }
 
   protected getLabel(code: string): string {
-    const languageNames = new Intl.DisplayNames([this.current ?? 'en'], {
+    const languageNames = new Intl.DisplayNames([code], {
       type: 'language',
     });
     return languageNames.of(code) ?? code;


### PR DESCRIPTION
Each locale option in the locale selector is now rendered in it’s own locale, so that the user who ended up in the wrong local is able to switch. Previously, labels where rendered in the active locale, which causes difficulties for users to switch.

closes [HRZ-2581](https://spryker.atlassian.net/browse/HRZ-2581)

[HRZ-2581]: https://spryker.atlassian.net/browse/HRZ-2581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ