### PR TITLE
feat: price component

### DIFF
--- a/apps/storefront-e2e/src/support/page_fragments/cart-entry.fragment.ts
+++ b/apps/storefront-e2e/src/support/page_fragments/cart-entry.fragment.ts
@@ -18,7 +18,7 @@ export class CartEntryFragment {
     this.getWrapper().find('oryx-product-price').find('[part="sales"]');
   getOriginalPrice = () =>
     this.getWrapper().find('oryx-product-price').find('[part="original"]');
-  getSubtotal = () => this.getWrapper().find('.entry-price');
+  getSubtotal = () => this.getWrapper().find('oryx-price').shadow();
   getRemoveBtn = () => this.getWrapper().find('[aria-label="remove"]');
   getQuantityInput = () =>
     new QuantityInputFragment(

--- a/libs/domain/cart/entry/src/entry.component.ts
+++ b/libs/domain/cart/entry/src/entry.component.ts
@@ -18,7 +18,7 @@ import { asyncState, i18n, valueType } from '@spryker-oryx/utilities';
 import { html, LitElement, PropertyValueMap, TemplateResult } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { when } from 'lit/directives/when.js';
-import { filter, first, map, switchMap } from 'rxjs';
+import { filter, map, switchMap } from 'rxjs';
 import {
   QuantityEventDetail,
   QuantityInputComponent,
@@ -54,7 +54,6 @@ export class CartEntryComponent
   @property() key?: string;
   @property({ type: Boolean }) readonly?: boolean;
 
-  @state() protected formattedPrice?: string;
   @state() protected requiresRemovalConfirmation?: boolean;
 
   protected willUpdate(
@@ -63,17 +62,7 @@ export class CartEntryComponent
     if (props.has('sku')) {
       this.context.provide(ProductContext.SKU, this.sku);
     }
-    if (props.has('price')) {
-      this.formatPrice();
-    }
     super.willUpdate(props);
-  }
-
-  protected formatPrice(): void {
-    this.pricingService
-      .format(this.price)
-      .pipe(first(Boolean))
-      .subscribe((formatted) => (this.formattedPrice = formatted));
   }
 
   protected productService = resolve(ProductService);
@@ -180,7 +169,7 @@ export class CartEntryComponent
     return html`
       <section class="pricing">
         ${qtyTemplate}
-        <span class="entry-price">${this.formattedPrice}</span>
+        <oryx-price .value=${this.price}></oryx-price>
 
         ${when(
           this.componentOptions?.enableItemPrice,

--- a/libs/domain/cart/entry/src/styles/entry.styles.ts
+++ b/libs/domain/cart/entry/src/styles/entry.styles.ts
@@ -18,7 +18,7 @@ const pricing = css`
     display: contents;
   }
 
-  .entry-price {
+  oryx-price {
     font-size: var(--oryx-typography-h6-size);
     font-weight: var(--oryx-typography-h6-weight);
     line-height: var(--oryx-typography-h6-line);

--- a/libs/domain/site/price/index.ts
+++ b/libs/domain/site/price/index.ts
@@ -1,0 +1,2 @@
+export * from './price.component';
+export * from './price.model';

--- a/libs/domain/site/price/price.component.spec.ts
+++ b/libs/domain/site/price/price.component.spec.ts
@@ -1,0 +1,130 @@
+import { fixture } from '@open-wc/testing-helpers';
+import { useComponent } from '@spryker-oryx/core/utilities';
+import { createInjector, destroyInjector } from '@spryker-oryx/di';
+import { LocaleService } from '@spryker-oryx/i18n';
+import {
+  CurrencyService,
+  priceComponent,
+  siteProviders,
+} from '@spryker-oryx/site';
+import { html } from 'lit';
+import { of } from 'rxjs';
+import { PriceComponent } from './price.component';
+
+class MockLocaleService implements Partial<LocaleService> {
+  get = vi.fn().mockReturnValue(of('en'));
+}
+
+class MockCurrencyService implements Partial<CurrencyService> {
+  get = vi.fn().mockReturnValue(of('EUR'));
+}
+
+class mockPricingService {
+  format = vi.fn().mockReturnValue(of());
+}
+
+describe('PriceComponent', () => {
+  let element: PriceComponent;
+  let localeService: MockLocaleService;
+  let currencyService: MockCurrencyService;
+
+  beforeAll(async () => {
+    await useComponent([priceComponent]);
+  });
+
+  beforeEach(async () => {
+    const injector = createInjector({
+      providers: [
+        ...siteProviders,
+        {
+          provide: LocaleService,
+          useClass: MockLocaleService,
+        },
+        {
+          provide: CurrencyService,
+          useClass: MockCurrencyService,
+        },
+      ],
+    });
+
+    localeService = injector.inject(
+      LocaleService
+    ) as unknown as MockLocaleService;
+    currencyService = injector.inject(
+      CurrencyService
+    ) as unknown as MockCurrencyService;
+  });
+
+  afterEach(() => {
+    destroyInjector();
+    vi.clearAllMocks();
+  });
+
+  describe('when the component is initialised', () => {
+    beforeEach(async () => {
+      element = await fixture(html`<oryx-price></oryx-price>`);
+    });
+
+    it('should be an instance of PriceComponent', () => {
+      expect(element).toBeInstanceOf(PriceComponent);
+    });
+  });
+
+  describe('when the current locale is "en" and the current currency is "EUR"', () => {
+    beforeEach(async () => {
+      localeService.get.mockReturnValue(of('en'));
+      currencyService.get.mockReturnValue(of('EUR'));
+    });
+
+    describe('and the value is 1234', () => {
+      beforeEach(async () => {
+        element = await fixture(html`<oryx-price .value=${1234}></oryx-price>`);
+      });
+
+      it('should render €12.34', () => {
+        expect(element.shadowRoot?.textContent?.trim()).toBe('€12.34');
+      });
+    });
+
+    describe('and when the currency property is set to "USD"', () => {
+      beforeEach(async () => {
+        element = await fixture(
+          html`<oryx-price .value=${1234} currency="USD"></oryx-price>`
+        );
+      });
+
+      it('should render $12.34', () => {
+        expect(element.shadowRoot?.textContent?.trim()).toBe('$12.34');
+      });
+    });
+  });
+
+  describe('when the current locale is "de" and the current currency is "GBP"', () => {
+    beforeEach(async () => {
+      localeService.get.mockReturnValue(of('de'));
+      currencyService.get.mockReturnValue(of('GBP'));
+    });
+
+    describe('and the value is 1234', () => {
+      beforeEach(async () => {
+        element = await fixture(html`<oryx-price .value=${1234}></oryx-price>`);
+      });
+
+      it('should render 12,34 £', () => {
+        expect(element.shadowRoot?.textContent?.trim()).toBe('12,34 £');
+      });
+    });
+
+    describe('and when the currency property is set to "USD"', () => {
+      beforeEach(async () => {
+        element = await fixture(
+          html`<oryx-price .value=${1234} currency="USD"></oryx-price>`
+        );
+      });
+
+      it('should render $12.34', () => {
+        expect(element.shadowRoot?.textContent?.trim()).toBe('12,34 $');
+      });
+    });
+  });
+});

--- a/libs/domain/site/price/price.component.ts
+++ b/libs/domain/site/price/price.component.ts
@@ -1,0 +1,37 @@
+import { resolve } from '@spryker-oryx/di';
+import { computed, hydratable, signal } from '@spryker-oryx/utilities';
+import { html, LitElement, TemplateResult } from 'lit';
+import { property } from 'lit/decorators.js';
+import { PricingService } from '../src/services';
+import { PriceComponentAttributes } from './price.model';
+
+@hydratable()
+export class PriceComponent
+  extends LitElement
+  implements PriceComponentAttributes
+{
+  protected pricingService = resolve(PricingService);
+
+  // TODO: replace with new propertySignal when it's ready
+  protected currencyValue = signal(undefined as undefined | string);
+  @property() set currency(value: string) {
+    this.currencyValue.set(value);
+  }
+
+  // TODO: replace with new propertySignal when it's ready
+  protected priceValue = signal(undefined as undefined | number);
+  @property() set value(value: number) {
+    this.priceValue.set(value);
+  }
+
+  // TODO: drop inner signal when observables are natively supported
+  protected price = computed(() =>
+    signal(
+      this.pricingService.format(this.priceValue(), this.currencyValue())
+    )()
+  );
+
+  protected override render(): TemplateResult | void {
+    return html`${this.price()}`;
+  }
+}

--- a/libs/domain/site/price/price.component.ts
+++ b/libs/domain/site/price/price.component.ts
@@ -13,15 +13,15 @@ export class PriceComponent
   protected pricingService = resolve(PricingService);
 
   // TODO: replace with new propertySignal when it's ready
-  protected currencyValue = signal(undefined as undefined | string);
-  @property() set currency(value: string) {
-    this.currencyValue.set(value);
-  }
-
-  // TODO: replace with new propertySignal when it's ready
   protected priceValue = signal(undefined as undefined | number);
   @property() set value(value: number) {
     this.priceValue.set(value);
+  }
+
+  // TODO: replace with new propertySignal when it's ready
+  protected currencyValue = signal(undefined as undefined | string);
+  @property() set currency(value: string) {
+    this.currencyValue.set(value);
   }
 
   // TODO: drop inner signal when observables are natively supported

--- a/libs/domain/site/price/price.def.ts
+++ b/libs/domain/site/price/price.def.ts
@@ -1,0 +1,6 @@
+import { componentDef } from '@spryker-oryx/core';
+
+export const priceComponent = componentDef({
+  name: 'oryx-price',
+  impl: () => import('./price.component').then((m) => m.PriceComponent),
+});

--- a/libs/domain/site/price/price.model.ts
+++ b/libs/domain/site/price/price.model.ts
@@ -1,0 +1,21 @@
+export interface PriceComponentAttributes {
+  /**
+   * The value property represents the price in cents. For example,
+   * if the price is €30.001, the value should be set to `3000.1`.
+   *
+   * Note that this property uses the smallest currency unit as the base unit
+   * for prices.
+   */
+  value: number;
+
+  /**
+   * The currency property represents the currency used for the price.
+   * If not provided, the component will use the active currency.
+   *
+   * To explicitly set the currency, pass a string representing the
+   * currency code (e.g. 'USD', 'EUR', etc.). The currency code should
+   * be provided using the ISO 4217, which is a three-letter codes for
+   * currencies used worldwide.
+   */
+  currency?: string;
+}

--- a/libs/domain/site/price/price.model.ts
+++ b/libs/domain/site/price/price.model.ts
@@ -1,10 +1,7 @@
 export interface PriceComponentAttributes {
   /**
    * The value property represents the price in cents. For example,
-   * if the price is €30.001, the value should be set to `3000.1`.
-   *
-   * Note that this property uses the smallest currency unit as the base unit
-   * for prices.
+   * if the price is €12.34, the value should be set to `1234`.
    */
   value: number;
 

--- a/libs/domain/site/price/stories/price.stories.ts
+++ b/libs/domain/site/price/stories/price.stories.ts
@@ -1,0 +1,28 @@
+import { Meta, Story } from '@storybook/web-components';
+import { html, TemplateResult } from 'lit';
+import { storybookPrefix } from '../../.constants';
+import { PriceComponentAttributes } from '../price.model';
+
+export default {
+  title: `${storybookPrefix}/price`,
+  args: {
+    value: 1234,
+  },
+  argTypes: {
+    currency: {
+      control: { type: 'select' },
+      options: ['USD', 'EUR', 'GBP', 'NOK', 'ZWL'],
+    },
+  },
+} as Meta;
+
+const Template: Story<PriceComponentAttributes> = (
+  props: PriceComponentAttributes
+): TemplateResult => {
+  return html`<oryx-price
+    .value=${props.value}
+    .currency=${props.currency}
+  ></oryx-price>`;
+};
+
+export const Demo = Template.bind({});

--- a/libs/domain/site/src/components.ts
+++ b/libs/domain/site/src/components.ts
@@ -1,3 +1,4 @@
 export * from '../currency-selector/src/currency-selector.def';
 export * from '../locale-selector/src/locale-selector.def';
 export * from '../notification-center/src/notification-center.def';
+export * from '../price/price.def';

--- a/libs/domain/site/src/services/pricing/default-pricing.service.ts
+++ b/libs/domain/site/src/services/pricing/default-pricing.service.ts
@@ -8,7 +8,13 @@ export class DefaultPricingService implements PricingService {
   protected currencyService = resolve(CurrencyService);
   protected localeService = resolve(LocaleService);
 
-  format(price?: PriceValue): Observable<string | null> {
+  format(price?: PriceValue, currency?: string): Observable<string | null> {
+    if (currency) {
+      return this.localeService
+        .get()
+        .pipe(map((locale) => this.formatPrice(price, currency, locale)));
+    }
+
     return combineLatest([
       this.currencyService.get(),
       this.localeService.get(),

--- a/libs/domain/site/src/services/pricing/pricing.service.ts
+++ b/libs/domain/site/src/services/pricing/pricing.service.ts
@@ -17,7 +17,7 @@ export interface PricingService {
    *
    * @return formatted price as string
    */
-  format(price?: PriceValue): Observable<string | null>;
+  format(price?: PriceValue, currency?: string): Observable<string | null>;
 }
 
 export const PricingService = 'oryx.PricingService';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -153,6 +153,7 @@
       "@spryker-oryx/site/notification-center": [
         "libs/domain/site/notification-center/index.ts"
       ],
+      "@spryker-oryx/site/price": ["libs/domain/site/price/index.ts"],
       "@spryker-oryx/testing": ["tools/testing"],
       "@spryker-oryx/themes": ["libs/template/themes/src/index.ts"],
       "@spryker-oryx/themes/breakpoints": [


### PR DESCRIPTION
The price component renders the price in the expected format by observing the current locale and currency. 
Optionally, a static currency can be used in those cases where a price should be formatted in a non-current currency.

fixes [HRZ-2605](https://spryker.atlassian.net/browse/HRZ-2605)

[HRZ-2605]: https://spryker.atlassian.net/browse/HRZ-2605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ