### PR TITLE
fix: multirange component conflicting properties

### DIFF
--- a/libs/base/ui/form/multi-range/src/multi-range.component.spec.ts
+++ b/libs/base/ui/form/multi-range/src/multi-range.component.spec.ts
@@ -189,20 +189,6 @@ describe('MultiRangeComponent', () => {
     });
   });
 
-  describe('minValue property is set to the value bigger then maxValue', () => {
-    beforeEach(async () => {
-      element = await fixture(
-        html`<oryx-multi-range maxValue="10"></oryx-multi-range>`
-      );
-    });
-
-    it('minValue should be one step less then maxValue', async () => {
-      element.minValue = 11;
-
-      await expect(element.minValue).toBe(9);
-    });
-  });
-
   describe('minValue property is set to the value less then min', () => {
     beforeEach(async () => {
       element = await fixture(
@@ -212,32 +198,6 @@ describe('MultiRangeComponent', () => {
 
     it('minValue should be equal to min', async () => {
       await expect(element.minValue).toBe(0);
-    });
-  });
-
-  describe('maxValue property is set to the value less then minValue', () => {
-    beforeEach(async () => {
-      element = await fixture(
-        html`<oryx-multi-range minValue="1"></oryx-multi-range>`
-      );
-    });
-
-    it('maxValue should be one step bigger then minValue', async () => {
-      element.maxValue = 0;
-
-      await expect(element.maxValue).toBe(2);
-    });
-  });
-
-  describe('maxValue property is set to the value bigger then max', () => {
-    beforeEach(async () => {
-      element = await fixture(
-        html`<oryx-multi-range max="10" maxValue="11"></oryx-multi-range>`
-      );
-    });
-
-    it('maxValue should be equal to max', async () => {
-      await expect(element.maxValue).toBe(10);
     });
   });
 

--- a/libs/base/ui/form/multi-range/src/multi-range.component.ts
+++ b/libs/base/ui/form/multi-range/src/multi-range.component.ts
@@ -16,88 +16,49 @@ export class MultiRangeComponent
   @property({ type: Boolean }) disabled?: boolean;
   @property({ type: Number }) step = 1;
 
-  protected _min = 0;
-  @property({ type: Number })
-  get min(): number {
-    return this._min;
-  }
-  set min(value: number) {
-    const oldValue = this._min;
-    this._min = value >= this.max ? this.max - this.step : value;
-    this.requestUpdate('min', oldValue);
-  }
-
-  protected _max = 100;
-  @property({ type: Number })
-  get max(): number {
-    return this._max;
-  }
-  set max(value: number) {
-    const oldValue = this._max;
-    this._max = value <= this.min ? this.min + this.step : value;
-    this.requestUpdate('max', oldValue);
-  }
-
-  protected _minValue = 0;
-  @property({ type: Number })
-  get minValue(): number {
-    return this._minValue;
-  }
-  set minValue(value: number) {
-    const oldValue = this._minValue;
-    this._minValue =
-      value <= this.min
-        ? this.min
-        : value >= this.maxValue
-        ? this.maxValue - this.step
-        : value;
-    if (this.inputMinRef && this.inputMinRef.value) {
-      this.inputMinRef.value.value = String(this._minValue);
-    }
-    this.requestUpdate('minValue', oldValue);
-  }
-
-  protected _maxValue = 100;
-  @property({ type: Number })
-  get maxValue(): number {
-    return this._maxValue;
-  }
-  set maxValue(value: number) {
-    const oldValue = this._maxValue;
-    this._maxValue =
-      value >= this.max
-        ? this.max
-        : value <= this.minValue
-        ? this.minValue + this.step
-        : value;
-    if (this.inputMaxRef && this.inputMaxRef.value) {
-      this.inputMaxRef.value.value = String(this._maxValue);
-    }
-    this.requestUpdate('maxValue', oldValue);
-  }
+  @property({ type: Number }) min = 0;
+  @property({ type: Number }) max = 100;
+  @property({ type: Number }) minValue = 0;
+  @property({ type: Number }) maxValue = 100;
 
   update(changedProperties: PropertyValues): void {
+    if (
+      this.min >= this.max ||
+      this.minValue >= this.max ||
+      this.minValue >= this.maxValue ||
+      this.maxValue > this.max ||
+      this.minValue < this.min ||
+      this.step > this.max - this.min
+    ) {
+      console.error(
+        'MultiRangeComponent',
+        'Provided attributes has conflicting values. Check it, please'
+      );
+    }
+
     const calculatePercentage = (
       value: number,
       minValue: number,
       maxValue: number
     ) => ((value - minValue) / (maxValue - minValue)) * 100;
+
     const sliderMinPercentage = calculatePercentage(
       this.minValue,
       this.min,
       this.max
     );
+
     const sliderMaxPercentage = calculatePercentage(
       this.maxValue,
       this.min,
       this.max
     );
+
     this.style.setProperty('--_multi-range-min', `${sliderMinPercentage}%`);
     this.style.setProperty(
       '--_multi-range-max',
       `${100 - sliderMaxPercentage}%`
     );
-
     super.update(changedProperties);
   }
 

--- a/libs/base/ui/form/multi-range/src/multi-range.component.ts
+++ b/libs/base/ui/form/multi-range/src/multi-range.component.ts
@@ -24,10 +24,9 @@ export class MultiRangeComponent
   update(changedProperties: PropertyValues): void {
     if (
       this.min >= this.max ||
-      this.minValue >= this.max ||
+      this.minValue < this.min ||
       this.minValue >= this.maxValue ||
       this.maxValue > this.max ||
-      this.minValue < this.min ||
       this.step > this.max - this.min
     ) {
       console.error(


### PR DESCRIPTION
closes: [HRZ-2241](https://spryker.atlassian.net/browse/HRZ-2241)

The component could be broken due to a combination of incorrect attributes. Some cases of incorrect attribute combinations were caught, but the component still only "simulated" the correct appearance. In this case, I decided to remove unnecessary checks to reduce the amount of JS code and the number of computational operations. 
Now the component only checks the correctness of the attributes and throws an error in the console if the values of the attributes conflict with each other.

[HRZ-2241]: https://spryker.atlassian.net/browse/HRZ-2241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ