### PR TITLE
fix: remove unnecessary override style for oryx button

### DIFF
--- a/libs/domain/user/address-list-item/src/address-list-item.styles.ts
+++ b/libs/domain/user/address-list-item/src/address-list-item.styles.ts
@@ -20,10 +20,6 @@ export const styles = css`
     overflow: initial;
   }
 
-  oryx-icon-button button {
-    padding: 10px;
-  }
-
   section,
   oryx-radio {
     padding: 12px 16px;


### PR DESCRIPTION
Closes [HRZ-2698](https://spryker.atlassian.net/browse/HRZ-2698)


[HRZ-2698]: https://spryker.atlassian.net/browse/HRZ-2698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ