### PR TITLE
fix: don't navigate when clicking picking in progress modal overlay on customer note page

### DIFF
--- a/apps/fulfillment-e2e/src/integration/start-picking-picklist-with-customer-note.cy.ts
+++ b/apps/fulfillment-e2e/src/integration/start-picking-picklist-with-customer-note.cy.ts
@@ -94,6 +94,16 @@ describe('Start picking a picklist with customer note', () => {
         .should('contain.text', 'Already in progress');
     });
 
+    describe('and modal is dismissed', () => {
+      beforeEach(() => {
+        customerNoteFragment.pickingInProgressModal.getOverlay().click();
+      });
+
+      it('should stay on the same page', () => {
+        cy.location('pathname').should('to.match', /^\/customer-note-info/);
+      });
+    });
+
     describe('and picking in progress modal is closed', () => {
       beforeEach(() => {
         customerNoteFragment.pickingInProgressModal.getCloseButton().click();

--- a/apps/fulfillment-e2e/src/support/page_fragments/picking-in-progress-modal.fragment.ts
+++ b/apps/fulfillment-e2e/src/support/page_fragments/picking-in-progress-modal.fragment.ts
@@ -2,4 +2,5 @@ export class PickingInProgressModalFragment {
   getWrapper = () => cy.get('oryx-picking-in-progress-modal');
   getModal = () => this.getWrapper().find('oryx-modal');
   getCloseButton = () => this.getWrapper().find('button').eq(0);
+  getOverlay = () => this.getModal().find('dialog');
 }

--- a/libs/domain/picking/src/components/customer-note/customer-note.component.spec.ts
+++ b/libs/domain/picking/src/components/customer-note/customer-note.component.spec.ts
@@ -27,6 +27,12 @@ describe('CustomerNoteComponent', () => {
   let service: MockPickingListService;
   let routerService: MockRouterService;
 
+  const getPickingInProgressModal = () => {
+    return element.renderRoot.querySelector(
+      'oryx-picking-in-progress-modal'
+    ) as PickingInProgressModalComponent;
+  };
+
   beforeAll(async () => {
     await useComponent([
       customerNoteComponent,
@@ -119,20 +125,30 @@ describe('CustomerNoteComponent', () => {
       });
 
       it('should open picking in progress modal', () => {
-        expect(
-          (
-            element.renderRoot.querySelector(
-              'oryx-picking-in-progress-modal'
-            ) as PickingInProgressModalComponent
-          )?.open
-        ).toBe(true);
+        expect(getPickingInProgressModal().open).toBe(true);
       });
 
-      describe('and picking in progress modal is closed', () => {
+      describe('and picking in progress modal is dismissed', () => {
         beforeEach(() => {
-          element.renderRoot
-            .querySelector('oryx-picking-in-progress-modal')
-            ?.shadowRoot?.querySelector('button')
+          getPickingInProgressModal()
+            .shadowRoot?.querySelector('oryx-modal')
+            ?.shadowRoot?.querySelector('dialog')
+            ?.click();
+        });
+
+        it('should not navigate to picking lists', () => {
+          expect(routerService.navigate).not.toHaveBeenCalledWith('/');
+        });
+
+        it('should close modal', () => {
+          expect(getPickingInProgressModal().open).toBe(false);
+        });
+      });
+
+      describe('and back to pick lists button is clicked', () => {
+        beforeEach(() => {
+          getPickingInProgressModal()
+            .shadowRoot?.querySelector('button')
             ?.click();
         });
 

--- a/libs/domain/picking/src/components/customer-note/customer-note.component.ts
+++ b/libs/domain/picking/src/components/customer-note/customer-note.component.ts
@@ -59,7 +59,7 @@ export class CustomerNoteComponent extends PickingListMixin(LitElement) {
         </button>
       </oryx-button>
       <oryx-picking-in-progress-modal
-        @oryx.close=${this.closePickingInProgressModal}
+        @oryx.close-button=${this.closePickingInProgressModal}
         ${ref(this.pickingInProgressModal)}
       ></oryx-picking-in-progress-modal>
     `;

--- a/libs/domain/picking/src/components/customer-note/customer-note.component.ts
+++ b/libs/domain/picking/src/components/customer-note/customer-note.component.ts
@@ -59,7 +59,7 @@ export class CustomerNoteComponent extends PickingListMixin(LitElement) {
         </button>
       </oryx-button>
       <oryx-picking-in-progress-modal
-        @oryx.close-button=${this.closePickingInProgressModal}
+        @oryx.back=${this.closePickingInProgressModal}
         ${ref(this.pickingInProgressModal)}
       ></oryx-picking-in-progress-modal>
     `;

--- a/libs/domain/picking/src/components/picking-in-progress/picking-in-progress.component.ts
+++ b/libs/domain/picking/src/components/picking-in-progress/picking-in-progress.component.ts
@@ -1,4 +1,5 @@
 import { ButtonType } from '@spryker-oryx/ui/button';
+import { BACK_EVENT } from '@spryker-oryx/ui/modal';
 import { i18n, Size } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
@@ -31,7 +32,7 @@ export class PickingInProgressModalComponent extends LitElement {
 
   protected closeButton(): void {
     this.dispatchEvent(
-      new CustomEvent('oryx.close-button', { bubbles: true, composed: true })
+      new CustomEvent(BACK_EVENT, { bubbles: true, composed: true })
     );
     this.close();
   }

--- a/libs/domain/picking/src/components/picking-in-progress/picking-in-progress.component.ts
+++ b/libs/domain/picking/src/components/picking-in-progress/picking-in-progress.component.ts
@@ -18,7 +18,7 @@ export class PickingInProgressModalComponent extends LitElement {
       </oryx-heading>
       ${i18n('picking.list.already-in-progress')}
       <oryx-button slot="footer" type=${ButtonType.Primary} size=${Size.Md}>
-        <button @click=${this.close}>
+        <button @click=${this.closeButton}>
           ${i18n('picking.list.back-to-pick-lists')}
         </button>
       </oryx-button>
@@ -27,5 +27,12 @@ export class PickingInProgressModalComponent extends LitElement {
 
   protected close(): void {
     this.open = false;
+  }
+
+  protected closeButton(): void {
+    this.dispatchEvent(
+      new CustomEvent('oryx.close-button', { bubbles: true, composed: true })
+    );
+    this.close();
   }
 }


### PR DESCRIPTION
Closes [HRZ-2970](https://spryker.atlassian.net/browse/HRZ-2970)

[HRZ-2970]: https://spryker.atlassian.net/browse/HRZ-2970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ