### PR TITLE
fix: carousel layouts in bleed mode bleed out on the end

### DIFF
--- a/libs/platform/experience/src/services/layout/styles/grid-system.styles.ts
+++ b/libs/platform/experience/src/services/layout/styles/grid-system.styles.ts
@@ -31,6 +31,12 @@ export const gridSystem = css`
     justify-items: var(--justify);
   }
 
+  *,
+  ::slotted(*) {
+    justify-self: var(--justify);
+    align-self: var(--align, start);
+  }
+
   *:not(style),
   ::slotted(*:not(style)) {
     --_np: var(--inline-padding);

--- a/libs/platform/experience/src/services/layout/styles/grid-system.styles.ts
+++ b/libs/platform/experience/src/services/layout/styles/grid-system.styles.ts
@@ -34,7 +34,7 @@ export const gridSystem = css`
   *,
   ::slotted(*) {
     justify-self: var(--justify);
-    align-self: var(--align, start);
+    align-self: var(--align);
   }
 
   *:not(style),

--- a/libs/template/presets/src/storefront/experience/pages/home-page.ts
+++ b/libs/template/presets/src/storefront/experience/pages/home-page.ts
@@ -30,7 +30,12 @@ export const homePage: StaticComponent = {
       type: 'oryx-product-list',
       options: {
         data: {
-          rules: [{ layout: 'carousel', padding: '30px 0 0' }],
+          rules: [
+            {
+              layout: 'carousel',
+              padding: '30px 0 0',
+            },
+          ],
           category: '10',
           sort: 'rating',
         },
@@ -44,15 +49,18 @@ export const homePage: StaticComponent = {
           rules: [
             {
               layout: 'grid',
-              bleed: true,
-              padding: '60px',
+              padding: '60px 0',
               gap: '30px 0px',
-              columnCount: 5,
-              justify: 'center',
+              columnCount: 6,
               fill: 'var(--oryx-color-neutral-200)',
             },
             { query: { breakpoint: 'md' }, columnCount: 4 },
-            { query: { childs: true }, height: '50px', padding: '0px 40px' },
+            {
+              query: { childs: true },
+              height: '50px',
+              padding: '0px 40px',
+              justify: 'center',
+            },
             { query: { childs: true, hover: true }, fill: 'initial' },
           ],
         },


### PR DESCRIPTION
When a carousel is used inside a bleeded layout, the carousel should start at the container edge, however the end of the carousel bleed out the container. Once you scroll, the items will scroll into the bleed at the start.