### PR TITLE
feat: date component

### DIFF
--- a/libs/base/ui/form/styles/group-item.styles.ts
+++ b/libs/base/ui/form/styles/group-item.styles.ts
@@ -1,4 +1,5 @@
 import { css } from 'lit';
+import { HeadingTag, headingUtil } from '../../structure/heading/src';
 
 export const groupItemStyles = css`
   :host {
@@ -16,13 +17,12 @@ export const groupItemStyles = css`
   }
 
   slot[name='subtext'] {
+    ${headingUtil(HeadingTag.Caption)};
+
     display: block;
     grid-column: 2 / span 1;
-  }
-
-  slot[name='subtext']::slotted(small) {
-    font-weight: 600;
     color: var(--oryx-color-neutral-300);
+    margin-block-start: 4px;
   }
 
   oryx-error-message {

--- a/libs/base/utilities/src/signals/decorators/signal-property.ts
+++ b/libs/base/utilities/src/signals/decorators/signal-property.ts
@@ -57,7 +57,7 @@ function standardSignalProperty<T extends LitElement>(
   const { elements } = protoOrDescriptor;
   const propertyKey = protoOrDescriptor.key as keyof T;
 
-  return {
+  const descriptor = {
     kind: 'method',
     elements,
     key: propertyKey,
@@ -66,6 +66,7 @@ function standardSignalProperty<T extends LitElement>(
       propertyKey as string
     ),
   };
+  return property({ ...options, noAccessor: true })(descriptor);
 }
 
 export function signalProperty(options?: PropertyDeclaration) {

--- a/libs/domain/checkout/payment/src/payment.component.ts
+++ b/libs/domain/checkout/payment/src/payment.component.ts
@@ -109,11 +109,11 @@ export class CheckoutPaymentComponent extends ComponentMixin() {
           }}"
         />
         ${method.name}
-        <small slot="subtext">
+        <span slot="subtext">
           ${i18n('checkout.payment.select-<method>', {
             method: method.name,
           })}
-        </small>
+        </span>
       </oryx-radio>
     </oryx-tile>`;
   }

--- a/libs/domain/checkout/shipment/src/shipment.component.spec.ts
+++ b/libs/domain/checkout/shipment/src/shipment.component.spec.ts
@@ -9,7 +9,6 @@ import {
 } from '@spryker-oryx/checkout/mocks';
 import { useComponent } from '@spryker-oryx/core/utilities';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
-import { LocaleService } from '@spryker-oryx/i18n';
 import { PricingService } from '@spryker-oryx/site';
 import { radioComponent } from '@spryker-oryx/ui';
 import { html } from 'lit';
@@ -26,10 +25,6 @@ class MockPricingService implements Partial<PricingService> {
   format = vi.fn().mockReturnValue(of('mockprice'));
 }
 
-class MockLocaleService implements Partial<LocaleService> {
-  formatDate = vi.fn().mockReturnValue(of('mockdate'));
-}
-
 class MockOrchestrationService
   implements Partial<CheckoutOrchestrationService>
 {
@@ -40,7 +35,6 @@ class MockOrchestrationService
 describe('Checkout Shipment Selector component', () => {
   let element: CheckoutShipmentComponent;
   let shipmentService: MockShipmentService;
-  let localeService: MockLocaleService;
 
   const getElement = async () => {
     element = await fixture(html`<checkout-shipment></checkout-shipment>`);
@@ -62,10 +56,6 @@ describe('Checkout Shipment Selector component', () => {
           useClass: MockShipmentService,
         },
         {
-          provide: LocaleService,
-          useClass: MockLocaleService,
-        },
-        {
           provide: CheckoutOrchestrationService,
           useClass: MockOrchestrationService,
         },
@@ -75,9 +65,6 @@ describe('Checkout Shipment Selector component', () => {
     shipmentService = testInjector.inject(
       CheckoutShipmentService
     ) as unknown as MockShipmentService;
-    localeService = testInjector.inject(
-      LocaleService
-    ) as unknown as MockLocaleService;
   });
 
   afterEach(() => {
@@ -138,10 +125,8 @@ describe('Checkout Shipment Selector component', () => {
         await getElement();
       });
 
-      it('should format the delivery time', () => {
-        expect(localeService.formatDate).toHaveBeenLastCalledWith(
-          mockDeliveryTimeShipmentMethod[0].shipmentMethods[0].deliveryTime
-        );
+      it('should have an delivery time', () => {
+        expect(element).toContainElement('oryx-date');
       });
     });
 

--- a/libs/domain/checkout/shipment/src/shipment.component.ts
+++ b/libs/domain/checkout/shipment/src/shipment.component.ts
@@ -7,7 +7,6 @@ import {
 } from '@spryker-oryx/checkout';
 import { resolve } from '@spryker-oryx/di';
 import { ComponentMixin } from '@spryker-oryx/experience';
-import { LocaleService } from '@spryker-oryx/i18n';
 import { PricingService } from '@spryker-oryx/site';
 import {
   asyncValue,
@@ -34,7 +33,6 @@ export class CheckoutShipmentComponent extends ComponentMixin() {
 
   protected shipmentService = resolve(CheckoutShipmentService);
   protected priceService = resolve(PricingService);
-  protected localeService = resolve(LocaleService);
   protected orchestrationService = resolve(CheckoutOrchestrationService);
 
   protected carriers$ = this.shipmentService.getCarriers();
@@ -93,16 +91,11 @@ export class CheckoutShipmentComponent extends ComponentMixin() {
             ${asyncValue(this.priceService.format(method.price))}
           </span>
         </div>
-        ${when(
-          method.deliveryTime,
-          () =>
-            html`${asyncValue(
-              this.localeService.formatDate(method.deliveryTime!),
-              (date) => html`<small slot="subtext">
-                ${i18n('checkout.delivered-at-<date>', { date })}
-              </small>`
-            )}`
-        )}
+        <oryx-date
+          slot="subtext"
+          .stamp=${method.deliveryTime}
+          .i18nToken=${'checkout.delivered-at-<date>'}
+        ></oryx-date>
       </oryx-radio>
     </oryx-tile>`;
   }

--- a/libs/domain/checkout/shipment/src/shipment.styles.ts
+++ b/libs/domain/checkout/shipment/src/shipment.styles.ts
@@ -30,7 +30,7 @@ export const styles = css`
     margin-inline-start: auto;
   }
 
-  small {
+  oryx-date {
     font-weight: 600;
     color: var(--oryx-color-neutral-200);
   }

--- a/libs/domain/checkout/shipment/src/shipment.styles.ts
+++ b/libs/domain/checkout/shipment/src/shipment.styles.ts
@@ -30,11 +30,6 @@ export const styles = css`
     margin-inline-start: auto;
   }
 
-  oryx-date {
-    font-weight: 600;
-    color: var(--oryx-color-neutral-200);
-  }
-
   p {
     margin: 0;
   }

--- a/libs/domain/site/date/date.component.spec.ts
+++ b/libs/domain/site/date/date.component.spec.ts
@@ -1,0 +1,97 @@
+import { fixture } from '@open-wc/testing-helpers';
+import { useComponent } from '@spryker-oryx/core/utilities';
+import { createInjector, destroyInjector } from '@spryker-oryx/di';
+import { LocaleService } from '@spryker-oryx/i18n';
+import { dateComponent, siteProviders } from '@spryker-oryx/site';
+import { html } from 'lit';
+import { of } from 'rxjs';
+import { DateComponent } from './date.component';
+
+class MockLocaleService implements Partial<LocaleService> {
+  get = vi.fn().mockReturnValue(of('en'));
+  formatDate = vi.fn();
+}
+
+describe('DateComponent', () => {
+  let element: DateComponent;
+  let localeService: MockLocaleService;
+
+  beforeAll(async () => {
+    await useComponent([dateComponent]);
+  });
+
+  beforeEach(async () => {
+    const injector = createInjector({
+      providers: [
+        ...siteProviders,
+        {
+          provide: LocaleService,
+          useClass: MockLocaleService,
+        },
+      ],
+    });
+
+    localeService = injector.inject(
+      LocaleService
+    ) as unknown as MockLocaleService;
+  });
+
+  afterEach(() => {
+    destroyInjector();
+    vi.clearAllMocks();
+  });
+
+  describe('when the component is initialised', () => {
+    beforeEach(async () => {
+      element = await fixture(html`<oryx-date></oryx-date>`);
+    });
+
+    it('should be an instance of DateComponent', () => {
+      expect(element).toBeInstanceOf(DateComponent);
+    });
+  });
+
+  describe('when the current locale is "en"', () => {
+    beforeEach(async () => {
+      localeService.get.mockReturnValue(of('en'));
+    });
+
+    describe('and the stamp is 2023-04-26', () => {
+      beforeEach(async () => {
+        localeService.formatDate.mockReturnValue('formatted-date');
+        element = await fixture(
+          html`<oryx-date .stamp=${new Date('2023-04-26')}></oryx-date>`
+        );
+      });
+
+      it('should call the locale service to format the date', () => {
+        expect(localeService.formatDate).toHaveBeenCalledWith(
+          new Date('2023-04-26')
+        );
+      });
+
+      it('should render the formatted date', () => {
+        expect(element.shadowRoot?.textContent?.trim()).toBe('formatted-date');
+      });
+    });
+  });
+
+  describe('when an i18n token is provided', () => {
+    beforeEach(async () => {
+      localeService.get.mockReturnValue(of('en'));
+      localeService.formatDate.mockReturnValue('formatted-date');
+      element = await fixture(
+        html`<oryx-date
+          .stamp=${new Date('2023-04-26')}
+          i18nToken="my.custom-<date>-date"
+        ></oryx-date>`
+      );
+    });
+
+    it('should render the token', () => {
+      expect(element.shadowRoot?.textContent?.trim()).toBe(
+        'Custom formatted-date date'
+      );
+    });
+  });
+});

--- a/libs/domain/site/date/date.component.spec.ts
+++ b/libs/domain/site/date/date.component.spec.ts
@@ -80,18 +80,38 @@ describe('DateComponent', () => {
     beforeEach(async () => {
       localeService.get.mockReturnValue(of('en'));
       localeService.formatDate.mockReturnValue('formatted-date');
-      element = await fixture(
-        html`<oryx-date
-          .stamp=${new Date('2023-04-26')}
-          i18nToken="my.custom-<date>-date"
-        ></oryx-date>`
-      );
     });
 
-    it('should render the token', () => {
-      expect(element.shadowRoot?.textContent?.trim()).toBe(
-        'Custom formatted-date date'
-      );
+    describe('and there is a date available', () => {
+      beforeEach(async () => {
+        element = await fixture(
+          html`<oryx-date
+            .stamp=${new Date('2023-04-26')}
+            i18nToken="my.custom-<date>-date"
+          ></oryx-date>`
+        );
+      });
+
+      it('should render the token', () => {
+        expect(element.shadowRoot?.textContent?.trim()).toBe(
+          'Custom formatted-date date'
+        );
+      });
+    });
+
+    describe('and there is no date available', () => {
+      beforeEach(async () => {
+        element = await fixture(
+          html`<oryx-date
+            .stamp=${null}
+            i18nToken="my.custom-<date>-date"
+          ></oryx-date>`
+        );
+      });
+
+      it('should not render the token', () => {
+        expect(element.shadowRoot?.textContent?.trim()).toBe('');
+      });
     });
   });
 });

--- a/libs/domain/site/date/date.component.ts
+++ b/libs/domain/site/date/date.component.ts
@@ -1,0 +1,35 @@
+import { resolve } from '@spryker-oryx/di';
+import { LocaleService } from '@spryker-oryx/i18n';
+import {
+  computed,
+  hydratable,
+  i18n,
+  signalAware,
+  signalProperty,
+} from '@spryker-oryx/utilities';
+import { html, LitElement, TemplateResult } from 'lit';
+import { DateComponentAttributes } from './date.model';
+
+@hydratable()
+@signalAware()
+export class DateComponent
+  extends LitElement
+  implements DateComponentAttributes
+{
+  protected localeService = resolve(LocaleService);
+
+  @signalProperty() stamp?: string | number | Date;
+  @signalProperty() i18nToken?: string;
+
+  protected date = computed(() =>
+    this.stamp ? this.localeService.formatDate(this.stamp) : undefined
+  );
+
+  protected override render(): TemplateResult | void {
+    if (this.i18nToken) {
+      return html`${i18n(this.i18nToken, { date: this.date() })}`;
+    } else {
+      return html`${this.date()}`;
+    }
+  }
+}

--- a/libs/domain/site/date/date.component.ts
+++ b/libs/domain/site/date/date.component.ts
@@ -26,6 +26,7 @@ export class DateComponent
   );
 
   protected override render(): TemplateResult | void {
+    if (!this.date()) return;
     if (this.i18nToken) {
       return html`${i18n(this.i18nToken, { date: this.date() })}`;
     } else {

--- a/libs/domain/site/date/date.def.ts
+++ b/libs/domain/site/date/date.def.ts
@@ -1,0 +1,6 @@
+import { componentDef } from '@spryker-oryx/core';
+
+export const dateComponent = componentDef({
+  name: 'oryx-date',
+  impl: () => import('./date.component').then((m) => m.DateComponent),
+});

--- a/libs/domain/site/date/date.model.ts
+++ b/libs/domain/site/date/date.model.ts
@@ -1,0 +1,17 @@
+export interface DateComponentAttributes {
+  /**
+   * The value property represents the date in milliseconds.
+   */
+  stamp?: number | string | Date;
+
+  /**
+   * The i18n token can be used to generate a date inside a text. The i18n token
+   * comes with a default token context parameter ("date"), which will generate the following
+   * i18n syntax:
+   *
+   * ```
+   * i18n('my.token-<date>', {date: '26-04-2023'})
+   * ```
+   */
+  i18nToken?: string;
+}

--- a/libs/domain/site/date/index.ts
+++ b/libs/domain/site/date/index.ts
@@ -1,0 +1,2 @@
+export * from './date.component';
+export * from './date.model';

--- a/libs/domain/site/date/stories/demo.stories.ts
+++ b/libs/domain/site/date/stories/demo.stories.ts
@@ -1,0 +1,25 @@
+import { Meta, Story } from '@storybook/web-components';
+import { html, TemplateResult } from 'lit';
+import { storybookPrefix } from '../../.constants';
+import { DateComponentAttributes } from '../date.model';
+
+export default {
+  title: `${storybookPrefix}/date`,
+  args: {
+    stamp: new Date('2023-04-26'),
+  },
+  argTypes: {
+    i18nToken: { control: { type: 'text' } },
+  },
+} as Meta;
+
+const Template: Story<DateComponentAttributes> = (
+  props: DateComponentAttributes
+): TemplateResult => {
+  return html`<oryx-date
+    .stamp=${props.stamp}
+    .i18nToken=${props.i18nToken}
+  ></oryx-date>`;
+};
+
+export const Demo = Template.bind({});

--- a/libs/domain/site/price/price.component.spec.ts
+++ b/libs/domain/site/price/price.component.spec.ts
@@ -19,9 +19,9 @@ class MockCurrencyService implements Partial<CurrencyService> {
   get = vi.fn().mockReturnValue(of('EUR'));
 }
 
-class mockPricingService {
-  format = vi.fn().mockReturnValue(of());
-}
+// class mockPricingService {
+//   format = vi.fn().mockReturnValue(of());
+// }
 
 describe('PriceComponent', () => {
   let element: PriceComponent;

--- a/libs/domain/site/price/price.component.spec.ts
+++ b/libs/domain/site/price/price.component.spec.ts
@@ -19,10 +19,6 @@ class MockCurrencyService implements Partial<CurrencyService> {
   get = vi.fn().mockReturnValue(of('EUR'));
 }
 
-// class mockPricingService {
-//   format = vi.fn().mockReturnValue(of());
-// }
-
 describe('PriceComponent', () => {
   let element: PriceComponent;
   let localeService: MockLocaleService;

--- a/libs/domain/site/src/components.ts
+++ b/libs/domain/site/src/components.ts
@@ -1,4 +1,5 @@
 export * from '../currency-selector/src/currency-selector.def';
+export * from '../date/date.def';
 export * from '../locale-selector/src/locale-selector.def';
 export * from '../navigation-button/src/navigation-button.def';
 export * from '../navigation-item/src/navigation-item.def';

--- a/libs/template/themes/design-tokens/src/backoffice/typography.tokens.ts
+++ b/libs/template/themes/design-tokens/src/backoffice/typography.tokens.ts
@@ -18,7 +18,8 @@ export const typographySmallTokens: ThemeToken = {
     h4: { size: '1em', line: '1.5714285714em', weight: '600' },
     h5: { size: '1em', line: '1.5714285714em', weight: '700' },
     h6: { size: '0.8571428571em', line: '1.3333333333em', weight: '600' },
-    subtitle: { size: '1em', line: '1.5714285714em', weight: '600' },
+    subtitle: { size: '1rem', line: '1.5714285714', weight: '500' },
+    caption: { size: '0.8571428571', line: '1.33', weight: '600' },
   },
 };
 
@@ -30,6 +31,7 @@ export const typographyMediumAndLargerTokens: ThemeToken = {
     h4: { size: '1.2857142857em', line: '1.4444444444em', weight: '600' },
     h5: { size: '1.1428571429em', line: '1.375em', weight: '600' },
     h6: { size: '1.1428571429em', line: '1.375em', weight: '500' },
-    subtitle: { size: '1em', line: '1.5714285714em', weight: '500' },
+    subtitle: { size: '1rem', line: '1.5714285714', weight: '500' },
+    caption: { size: '0.8571428571', line: '1.33', weight: '600' },
   },
 };

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -143,6 +143,7 @@
       "@spryker-oryx/site/currency-selector": [
         "libs/domain/site/currency-selector/index.ts"
       ],
+      "@spryker-oryx/site/date": ["libs/domain/site/date/index.ts"],
       "@spryker-oryx/site/locale-selector": [
         "libs/domain/site/locale-selector/index.ts"
       ],


### PR DESCRIPTION
The date component takes care of formatting the date according to the (current) locale. 
The component can optionally take a i18nToken, so that the date can be wrapped inside a text.

closes [HRZ-2818](https://spryker.atlassian.net/browse/HRZ-2818)

[HRZ-2818]: https://spryker.atlassian.net/browse/HRZ-2818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ