### PR TITLE
feat: signalAware decorator

### DIFF
--- a/libs/base/utilities/src/decorators/hydratable/hydratable.ts
+++ b/libs/base/utilities/src/decorators/hydratable/hydratable.ts
@@ -80,7 +80,6 @@ function hydratableClass<T extends Type<HTMLElement>>(
 
     constructor(...args: any[]) {
       super(...args);
-      new SignalController(this as any);
 
       this.hasSsr = !isServer && !!this.shadowRoot;
 

--- a/libs/base/utilities/src/decorators/hydratable/hydratable.ts
+++ b/libs/base/utilities/src/decorators/hydratable/hydratable.ts
@@ -5,7 +5,7 @@ import {
 } from '@lit/reactive-element/decorators.js';
 import { Type } from '@spryker-oryx/di';
 import { html, isServer, LitElement, noChange, TemplateResult } from 'lit';
-import { Effect, effect, SignalController } from '../../signals';
+import { Effect, effect } from '../../signals';
 import { asyncStates } from '../async-state';
 
 const DEFER_HYDRATION = Symbol('deferHydration');

--- a/libs/base/utilities/src/signals/index.ts
+++ b/libs/base/utilities/src/signals/index.ts
@@ -1,4 +1,5 @@
 export * as Signals from './core';
 export * from './signal';
+export * from './signal-aware';
 export * from './signal-from';
 export * from './signal.controller';

--- a/libs/base/utilities/src/signals/signal-aware.spec.ts
+++ b/libs/base/utilities/src/signals/signal-aware.spec.ts
@@ -1,0 +1,31 @@
+import { fixture, nextFrame } from '@open-wc/testing-helpers';
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { signal } from './signal';
+import { signalAware } from './signal-aware';
+
+@customElement('mock-signal-aware-component')
+@signalAware()
+class MockSignalAwareComponent extends LitElement {
+  mockSignal = signal(42);
+}
+
+describe('signalAware decorator', () => {
+  let element: MockSignalAwareComponent;
+
+  beforeEach(async () => {
+    element = await fixture(
+      html`<mock-signal-aware-component></mock-signal-aware-component>`
+    );
+  });
+
+  it('should instantiate SignalController for a custom element using signalAware decorator', async () => {
+    await nextFrame();
+    expect((element as any)[Symbol.for('SignalController')]).toBeDefined();
+  });
+
+  it('should properly set up a signal on a custom element using signalAware decorator', async () => {
+    await nextFrame();
+    expect(element.mockSignal()).toBe(42);
+  });
+});

--- a/libs/base/utilities/src/signals/signal-aware.ts
+++ b/libs/base/utilities/src/signals/signal-aware.ts
@@ -1,0 +1,36 @@
+import { ReactiveElement } from '@lit/reactive-element';
+import { ClassDescriptor } from '@lit/reactive-element/decorators.js';
+import { Type } from '@spryker-oryx/di';
+import { SignalController } from './signal.controller';
+
+const legacySignalAware = (clazz: Type<ReactiveElement>) => {
+  return class extends clazz {
+    constructor(...args: any[]) {
+      super(...args);
+      new SignalController(this);
+    }
+  } as any;
+};
+
+const standardSignalAware = (descriptor: ClassDescriptor) => {
+  const { kind, elements } = descriptor;
+  return {
+    kind,
+    elements,
+    finisher(clazz: Type<ReactiveElement>) {
+      (clazz as any).addInitializer((instance: ReactiveElement) => {
+        new SignalController(instance);
+      });
+      return clazz;
+    },
+  };
+};
+
+export const signalAware =
+  <T extends ReactiveElement>(): ((
+    classOrDescriptor: Type<T>
+  ) => Type<T> | ClassDescriptor | any) =>
+  (classOrDescriptor: Type<T> | ClassDescriptor) =>
+    typeof classOrDescriptor === 'function'
+      ? legacySignalAware(classOrDescriptor)
+      : standardSignalAware(classOrDescriptor as ClassDescriptor);

--- a/libs/domain/cart/src/mixins/cart.mixin.ts
+++ b/libs/domain/cart/src/mixins/cart.mixin.ts
@@ -1,5 +1,5 @@
 import { Type } from '@spryker-oryx/di';
-import { signal, Signal } from '@spryker-oryx/utilities';
+import { signal, Signal, SignalController } from '@spryker-oryx/utilities';
 import { LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
 import { CartController } from '../controllers';
@@ -42,6 +42,12 @@ export const CartComponentMixin = <
       this.cartController.getTotalQuantity(),
       null
     );
+
+    constructor(...args: any[]) {
+      super(...args);
+      // add signal support for components using this mixin
+      new SignalController(this);
+    }
   }
   return CartMixinClass as unknown as Type<CartMixinInterface> & T;
 };

--- a/libs/domain/product/src/mixins/product.mixin.ts
+++ b/libs/domain/product/src/mixins/product.mixin.ts
@@ -1,9 +1,11 @@
 import { Type } from '@spryker-oryx/di';
 import {
-  ComponentMixin,
-  ContentComponentProperties,
-} from '@spryker-oryx/experience';
-import { asyncState, Signal, signal, valueType } from '@spryker-oryx/utilities';
+  asyncState,
+  Signal,
+  signal,
+  SignalController,
+  valueType,
+} from '@spryker-oryx/utilities';
 import { LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
 import { ProductController } from '../controllers';
@@ -26,6 +28,11 @@ export const ProductMixin = <
   superClass: T
 ): Type<ProductMixinInterface> & T => {
   class ProductMixinClass extends superClass {
+    constructor(...args: any[]) {
+      super(...args);
+      new SignalController(this);
+    }
+
     @property({ reflect: true }) sku?: string;
 
     protected productController = new ProductController(this);
@@ -37,20 +44,4 @@ export const ProductMixin = <
   }
   // Cast return type to your mixin's interface intersected with the superClass type
   return ProductMixinClass as unknown as Type<ProductMixinInterface> & T;
-};
-
-/** @deprecated Use ProductMixin instead */
-export const ProductComponentMixin = <T>(): Type<
-  LitElement & ContentComponentProperties<T> & ProductComponentProperties
-> => {
-  class ProductComponent
-    extends ComponentMixin<T>()
-    implements ProductComponentProperties
-  {
-    @property({ reflect: true }) sku?: string;
-    @property({ type: Object, reflect: true }) product?: Product;
-  }
-  return ProductComponent as Type<
-    LitElement & ContentComponentProperties<T> & ProductComponentProperties
-  >;
 };

--- a/libs/domain/product/src/mixins/product.mixin.ts
+++ b/libs/domain/product/src/mixins/product.mixin.ts
@@ -28,11 +28,6 @@ export const ProductMixin = <
   superClass: T
 ): Type<ProductMixinInterface> & T => {
   class ProductMixinClass extends superClass {
-    constructor(...args: any[]) {
-      super(...args);
-      new SignalController(this);
-    }
-
     @property({ reflect: true }) sku?: string;
 
     protected productController = new ProductController(this);
@@ -41,6 +36,12 @@ export const ProductMixin = <
     protected product = valueType(this.productController.getProduct());
 
     protected $product = signal(this.productController.getProduct(), null);
+
+    constructor(...args: any[]) {
+      super(...args);
+      // add signal support for components using this mixin
+      new SignalController(this);
+    }
   }
   // Cast return type to your mixin's interface intersected with the superClass type
   return ProductMixinClass as unknown as Type<ProductMixinInterface> & T;

--- a/libs/domain/site/price/price.component.ts
+++ b/libs/domain/site/price/price.component.ts
@@ -1,11 +1,17 @@
 import { resolve } from '@spryker-oryx/di';
-import { computed, hydratable, signal } from '@spryker-oryx/utilities';
+import {
+  computed,
+  hydratable,
+  signal,
+  signalAware,
+} from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
 import { PricingService } from '../src/services';
 import { PriceComponentAttributes } from './price.model';
 
 @hydratable()
+@signalAware()
 export class PriceComponent
   extends LitElement
   implements PriceComponentAttributes

--- a/libs/platform/experience/src/mixins/content.mixin.ts
+++ b/libs/platform/experience/src/mixins/content.mixin.ts
@@ -64,6 +64,7 @@ export const ContentMixin = <
 
     constructor(...args: any[]) {
       super(...args);
+      // add signal support for components using this mixin
       new SignalController(this);
     }
   }

--- a/libs/platform/experience/src/mixins/content.mixin.ts
+++ b/libs/platform/experience/src/mixins/content.mixin.ts
@@ -1,5 +1,11 @@
 import { Type } from '@spryker-oryx/di';
-import { asyncState, signal, Signal, valueType } from '@spryker-oryx/utilities';
+import {
+  asyncState,
+  signal,
+  Signal,
+  SignalController,
+  valueType,
+} from '@spryker-oryx/utilities';
 import { LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
 import { Observable } from 'rxjs';
@@ -55,6 +61,11 @@ export const ContentMixin = <
 
     protected $options = signal(this.contentController.getOptions(), {});
     protected $content = signal(this.contentController.getContent(), {});
+
+    constructor(...args: any[]) {
+      super(...args);
+      new SignalController(this);
+    }
   }
   return ContentMixinClass as unknown as Type<
     ContentMixinInterface<OptionsType, ContentType>


### PR DESCRIPTION
- adds @signalAware decorator
- adds signal support to mixins leveraging signals

Closes [HRZ-2679](https://spryker.atlassian.net/browse/HRZ-2679)

[HRZ-2679]: https://spryker.atlassian.net/browse/HRZ-2679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ