### PR TITLE
feat: support observables in computed

### DIFF
--- a/libs/base/utilities/src/signals/index.ts
+++ b/libs/base/utilities/src/signals/index.ts
@@ -1,4 +1,4 @@
-export * from './core';
+export * as Signals from './core';
 export * from './signal';
 export * from './signal-from';
 export * from './signal.controller';

--- a/libs/base/utilities/src/signals/signal-from.spec.ts
+++ b/libs/base/utilities/src/signals/signal-from.spec.ts
@@ -1,5 +1,6 @@
-import { SignalConsumer } from '@spryker-oryx/utilities';
-import { BehaviorSubject, of } from 'rxjs';
+import { wait } from '@spryker-oryx/utilities';
+import { BehaviorSubject, delay, of } from 'rxjs';
+import { SignalConsumer } from './core/signals';
 import { signalFrom, SignalObservable } from './signal-from';
 
 describe('signalFrom', () => {
@@ -11,16 +12,26 @@ describe('signalFrom', () => {
     expect(result).toHaveProperty('disconnect');
   });
 
-  it('should connect and update the value when the observable emits', () => {
+  it('should connect and update the value when the async observable emits', async () => {
     const observable = new BehaviorSubject(42);
-    const signal = signalFrom(observable);
-    expect(signal()).toBeUndefined();
+    const signal = signalFrom(observable.pipe(delay(0)));
+    expect(signal()).toBe(undefined);
     signal.connect();
+    await wait(0);
     expect(signal()).toBe(42);
     observable.next(43);
+    await wait(0);
     expect(signal()).toBe(43);
     signal.disconnect();
     observable.next(44);
+    expect(signal()).toBe(undefined);
+  });
+
+  it('should return synchronous emission without connect', () => {
+    const observable = new BehaviorSubject(42);
+    const signal = signalFrom(observable);
+    expect(signal()).toBe(42);
+    observable.next(43);
     expect(signal()).toBe(43);
   });
 });

--- a/libs/base/utilities/src/signals/signal-from.spec.ts
+++ b/libs/base/utilities/src/signals/signal-from.spec.ts
@@ -1,9 +1,15 @@
-import { wait } from '@spryker-oryx/utilities';
 import { BehaviorSubject, delay, of } from 'rxjs';
 import { SignalConsumer } from './core/signals';
 import { signalFrom, SignalObservable } from './signal-from';
 
 describe('signalFrom', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('should return a ConnectableSignal for a given observable', () => {
     const observable = of(42);
     const result = signalFrom(observable);
@@ -12,15 +18,15 @@ describe('signalFrom', () => {
     expect(result).toHaveProperty('disconnect');
   });
 
-  it('should connect and update the value when the async observable emits', async () => {
+  it('should connect and update the value when the async observable emits', () => {
     const observable = new BehaviorSubject(42);
-    const signal = signalFrom(observable.pipe(delay(0)));
+    const signal = signalFrom(observable.pipe(delay(1)));
     expect(signal()).toBe(undefined);
     signal.connect();
-    await wait(0);
+    vi.advanceTimersByTime(1);
     expect(signal()).toBe(42);
     observable.next(43);
-    await wait(0);
+    vi.advanceTimersByTime(1);
     expect(signal()).toBe(43);
     signal.disconnect();
     observable.next(44);

--- a/libs/base/utilities/src/signals/signal-from.ts
+++ b/libs/base/utilities/src/signals/signal-from.ts
@@ -14,6 +14,16 @@ export class SignalObservable<T, K = undefined> extends StateSignal<T | K> {
     super(initialValue as K);
   }
 
+  get value(): T | K {
+    this.accessed();
+    if (!this.subscription) {
+      let syncResult: T | undefined;
+      this.observable.subscribe((value) => (syncResult = value)).unsubscribe();
+      return syncResult ?? this.initialValue;
+    }
+    return this.state;
+  }
+
   watch(sniffer: SignalConsumer): void {
     if (this.consumers.size === 0) this.connect();
     super.watch(sniffer);

--- a/libs/base/utilities/src/signals/signal.spec.ts
+++ b/libs/base/utilities/src/signals/signal.spec.ts
@@ -1,5 +1,6 @@
-import { of } from 'rxjs';
-import { signal } from './signal';
+import { wait } from '@spryker-oryx/utilities';
+import { BehaviorSubject, interval, of } from 'rxjs';
+import { computed, effect, signal } from './signal';
 
 describe('signal', () => {
   it('should return a SettableSignal for a non-observable value', () => {
@@ -13,5 +14,62 @@ describe('signal', () => {
     const result = signal(observable);
 
     expect(result.connect).toBeDefined();
+  });
+});
+
+describe('computed', () => {
+  it('should return a Signal for a non-observable value', () => {
+    const value = 42;
+    const result = computed(() => value);
+    expect(result()).toBe(value);
+  });
+
+  it('should return a Signal for an observable value', () => {
+    const value = 42;
+    const result = computed(() => of(value));
+    expect(result()).toBe(value);
+  });
+
+  it('should react to changes in the observable value', () => {
+    const observable = new BehaviorSubject(1);
+    const result = computed(() => observable);
+
+    const values = [1, 2, 3];
+
+    const results: any[] = [];
+
+    const ef = effect(() => {
+      results.push(result());
+    });
+
+    while (results.length < values.length) {
+      observable.next(values[results.length]);
+    }
+    ef.stop();
+    expect(results).toEqual(values);
+  });
+
+  it('should create a computed with a signal-based input', async () => {
+    const period = signal(100);
+    const c = computed(() => interval(period()));
+
+    const values: any[] = [];
+    const maxValues = 3;
+
+    const ef = effect(() => {
+      values.push(c());
+    });
+
+    await wait(100 * maxValues + 50);
+
+    expect(values.length).toBe(maxValues + 1);
+    expect(values).toEqual([undefined, 0, 1, 2]);
+
+    period.set(200);
+    await wait(200 * maxValues + 50);
+
+    expect(values).toEqual([undefined, 0, 1, 2, undefined, 0, 1, 2]);
+
+    ef.stop();
   });
 });

--- a/libs/base/utilities/src/signals/signal.ts
+++ b/libs/base/utilities/src/signals/signal.ts
@@ -1,7 +1,17 @@
 import { isObservable, Observable } from 'rxjs';
-import { createSignal, SettableSignal } from './core/factories';
+import { Computed } from './core';
+import { createSignal, SettableSignal, Signal } from './core/factories';
 import { ConnectableSignal, signalFrom } from './signal-from';
 
+export { effect } from './core/factories';
+export type { Signal } from './core/factories';
+export { Effect } from './core/signals';
+
+/**
+ * Factory function for creating signals with built-in support for observables:
+ * - If the first argument is a value, a signal will be created with the value.
+ * - If the first argument is an observable, a signal will be created from the observable.
+ */
 export function signal<T>(
   observable: Observable<T>,
   initialValue: T
@@ -20,4 +30,39 @@ export function signal<T>(
   }
 
   return createSignal(value);
+}
+
+/**
+ * Factory function for creating computes with built-in support for observables
+ * - If computed result is an observable, a transparent signal will be created from the observable.
+ */
+export function computed<T>(
+  computation: () => Observable<T>
+): ConnectableSignal<T | undefined>;
+export function computed<T>(computation: () => T): Signal<T>;
+export function computed<T>(
+  computation: () => T | Observable<T>
+): Signal<T> | ConnectableSignal<T | undefined> {
+  const instance = new Computed(computation);
+
+  let last: undefined | T | Observable<T>;
+  let observableSignal: undefined | ConnectableSignal<T>;
+
+  function getValue() {
+    const value = instance.value;
+    if (isObservable(value)) {
+      if (value !== last) {
+        last = value;
+        observableSignal = signalFrom(value);
+      }
+      return observableSignal!();
+    }
+    return value;
+  }
+
+  const computed = () => getValue();
+  computed.valueOf = () => getValue();
+  computed.toString = () => String(getValue());
+
+  return computed as Signal<T>;
 }

--- a/libs/domain/product/list/src/list.component.ts
+++ b/libs/domain/product/list/src/list.component.ts
@@ -5,7 +5,7 @@ import {
   ProductListQualifier,
   ProductListService,
 } from '@spryker-oryx/product';
-import { computed, hydratable, signal } from '@spryker-oryx/utilities';
+import { computed, hydratable } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
 import { ProductListOptions } from './list.model';
 import { baseStyles } from './list.styles';
@@ -22,8 +22,8 @@ export class ProductListComponent extends ContentMixin<ProductListOptions>(
   protected list = computed(() => {
     const params = this.searchParams();
     return params
-      ? signal(this.productListService.get(params))()
-      : signal(this.productListPageService.get())();
+      ? this.productListService.get(params)
+      : this.productListPageService.get();
   });
 
   protected override render(): TemplateResult {

--- a/libs/domain/site/price/price.component.ts
+++ b/libs/domain/site/price/price.component.ts
@@ -24,7 +24,6 @@ export class PriceComponent
     this.currencyValue.set(value);
   }
 
-  // TODO: drop inner signal when observables are natively supported
   protected price = computed(() =>
     this.pricingService.format(this.priceValue(), this.currencyValue())
   );

--- a/libs/domain/site/price/price.component.ts
+++ b/libs/domain/site/price/price.component.ts
@@ -26,9 +26,7 @@ export class PriceComponent
 
   // TODO: drop inner signal when observables are natively supported
   protected price = computed(() =>
-    signal(
-      this.pricingService.format(this.priceValue(), this.currencyValue())
-    )()
+    this.pricingService.format(this.priceValue(), this.currencyValue())
   );
 
   protected override render(): TemplateResult | void {


### PR DESCRIPTION
Add built-in support for observables in computed. 

When result of computation will return an observable, it will be transparently converted to ConnectableSignal. 

Closes [HRZ-2678](https://spryker.atlassian.net/browse/HRZ-2678)

[HRZ-2678]: https://spryker.atlassian.net/browse/HRZ-2678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ