### PR TITLE
feat: elementEffect decorator

### DIFF
--- a/libs/base/utilities/src/signals/decorators/effect.controller.spec.ts
+++ b/libs/base/utilities/src/signals/decorators/effect.controller.spec.ts
@@ -1,0 +1,70 @@
+import { ReactiveControllerHost } from 'lit';
+import { Effect } from '../core';
+import { EffectController } from './effect.controller';
+
+class MockHost implements Partial<ReactiveControllerHost> {
+  addController() {}
+  requestUpdate() {}
+  updateComplete = Promise.resolve(true);
+}
+
+class MockEffect implements Partial<Effect> {
+  start = vi.fn();
+  stop = vi.fn();
+}
+
+describe('EffectController', () => {
+  let controller: EffectController;
+  let host: MockHost;
+
+  beforeEach(() => {
+    host = new MockHost();
+    controller = new EffectController(
+      host as unknown as ReactiveControllerHost
+    );
+  });
+
+  it('should correctly add an effect', () => {
+    const effect = new MockEffect() as unknown as Effect;
+    controller.add(effect, 'testEffect');
+
+    expect(controller.get('testEffect')).toBe(effect);
+  });
+
+  it('should correctly start effects on hostConnected', () => {
+    const effect = new MockEffect() as unknown as Effect;
+    controller.add(effect, 'testEffect');
+    controller.hostConnected();
+
+    expect(effect.start).toHaveBeenCalled();
+  });
+
+  it('should correctly stop effects on hostDisconnected', () => {
+    const effect = new MockEffect() as unknown as Effect;
+    controller.add(effect, 'testEffect');
+    controller.hostDisconnected();
+
+    expect(effect.stop).toHaveBeenCalled();
+  });
+
+  it('should replace and stop a current effect when a new one is added with the same key', () => {
+    const oldEffect = new MockEffect() as unknown as Effect;
+    const newEffect = new MockEffect() as unknown as Effect;
+
+    controller.add(oldEffect, 'testEffect');
+    controller.add(newEffect, 'testEffect');
+
+    expect(oldEffect.stop).toHaveBeenCalled();
+    expect(controller.get('testEffect')).toBe(newEffect);
+  });
+
+  it('should create and add an effect if a function is passed', () => {
+    const func = () => {};
+
+    controller.add(func, 'testEffect');
+    const effect = controller.get('testEffect');
+
+    expect(effect).toBeDefined();
+    expect(effect).toBeInstanceOf(Effect);
+  });
+});

--- a/libs/base/utilities/src/signals/decorators/effect.controller.spec.ts
+++ b/libs/base/utilities/src/signals/decorators/effect.controller.spec.ts
@@ -4,6 +4,7 @@ import { EffectController } from './effect.controller';
 
 class MockHost implements Partial<ReactiveControllerHost> {
   addController() {}
+
   requestUpdate() {}
   updateComplete = Promise.resolve(true);
 }

--- a/libs/base/utilities/src/signals/decorators/effect.controller.spec.ts
+++ b/libs/base/utilities/src/signals/decorators/effect.controller.spec.ts
@@ -3,8 +3,9 @@ import { Effect } from '../core';
 import { EffectController } from './effect.controller';
 
 class MockHost implements Partial<ReactiveControllerHost> {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   addController() {}
-
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   requestUpdate() {}
   updateComplete = Promise.resolve(true);
 }
@@ -60,6 +61,7 @@ describe('EffectController', () => {
   });
 
   it('should create and add an effect if a function is passed', () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     const func = () => {};
 
     controller.add(func, 'testEffect');

--- a/libs/base/utilities/src/signals/decorators/effect.controller.ts
+++ b/libs/base/utilities/src/signals/decorators/effect.controller.ts
@@ -34,7 +34,7 @@ export class EffectController implements ReactiveController {
     }
 
     if (typeof effect === 'function') {
-      effect = new Effect(effect);
+      effect = new Effect(effect, { defer: true });
     }
 
     // add some logic to check if it is an effect, allow for specifying full effect

--- a/libs/base/utilities/src/signals/decorators/effect.controller.ts
+++ b/libs/base/utilities/src/signals/decorators/effect.controller.ts
@@ -1,7 +1,6 @@
-import {resolve} from '@spryker-oryx/di';
-import {ReactiveController, ReactiveControllerHost} from 'lit';
-import {Effect} from "../core";
-
+import { resolve } from '@spryker-oryx/di';
+import { ReactiveController, ReactiveControllerHost } from 'lit';
+import { Effect } from '../core';
 
 export class EffectController implements ReactiveController {
   protected effects = new Map<string, Effect>();
@@ -12,7 +11,9 @@ export class EffectController implements ReactiveController {
   constructor(public host: ReactiveControllerHost) {
     (this.host = host).addController(this);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (this.context as any)?.rendered$?.subscribe?.(() => this.hostDisconnected());
+    (this.context as any)?.rendered$?.subscribe?.(() =>
+      this.hostDisconnected()
+    );
   }
 
   hostConnected(): void {
@@ -36,7 +37,7 @@ export class EffectController implements ReactiveController {
       effect = new Effect(effect);
     }
 
-    // add some logic to check if it is an effect, allow for specyfing full effect
+    // add some logic to check if it is an effect, allow for specifying full effect
     this.effects.set(key, effect);
   }
 

--- a/libs/base/utilities/src/signals/decorators/effect.controller.ts
+++ b/libs/base/utilities/src/signals/decorators/effect.controller.ts
@@ -1,0 +1,46 @@
+import {resolve} from '@spryker-oryx/di';
+import {ReactiveController, ReactiveControllerHost} from 'lit';
+import {Effect} from "../core";
+
+
+export class EffectController implements ReactiveController {
+  protected effects = new Map<string, Effect>();
+
+  // TODO: temporary solution should be solved with proper hook provided from lit
+  protected context = resolve('FES.ContextService', null);
+
+  constructor(public host: ReactiveControllerHost) {
+    (this.host = host).addController(this);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (this.context as any)?.rendered$?.subscribe?.(() => this.hostDisconnected());
+  }
+
+  hostConnected(): void {
+    for (const effect of this.effects.values()) {
+      effect.start();
+    }
+  }
+
+  hostDisconnected(): void {
+    for (const effect of this.effects.values()) {
+      effect.stop();
+    }
+  }
+
+  add(effect: Effect | (() => void), key: string): void {
+    if (this.effects.has(key)) {
+      this.effects.get(key)?.stop();
+    }
+
+    if (typeof effect === 'function') {
+      effect = new Effect(effect);
+    }
+
+    // add some logic to check if it is an effect, allow for specyfing full effect
+    this.effects.set(key, effect);
+  }
+
+  get(key: string): Effect | undefined {
+    return this.effects.get(key);
+  }
+}

--- a/libs/base/utilities/src/signals/decorators/element-effect.spec.ts
+++ b/libs/base/utilities/src/signals/decorators/element-effect.spec.ts
@@ -1,0 +1,44 @@
+import { fixture, nextFrame } from '@open-wc/testing-helpers';
+import { html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { elementEffect } from './element-effect';
+
+@customElement('mock-effect-component')
+class MockEffectComponent extends LitElement {
+  mockEffectCallback = vi.fn();
+  mockAnotherEffectCallback = vi.fn();
+
+  @elementEffect()
+  mockEffect = () => this.mockEffectCallback();
+
+  @elementEffect()
+  mockAnotherEffect = () => this.mockAnotherEffectCallback();
+
+  @property()
+  test = 'new';
+}
+
+describe('elementEffect decorator', () => {
+  let element: MockEffectComponent;
+
+  beforeEach(async () => {
+    element = await fixture(
+      html`<mock-effect-component></mock-effect-component>`
+    );
+  });
+
+  it('should invoke effects on connectedCallback hook', async () => {
+    await nextFrame();
+
+    expect(element.mockEffectCallback).toHaveBeenCalled();
+    expect(element.mockAnotherEffectCallback).toHaveBeenCalled();
+  });
+
+  it('should invoke effects on property update', async () => {
+    element.test = 'updated';
+    await element.updateComplete;
+
+    expect(element.mockEffectCallback).toHaveBeenCalled();
+    expect(element.mockAnotherEffectCallback).toHaveBeenCalled();
+  });
+});

--- a/libs/base/utilities/src/signals/decorators/element-effect.ts
+++ b/libs/base/utilities/src/signals/decorators/element-effect.ts
@@ -57,8 +57,12 @@ const standardElementEffect = (
   };
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function elementEffect(): any {
+/**
+ * Decorator to easily tie effects to component lifecycles:
+ *   - effect will start when component is connected to DOM
+ *   - effect will stop when component is disconnected from DOM
+ */
+export function elementEffect() {
   return (
     context: DecoratorContext | TargetDecorator,
     name?: PropertyKey

--- a/libs/base/utilities/src/signals/decorators/element-effect.ts
+++ b/libs/base/utilities/src/signals/decorators/element-effect.ts
@@ -1,0 +1,74 @@
+import { LitElement, ReactiveControllerHost, ReactiveElement } from 'lit';
+import { isLegacyDecorator } from '../../guards';
+import { DecoratorContext, TargetDecorator } from '../../model';
+import { Effect } from '../core';
+import { EffectController } from './effect.controller';
+
+const EFFECT_CONTROLLER = Symbol('effectController');
+
+function controllerCreation(target: TargetDecorator): void {
+  if (!target[EFFECT_CONTROLLER]) {
+    const descriptor = {
+      value: new EffectController(target as ReactiveControllerHost),
+      enumerable: false,
+      configurable: true,
+    };
+
+    Object.defineProperty(target, EFFECT_CONTROLLER, descriptor);
+  }
+}
+
+const legacyElementEffect = (context: TargetDecorator, name: string): void => {
+  const constructor = context.constructor as typeof LitElement;
+  const willUpdate = context['willUpdate'];
+
+  Object.defineProperty(context, name, {
+    get: function (this: TargetDecorator) {
+      return (this[EFFECT_CONTROLLER] as EffectController).get(name);
+    },
+    set: function (this: TargetDecorator, effect: Effect | (() => void)) {
+      (this[EFFECT_CONTROLLER] as EffectController).add(effect, name);
+    },
+    configurable: true,
+  });
+
+  context['willUpdate'] = function (props): void {
+    (this[EFFECT_CONTROLLER] as EffectController).hostConnected();
+    willUpdate.call(this, props);
+  };
+
+  constructor.addInitializer((instance: ReactiveElement) => {
+    controllerCreation(instance as TargetDecorator);
+  });
+};
+
+const standardElementEffect = (
+  context: DecoratorContext,
+  name: string
+): DecoratorContext => {
+  return {
+    ...context,
+    initializer(this: TargetDecorator): void {
+      const effect = context.initializer?.call(this);
+      controllerCreation(this);
+      (this[EFFECT_CONTROLLER] as EffectController).add(effect, name);
+      return effect;
+    },
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function elementEffect(): any {
+  return (
+    context: DecoratorContext | TargetDecorator,
+    name?: PropertyKey
+  ): DecoratorContext | void => {
+    const propName = (
+      isLegacyDecorator(context, name) ? name : context.key
+    ) as string;
+
+    return isLegacyDecorator(context, name)
+      ? legacyElementEffect(context, propName)
+      : (standardElementEffect(context, propName) as unknown as void);
+  };
+}

--- a/libs/base/utilities/src/signals/decorators/element-effect.ts
+++ b/libs/base/utilities/src/signals/decorators/element-effect.ts
@@ -63,16 +63,21 @@ const standardElementEffect = (
  *   - effect will stop when component is disconnected from DOM
  */
 export function elementEffect() {
-  return (
-    context: DecoratorContext | TargetDecorator,
+  return <T extends LitElement>(
+    context: T | DecoratorContext,
     name?: PropertyKey
-  ): DecoratorContext | void => {
+  ): any => {
     const propName = (
-      isLegacyDecorator(context, name) ? name : context.key
+      isLegacyDecorator(context as DecoratorContext, name)
+        ? name
+        : (context as DecoratorContext).key
     ) as string;
 
-    return isLegacyDecorator(context, name)
-      ? legacyElementEffect(context, propName)
-      : (standardElementEffect(context, propName) as unknown as void);
+    return isLegacyDecorator(context as DecoratorContext, name)
+      ? legacyElementEffect(context as T, propName)
+      : (standardElementEffect(
+          context as DecoratorContext,
+          propName
+        ) as unknown as void);
   };
 }

--- a/libs/base/utilities/src/signals/decorators/element-effect.ts
+++ b/libs/base/utilities/src/signals/decorators/element-effect.ts
@@ -6,6 +6,10 @@ import { EffectController } from './effect.controller';
 
 const EFFECT_CONTROLLER = Symbol('effectController');
 
+interface ElementWithController extends LitElement {
+  [EFFECT_CONTROLLER]?: EffectController;
+}
+
 function controllerCreation(target: TargetDecorator): void {
   if (!target[EFFECT_CONTROLLER]) {
     const descriptor = {
@@ -18,7 +22,10 @@ function controllerCreation(target: TargetDecorator): void {
   }
 }
 
-const legacyElementEffect = (context: TargetDecorator, name: string): void => {
+const legacyElementEffect = (
+  context: ElementWithController,
+  name: string
+): void => {
   const constructor = context.constructor as typeof LitElement;
   const willUpdate = context['willUpdate'];
 

--- a/libs/base/utilities/src/signals/decorators/index.ts
+++ b/libs/base/utilities/src/signals/decorators/index.ts
@@ -1,4 +1,4 @@
+export * from './effect.controller';
+export * from './element-effect';
 export * from './signal-aware';
 export * from './signal-property';
-export * from './element-effect';
-export * from './effect.controller';

--- a/libs/base/utilities/src/signals/decorators/index.ts
+++ b/libs/base/utilities/src/signals/decorators/index.ts
@@ -1,2 +1,4 @@
 export * from './signal-aware';
 export * from './signal-property';
+export * from './element-effect';
+export * from './effect.controller';

--- a/libs/domain/checkout/customer/customer.component.ts
+++ b/libs/domain/checkout/customer/customer.component.ts
@@ -42,7 +42,7 @@ export class CheckoutCustomerComponent
   protected hasCustomerData = false;
 
   @elementEffect()
-  protected eff = () => {
+  protected eff = (): void => {
     if (!this.$options().enableGuestCheckout && !this.isAuthenticated()) {
       const route = this.loginRoute();
       if (route) this.routerService.navigate(route);
@@ -50,7 +50,7 @@ export class CheckoutCustomerComponent
   };
 
   @elementEffect()
-  protected storeCustomer = () => {
+  protected storeCustomer = (): void => {
     const customer = this.customer();
     if (customer) {
       const { email, salutation, firstName, lastName } =

--- a/libs/domain/checkout/customer/customer.component.ts
+++ b/libs/domain/checkout/customer/customer.component.ts
@@ -5,7 +5,12 @@ import { ContentMixin, defaultOptions } from '@spryker-oryx/experience';
 import { RouterService } from '@spryker-oryx/router';
 import { SemanticLinkService, SemanticLinkType } from '@spryker-oryx/site';
 import { UserService } from '@spryker-oryx/user';
-import { effect, hydratable, i18n, signal } from '@spryker-oryx/utilities';
+import {
+  elementEffect,
+  hydratable,
+  i18n,
+  signal,
+} from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
 import { query, state } from 'lit/decorators.js';
 import { CheckoutGuestComponent } from '../guest';
@@ -34,14 +39,16 @@ export class CheckoutCustomerComponent
   @state()
   protected hasCustomerData = false;
 
-  protected eff = effect(() => {
+  @elementEffect()
+  protected eff = () => {
     if (!this.$options().enableGuestCheckout && !this.isAuthenticated()) {
       const route = this.loginRoute();
       if (route) this.routerService.navigate(route);
     }
-  });
+  };
 
-  protected storeCustomer = effect(() => {
+  @elementEffect()
+  protected storeCustomer = () => {
     const customer = this.customer();
     if (customer) {
       const { email, salutation, firstName, lastName } =
@@ -52,7 +59,7 @@ export class CheckoutCustomerComponent
         value: { email, salutation, firstName, lastName },
       });
     }
-  });
+  };
 
   @query('oryx-checkout-guest')
   protected guest?: CheckoutGuestComponent;

--- a/libs/domain/checkout/orchestrator/orchestrator.component.ts
+++ b/libs/domain/checkout/orchestrator/orchestrator.component.ts
@@ -11,7 +11,7 @@ export class CheckoutOrchestratorComponent extends CheckoutMixin(
   static styles = [checkoutOrchestratorStyles];
 
   @elementEffect()
-  protected eff = () => {
+  protected eff = (): void => {
     if (this.isInvalid()) this.report();
   };
 

--- a/libs/domain/checkout/orchestrator/orchestrator.component.ts
+++ b/libs/domain/checkout/orchestrator/orchestrator.component.ts
@@ -1,6 +1,6 @@
 import { CheckoutMixin, isValid } from '@spryker-oryx/checkout';
 import { ContentMixin } from '@spryker-oryx/experience';
-import { effect, hydratable } from '@spryker-oryx/utilities';
+import { elementEffect, hydratable } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
 import { checkoutOrchestratorStyles } from './orchestrator.styles';
 
@@ -10,9 +10,10 @@ export class CheckoutOrchestratorComponent extends CheckoutMixin(
 ) {
   static styles = [checkoutOrchestratorStyles];
 
-  protected eff = effect(() => {
+  @elementEffect()
+  protected eff = () => {
     if (this.isInvalid()) this.report();
-  });
+  };
 
   protected override render(): TemplateResult | void {
     if (this.isEmpty()) return;

--- a/libs/domain/product/card/src/card.component.ts
+++ b/libs/domain/product/card/src/card.component.ts
@@ -12,6 +12,7 @@ import { IconTypes } from '@spryker-oryx/ui/icon';
 import {
   computed,
   effect,
+  elementEffect,
   hydratable,
   signalAware,
   Size,
@@ -50,6 +51,8 @@ export class ProductCardComponent extends ProductMixin(
   );
 
   protected context = new ContextController(this);
+
+  @elementEffect()
   protected skuController = effect(() => {
     this.context.provide(ProductContext.SKU, this.$options().sku ?? this.sku);
   });

--- a/libs/domain/site/src/components/notification-center/notification-center.component.ts
+++ b/libs/domain/site/src/components/notification-center/notification-center.component.ts
@@ -4,7 +4,7 @@ import {
   NotificationCenterComponent,
   NotificationPosition,
 } from '@spryker-oryx/ui/notification-center';
-import { effect, hydratable, signal } from '@spryker-oryx/utilities';
+import { elementEffect, hydratable, signal } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { map } from 'rxjs';
@@ -28,7 +28,8 @@ export class SiteNotificationCenterComponent extends ContentMixin<SiteNotificati
     this.siteNotificationService.get().pipe(map((n) => ({ ...n })))
   );
 
-  protected notification$ = effect(async () => {
+  @elementEffect()
+  protected notification$ = async () => {
     const notification = this.notification();
 
     if (!notification || Object.keys(notification).length === 0) return;
@@ -40,7 +41,7 @@ export class SiteNotificationCenterComponent extends ContentMixin<SiteNotificati
     }
 
     this.centerRef.value?.open(notification);
-  });
+  };
 
   protected override render(): TemplateResult {
     const { position, enableStacking } = this.$options();

--- a/libs/domain/site/src/components/notification-center/notification-center.component.ts
+++ b/libs/domain/site/src/components/notification-center/notification-center.component.ts
@@ -29,7 +29,7 @@ export class SiteNotificationCenterComponent extends ContentMixin<SiteNotificati
   );
 
   @elementEffect()
-  protected notification$ = async () => {
+  protected notification$ = async (): Promise<void> => {
     const notification = this.notification();
 
     if (!notification || Object.keys(notification).length === 0) return;

--- a/libs/domain/user/address-book/address-book.component.ts
+++ b/libs/domain/user/address-book/address-book.component.ts
@@ -3,7 +3,7 @@ import { IconTypes } from '@spryker-oryx/ui/icon';
 import { Address } from '@spryker-oryx/user';
 import { AddressDefaults } from '@spryker-oryx/user/address-list-item';
 import {
-  effect,
+  elementEffect,
   hydratable,
   i18n,
   signalProperty,
@@ -20,7 +20,8 @@ export class UserAddressBookComponent extends ContentMixin(LitElement) {
   @signalProperty() activeState = AddressBookState.List;
   @state() selected?: string;
 
-  protected dispatchStateChange = effect(() => {
+  @elementEffect()
+  protected dispatchStateChange = () => {
     if (this.activeState) {
       this.dispatchEvent(
         new CustomEvent(CHANGE_STATE_EVENT, {
@@ -30,7 +31,7 @@ export class UserAddressBookComponent extends ContentMixin(LitElement) {
         })
       );
     }
-  });
+  };
 
   protected override render(): TemplateResult {
     if (this.activeState !== AddressBookState.List) {

--- a/libs/domain/user/address-book/address-book.component.ts
+++ b/libs/domain/user/address-book/address-book.component.ts
@@ -21,7 +21,7 @@ export class UserAddressBookComponent extends ContentMixin(LitElement) {
   @state() selected?: string;
 
   @elementEffect()
-  protected dispatchStateChange = () => {
+  protected dispatchStateChange = (): void => {
     if (this.activeState) {
       this.dispatchEvent(
         new CustomEvent(CHANGE_STATE_EVENT, {


### PR DESCRIPTION
Introduces @elementEffect decorator to easily tie effects to component lifecycles. 

Closes [HRZ-2919](https://spryker.atlassian.net/browse/HRZ-2919)

[HRZ-2919]: https://spryker.atlassian.net/browse/HRZ-2919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ