### PR TITLE
fix: SCOS backend URL cannot be set by provider only

### DIFF
--- a/libs/template/application/src/auth/sapi/feature.ts
+++ b/libs/template/application/src/auth/sapi/feature.ts
@@ -18,7 +18,6 @@ import {
   AppFeature,
   ComponentsInfo,
   HttpInterceptor,
-  injectEnv,
 } from '@spryker-oryx/core';
 import { inject, Provider } from '@spryker-oryx/di';
 import { SapiIdentityService } from './sapi-identity.service';
@@ -38,7 +37,7 @@ export class SapiAuthFeature extends OauthFeature implements AppFeature {
           id: 'spryker',
           clientId: '',
           grantType: 'password',
-          tokenUrl: new URL('/token', injectEnv('SCOS_BASE_URL')).toString(),
+          tokenUrl: new URL('/token', inject('SCOS_BASE_URL')).toString(),
         },
       ],
     };
@@ -69,7 +68,7 @@ export class SapiAuthFeature extends OauthFeature implements AppFeature {
         provide: AuthTokenInterceptorConfig,
         useFactory: () =>
           ({
-            baseUrl: injectEnv('SCOS_BASE_URL'),
+            baseUrl: inject('SCOS_BASE_URL'),
             ...configFactory().tokenInterceptor,
           } as AuthTokenInterceptorConfig),
       },
@@ -77,7 +76,7 @@ export class SapiAuthFeature extends OauthFeature implements AppFeature {
         provide: AnonTokenInterceptorConfig,
         useFactory: () =>
           ({
-            baseUrl: injectEnv('SCOS_BASE_URL'),
+            baseUrl: inject('SCOS_BASE_URL'),
             headerName: 'X-Anonymous-Customer-Unique-Id',
             ...configFactory().anonTokenInterceptor,
           } as AnonTokenInterceptorConfig),


### PR DESCRIPTION
This one allows to setup SOCS backend URL without having to provide it via ENV variables (using ENV variables is still possible).

Closes [HRZ-2973](https://spryker.atlassian.net/browse/HRZ-2973)

[HRZ-2973]: https://spryker.atlassian.net/browse/HRZ-2973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ