### PR TITLE
feat: billing address

### DIFF
--- a/apps/storefront-e2e/src/integration/checkout.cy.ts
+++ b/apps/storefront-e2e/src/integration/checkout.cy.ts
@@ -10,6 +10,9 @@ let thankYouPage: ThankYouPage;
 const cartPage = new CartPage();
 const checkoutPage = new CheckoutPage();
 
+// TODO: refactor tests to make them more readable
+// TODO: add a test for an order with different shipping and billing addresses set
+
 describe('Checkout suite', () => {
   describe('Create a new order by authorized user without addresses', () => {
     beforeEach(() => {
@@ -42,7 +45,7 @@ describe('Checkout suite', () => {
       cy.location('pathname').should('be.eq', checkoutPage.url);
       cy.wait('@addresses');
 
-      checkoutPage.addressForm.fillAddressForm();
+      checkoutPage.shipping.addAddressForm.fillAddressForm();
       checkoutPage.getPlaceOrderBtn().click();
 
       cy.wait('@checkout')
@@ -97,7 +100,7 @@ describe('Checkout suite', () => {
       cy.location('pathname').should('be.eq', checkoutPage.anonymousUrl);
 
       checkoutPage.checkoutAsGuestForm.fillForm();
-      checkoutPage.addressForm.fillAddressForm();
+      checkoutPage.shipping.addAddressForm.fillAddressForm();
       checkoutPage.getPlaceOrderBtn().click();
 
       cy.wait('@checkout')

--- a/apps/storefront-e2e/src/support/page_fragments/addresses-list.fragment.ts
+++ b/apps/storefront-e2e/src/support/page_fragments/addresses-list.fragment.ts
@@ -1,0 +1,14 @@
+export class AddressesListFragment {
+  private wrapperSelector: string;
+
+  constructor(selector: string) {
+    this.wrapperSelector = selector;
+  }
+
+  getWrapper = () => cy.get(this.wrapperSelector);
+  getChangeAddressesButton = () =>
+    this.getWrapper().find('oryx-checkout-manage-address');
+  getAddressList = () => this.getWrapper().find('oryx-user-address-list');
+  getAddressListItem = () =>
+    this.getAddressList().find('oryx-user-address-list-item');
+}

--- a/apps/storefront-e2e/src/support/page_fragments/checkout/checkout-address-form.fragment.ts
+++ b/apps/storefront-e2e/src/support/page_fragments/checkout/checkout-address-form.fragment.ts
@@ -1,18 +1,27 @@
 import { defaultAddress } from '../../../../src/test-data/default-address';
 
 export class CheckoutAddressFormFragment {
-  getAddressForm = () => cy.get('oryx-user-address-form');
-  getCountrySelect = () => cy.get('oryx-select[label="Country"]');
-  getSalutationSelect = () => cy.get('oryx-select[label="Salutation"]');
+  private wrapperSelector: string;
+
+  constructor(selector: string) {
+    this.wrapperSelector = selector;
+  }
+
+  getWrapper = () => cy.get(this.wrapperSelector);
+  getAddressForm = () => this.getWrapper().find('oryx-user-address-form');
+  getCountrySelect = () =>
+    this.getWrapper().find('oryx-select[label="Country"]');
+  getSalutationSelect = () =>
+    this.getWrapper().find('oryx-select[label="Salutation"]');
   getFirstNameInput = () =>
     this.getAddressForm().find('input[name="firstName"]');
   getLastNameInput = () => this.getAddressForm().find('input[name="lastName"]');
-  getCompanyInput = () => cy.get('input[name="company"]');
-  getAddress1Input = () => cy.get('input[name="address1"]');
-  getAddress2Input = () => cy.get('input[name="address2"]');
-  getZipInput = () => cy.get('input[name="zipCode"]');
-  getCityInput = () => cy.get('input[name="city"]');
-  getPhoneInput = () => cy.get('input[name="phone"]');
+  getCompanyInput = () => this.getWrapper().find('input[name="company"]');
+  getAddress1Input = () => this.getWrapper().find('input[name="address1"]');
+  getAddress2Input = () => this.getWrapper().find('input[name="address2"]');
+  getZipInput = () => this.getWrapper().find('input[name="zipCode"]');
+  getCityInput = () => this.getWrapper().find('input[name="city"]');
+  getPhoneInput = () => this.getWrapper().find('input[name="phone"]');
 
   selectCoutry = (isoCode: string) => {
     this.getCountrySelect().click();

--- a/apps/storefront-e2e/src/support/page_fragments/checkout/checkout-address-modal.fragment.ts
+++ b/apps/storefront-e2e/src/support/page_fragments/checkout/checkout-address-modal.fragment.ts
@@ -1,20 +1,21 @@
+import { AddressesListFragment } from '../addresses-list.fragment';
 import { CheckoutAddressFormFragment } from './checkout-address-form.fragment';
 
 export class CheckoutAddressModalFragment {
   private wrapperSelector: string;
 
+  addressesList: AddressesListFragment;
+
   constructor(selector: string) {
     this.wrapperSelector = selector;
+    this.addressesList = new AddressesListFragment('oryx-modal');
   }
 
-  getWrapper = () => cy.get(this.wrapperSelector);
+  getWrapper = () => cy.get(this.wrapperSelector).find('oryx-modal');
   getAddAddressButton = () =>
     this.getWrapper().find('oryx-user-address-add-button');
-  getAddressList = () => this.getWrapper().find('oryx-user-address-list');
-  getAddressListItem = () =>
-    this.getAddressList().find('oryx-user-address-list-item');
 
-  addAddressForm = new CheckoutAddressFormFragment();
+  addAddressForm = new CheckoutAddressFormFragment('oryx-user-address-edit');
   getSaveAddressBtn = () =>
     this.getWrapper().find('oryx-button').contains('button', 'Save');
   getCloseModalBtn = () =>
@@ -35,7 +36,7 @@ export class CheckoutAddressModalFragment {
 
   editCompanyInAddress = (newCompany: string) => {
     // edit icon-button click
-    this.getAddressListItem().eq(0).find('button').eq(0).click();
+    this.addressesList.getAddressListItem().eq(0).find('button').eq(0).click();
     this.addAddressForm
       .getCompanyInput()
       .clear()
@@ -45,7 +46,7 @@ export class CheckoutAddressModalFragment {
 
   removeAddress = () => {
     // remove icon-button click
-    this.getAddressListItem().eq(0).find('button').eq(1).click();
+    this.addressesList.getAddressListItem().eq(0).find('button').eq(1).click();
     // remove button in remove address modal click
     cy.get('oryx-user-address-remove').find('button').eq(1).click();
   };

--- a/apps/storefront-e2e/src/support/page_fragments/login.fragment.ts
+++ b/apps/storefront-e2e/src/support/page_fragments/login.fragment.ts
@@ -10,8 +10,8 @@ export class LoginFragment {
   getBEValidationError = () => this.getWrapper().find('oryx-notification');
 
   login = (user: TestUserData) => {
-    this.getEmailInput().type(user.email);
-    this.getPasswordInput().type(user.password);
+    this.getEmailInput().type(user.email, { force: true });
+    this.getPasswordInput().type(user.password, { force: true });
     this.getRememberMeCheckbox().click();
     this.getLoginButton().click();
   };

--- a/apps/storefront-e2e/src/support/page_objects/checkout.page.ts
+++ b/apps/storefront-e2e/src/support/page_objects/checkout.page.ts
@@ -1,3 +1,4 @@
+import { AddressesListFragment } from '../page_fragments/addresses-list.fragment';
 import { CartTotalsFragment } from '../page_fragments/cart-totals.fragment';
 import { CheckoutAddressFormFragment } from '../page_fragments/checkout/checkout-address-form.fragment';
 import { CheckoutAddressModalFragment } from '../page_fragments/checkout/checkout-address-modal.fragment';
@@ -17,15 +18,27 @@ export class CheckoutPage extends AbstractSFPage {
   }
 
   checkoutAsGuestForm = new CheckoutAsGuestFormFragment();
-  addressForm = new CheckoutAddressFormFragment();
-  addressList = new CheckoutAddressModalFragment('oryx-checkout-address');
-  addressChangeModal = new CheckoutAddressModalFragment('oryx-modal');
 
-  getChangeAddressesButton = () => cy.get('oryx-checkout-manage-address');
+  shipping = {
+    addressesList: new AddressesListFragment('oryx-checkout-shipping-address'),
+    addAddressForm: new CheckoutAddressFormFragment(
+      'oryx-checkout-shipping-address'
+    ),
+    addressChangeModal: new CheckoutAddressModalFragment(
+      'oryx-checkout-shipping-address'
+    ),
+  };
+
+  billing = {
+    addressesList: new AddressesListFragment('oryx-checkout-billing-address'),
+    addAddressForm: new CheckoutAddressFormFragment(
+      'oryx-checkout-billing-address'
+    ),
+    addressChangeModal: new CheckoutAddressModalFragment(
+      'oryx-checkout-billing-address'
+    ),
+  };
+
   getCartTotals = new CartTotalsFragment();
   getPlaceOrderBtn = () => cy.get('oryx-checkout-place-order');
-
-  openChangeAddressesModal = () => {
-    this.getChangeAddressesButton().click();
-  };
 }

--- a/libs/domain/checkout/billing-address/billing-address.component.ts
+++ b/libs/domain/checkout/billing-address/billing-address.component.ts
@@ -9,6 +9,7 @@ import {
 import { effect, hydratable, i18n, signal } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
 import { query } from 'lit/decorators.js';
+import { when } from 'lit/directives/when.js';
 import { CheckoutAddressComponent } from '../address';
 import { checkoutBillingAddressStyles } from './billing-address.styles';
 
@@ -21,18 +22,17 @@ export class CheckoutBillingAddressComponent
 
   protected addressService = resolve(AddressService);
 
-  protected addresses = signal(this.addressService.getAddresses());
-  protected selected = signal(this.checkoutStateService.get('billingAddress'));
-  protected shippingAddress = signal(
+  protected $addresses = signal(this.addressService.getAddresses());
+  protected $selected = signal(this.checkoutStateService.get('billingAddress'));
+  protected $shippingAddress = signal(
     this.checkoutStateService.get('shippingAddress')
   );
-
-  protected sameAsShippingAddress = signal(true);
+  protected $isSameAsShippingAddress = signal(true);
 
   protected autoSelect = effect(() => {
-    const addresses = this.addresses();
+    const addresses = this.$addresses();
     if (!addresses?.length) return;
-    const selected = this.selected();
+    const selected = this.$selected();
 
     if (!selected || !addresses.find((address) => selected.id === address.id)) {
       const defaultAddress = addresses.find((a) => a.isDefaultBilling);
@@ -41,11 +41,11 @@ export class CheckoutBillingAddressComponent
   });
 
   protected persistCopy = effect(() => {
-    const deliveryAddress = this.shippingAddress();
+    const deliveryAddress = this.$shippingAddress();
     if (
       deliveryAddress &&
-      this.sameAsShippingAddress() &&
-      !this.addresses()?.length
+      this.$isSameAsShippingAddress() &&
+      !this.$addresses()?.length
     ) {
       this.checkoutStateService.set('billingAddress', {
         valid: true,
@@ -61,42 +61,39 @@ export class CheckoutBillingAddressComponent
     return html`${this.renderHeading()}${this.renderBody()}`;
   }
 
-  protected renderHeading(): TemplateResult[] {
-    const templates = [
-      html`<h3>${i18n('checkout.steps.billing-address')}</h3>`,
-    ];
-    if (this.addresses()?.length) {
-      templates.push(html`<oryx-checkout-manage-address
-        @change=${this.onChange}
-        .selected=${this.selected()}
-      ></oryx-checkout-manage-address>`);
-    } else {
-      templates.push(html`<oryx-button .type=${ButtonType.Text}>
-        <button @click=${this.reuseShippingAddress}>
-          ${i18n(
-            this.sameAsShippingAddress()
-              ? 'checkout.billing-address.change'
-              : 'checkout.billing-address.same-as-shipping-address'
-          )}
-        </button></oryx-button
-      >`);
-    }
-    return templates;
+  protected renderHeading(): TemplateResult {
+    return html`<h3>${i18n('checkout.steps.billing-address')}</h3>
+      ${when(
+        this.$addresses()?.length,
+        () => html`<oryx-checkout-manage-address
+          @change=${this.onChange}
+          .selected=${this.$selected()}
+        ></oryx-checkout-manage-address>`,
+        () => html`<oryx-button .type=${ButtonType.Text}>
+          <button @click=${this.reuseShippingAddress}>
+            ${i18n(
+              this.$isSameAsShippingAddress()
+                ? 'checkout.billing-address.change'
+                : 'checkout.billing-address.same-as-shipping-address'
+            )}
+          </button></oryx-button
+        >`
+      )} `;
   }
 
   protected renderBody(): TemplateResult {
-    if (!this.addresses()?.length && this.sameAsShippingAddress()) {
+    if (!this.$addresses()?.length && this.$isSameAsShippingAddress()) {
       return html`${i18n('checkout.billing-address.same-as-shipping-address')}`;
     } else {
       return html`<oryx-checkout-address
-        .addressId=${this.selected()?.id}
+        .addressId=${this.$selected()?.id}
         @change=${this.onChange}
       ></oryx-checkout-address>`;
     }
   }
 
   protected reuseShippingAddress(): void {
-    this.sameAsShippingAddress.set(!this.sameAsShippingAddress());
+    this.$isSameAsShippingAddress.set(!this.$isSameAsShippingAddress());
   }
 
   isValid(report: boolean): boolean {
@@ -104,8 +101,11 @@ export class CheckoutBillingAddressComponent
   }
 
   protected onChange(e: CustomEvent<AddressEventDetail>): void {
-    if (!this.sameAsShippingAddress() || this.addresses()?.length) {
-      if (e.detail?.address) this.persist(e.detail.address, e.detail.valid);
+    if (
+      e.detail?.address &&
+      (!this.$isSameAsShippingAddress() || this.$addresses()?.length)
+    ) {
+      this.persist(e.detail.address, e.detail.valid);
     }
   }
 

--- a/libs/domain/checkout/billing-address/billing-address.component.ts
+++ b/libs/domain/checkout/billing-address/billing-address.component.ts
@@ -1,0 +1,108 @@
+import { CheckoutMixin, isValid } from '@spryker-oryx/checkout';
+import { resolve } from '@spryker-oryx/di';
+import { ButtonType } from '@spryker-oryx/ui/button';
+import {
+  Address,
+  AddressEventDetail,
+  AddressService,
+} from '@spryker-oryx/user';
+import { effect, hydratable, i18n, signal } from '@spryker-oryx/utilities';
+import { html, LitElement, TemplateResult } from 'lit';
+import { query } from 'lit/decorators.js';
+import { when } from 'lit/directives/when.js';
+import { CheckoutAddressComponent } from '../address';
+import { billingAddressStyles } from './billing-address.styles';
+
+@hydratable()
+export class CheckoutBillingAddressComponent
+  extends CheckoutMixin(LitElement)
+  implements isValid
+{
+  static styles = [billingAddressStyles];
+
+  protected addressService = resolve(AddressService);
+
+  protected addresses = signal(this.addressService.getAddresses());
+  protected selected = signal(this.checkoutStateService.get('billingAddress'));
+  protected shippingAddress = signal(
+    this.checkoutStateService.get('shippingAddress')
+  );
+
+  protected same = signal(true);
+
+  protected autoSelect = effect(() => {
+    const addresses = this.addresses();
+    if (!addresses?.length) return;
+    const selected = this.selected();
+
+    if (!selected || !addresses.find((address) => selected.id === address.id)) {
+      const defaultAddress = addresses.find((a) => a.isDefaultBilling);
+      this.persist(defaultAddress ?? addresses[0], true);
+    }
+  });
+
+  protected persistCopy = effect(() => {
+    const deliveryAddress = this.shippingAddress();
+    if (this.same() && deliveryAddress) {
+      this.checkoutStateService.set('billingAddress', {
+        valid: true,
+        value: deliveryAddress,
+      });
+    }
+  });
+
+  @query('oryx-checkout-address')
+  protected checkoutAddress?: CheckoutAddressComponent;
+
+  protected override render(): TemplateResult {
+    return html`
+      <h3>${i18n('checkout.steps.billing-address')}</h3>
+      ${when(
+        this.addresses()?.length,
+        () =>
+          html`<oryx-checkout-manage-address
+            @change=${this.onChange}
+            .selected=${this.selected()}
+          ></oryx-checkout-manage-address>`,
+        () =>
+          html`<oryx-button .type=${ButtonType.Text}>
+            <button @click=${this.doSame}>
+              ${i18n(
+                this.same()
+                  ? 'checkout.billing-address.change'
+                  : 'checkout.billing-address.same-as-delivery-address'
+              )}
+            </button></oryx-button
+          >`
+      )}
+      ${when(
+        this.same(),
+        () =>
+          html`${i18n('checkout.billing-address.same-as-delivery-address')}`,
+        () => html`<oryx-checkout-address
+          .addressId=${this.selected()?.id}
+          @change=${this.onChange}
+        ></oryx-checkout-address>`
+      )}
+    `;
+  }
+
+  protected doSame(): void {
+    this.same.set(!this.same());
+  }
+
+  isValid(report: boolean): boolean {
+    return !!this.checkoutAddress?.isValid(report);
+  }
+
+  protected onChange(e: CustomEvent<AddressEventDetail>): void {
+    // only persist when it's not the same
+    if (!this.same()) {
+      if (e.detail?.address) this.persist(e.detail.address, e.detail.valid);
+    }
+  }
+
+  protected persist(value: Address, valid?: boolean): void {
+    this.checkoutStateService.set('billingAddress', { valid, value });
+  }
+}

--- a/libs/domain/checkout/billing-address/billing-address.component.ts
+++ b/libs/domain/checkout/billing-address/billing-address.component.ts
@@ -10,14 +10,14 @@ import { effect, hydratable, i18n, signal } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
 import { query } from 'lit/decorators.js';
 import { CheckoutAddressComponent } from '../address';
-import { billingAddressStyles } from './billing-address.styles';
+import { checkoutBillingAddressStyles } from './billing-address.styles';
 
 @hydratable()
 export class CheckoutBillingAddressComponent
   extends CheckoutMixin(LitElement)
   implements isValid
 {
-  static styles = [billingAddressStyles];
+  static styles = [checkoutBillingAddressStyles];
 
   protected addressService = resolve(AddressService);
 
@@ -42,7 +42,11 @@ export class CheckoutBillingAddressComponent
 
   protected persistCopy = effect(() => {
     const deliveryAddress = this.shippingAddress();
-    if (this.sameAsShippingAddress() && deliveryAddress) {
+    if (
+      deliveryAddress &&
+      this.sameAsShippingAddress() &&
+      !this.addresses()?.length
+    ) {
       this.checkoutStateService.set('billingAddress', {
         valid: true,
         value: deliveryAddress,

--- a/libs/domain/checkout/billing-address/billing-address.def.ts
+++ b/libs/domain/checkout/billing-address/billing-address.def.ts
@@ -1,0 +1,13 @@
+import { componentDef } from '@spryker-oryx/core';
+
+export const checkoutBillingAddressComponent = componentDef({
+  name: 'oryx-checkout-billing-address',
+  impl: () =>
+    import('./billing-address.component').then(
+      (m) => m.CheckoutBillingAddressComponent
+    ),
+  schema: () =>
+    import('./billing-address.schema').then(
+      (m) => m.checkoutBillingAddressSchema
+    ),
+});

--- a/libs/domain/checkout/billing-address/billing-address.schema.ts
+++ b/libs/domain/checkout/billing-address/billing-address.schema.ts
@@ -1,0 +1,8 @@
+import { ContentComponentSchema } from '@spryker-oryx/experience';
+import { CheckoutBillingAddressComponent } from './billing-address.component';
+
+export const checkoutBillingAddressSchema: ContentComponentSchema<CheckoutBillingAddressComponent> =
+  {
+    name: 'Checkout Billing Address',
+    group: 'Checkout',
+  };

--- a/libs/domain/checkout/billing-address/billing-address.styles.ts
+++ b/libs/domain/checkout/billing-address/billing-address.styles.ts
@@ -1,7 +1,7 @@
 import { HeadingTag, headingUtil } from '@spryker-oryx/ui/heading';
 import { css } from 'lit';
 
-export const billingAddressStyles = css`
+export const checkoutBillingAddressStyles = css`
   :host {
     display: grid;
     gap: 12px;

--- a/libs/domain/checkout/billing-address/billing-address.styles.ts
+++ b/libs/domain/checkout/billing-address/billing-address.styles.ts
@@ -1,7 +1,7 @@
 import { HeadingTag, headingUtil } from '@spryker-oryx/ui/heading';
 import { css } from 'lit';
 
-export const checkoutDeliveryStyles = css`
+export const billingAddressStyles = css`
   :host {
     display: grid;
     gap: 12px;

--- a/libs/domain/checkout/billing-address/index.ts
+++ b/libs/domain/checkout/billing-address/index.ts
@@ -1,0 +1,3 @@
+export * from './billing-address.component';
+export * from './billing-address.schema';
+export * from './billing-address.styles';

--- a/libs/domain/checkout/billing-address/stories/demo.stories.ts
+++ b/libs/domain/checkout/billing-address/stories/demo.stories.ts
@@ -6,7 +6,7 @@ import { html, TemplateResult } from 'lit';
 import { storybookPrefix } from '../../.constants';
 
 export default {
-  title: `${storybookPrefix}/Shipping address`,
+  title: `${storybookPrefix}/Billing address`,
   args: {
     addresses: MockAddressType.Two,
   },
@@ -26,7 +26,7 @@ interface Props {
 const Template: Story<Props> = (props): TemplateResult => {
   const service = resolve<MockAddressService>(AddressService);
   service.changeMockAddressType(props.addresses);
-  return html`<oryx-checkout-shipping-address></oryx-checkout-shipping-address> `;
+  return html`<oryx-checkout-billing-address></oryx-checkout-billing-address> `;
 };
 
 export const Demo = Template.bind({});

--- a/libs/domain/checkout/billing-address/stories/static.stories.ts
+++ b/libs/domain/checkout/billing-address/stories/static.stories.ts
@@ -6,7 +6,7 @@ import { html, TemplateResult } from 'lit';
 import { storybookPrefix } from '../../.constants';
 
 export default {
-  title: `${storybookPrefix}/Shipping address/Static`,
+  title: `${storybookPrefix}/Billing address/Static`,
 } as Meta;
 
 const Template: Story<{ type: MockAddressType }> = (args: {
@@ -14,7 +14,7 @@ const Template: Story<{ type: MockAddressType }> = (args: {
 }): TemplateResult => {
   const service = resolve<MockAddressService>(AddressService);
   service.changeMockAddressType(args.type);
-  return html`<oryx-checkout-shipping-address></oryx-checkout-shipping-address> `;
+  return html`<oryx-checkout-billing-address></oryx-checkout-billing-address> `;
 };
 
 export const None = Template.bind({});

--- a/libs/domain/checkout/delivery/delivery.component.spec.ts
+++ b/libs/domain/checkout/delivery/delivery.component.spec.ts
@@ -6,7 +6,11 @@ import {
 } from '@spryker-oryx/checkout';
 import { useComponent } from '@spryker-oryx/core/utilities';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
-import { AddressEventDetail, AddressService } from '@spryker-oryx/user';
+import {
+  Address,
+  AddressEventDetail,
+  AddressService,
+} from '@spryker-oryx/user';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { of } from 'rxjs';
@@ -114,19 +118,42 @@ describe('CheckoutDeliveryComponent', () => {
     });
 
     describe('and there is no pre-selected address', () => {
-      beforeEach(async () => {
-        addressService.getAddresses.mockReturnValue([mockAddress, 2, 3]);
-        checkoutStateService.get.mockReturnValue(of(null));
-        element = await fixture(
-          html`<oryx-checkout-delivery></oryx-checkout-delivery>`
-        );
+      describe('and there is a default shipping address', () => {
+        beforeEach(async () => {
+          addressService.getAddresses.mockReturnValue([
+            mockAddress,
+            { id: 'bar', isDefaultShipping: true } as Address,
+            3,
+          ]);
+          checkoutStateService.get.mockReturnValue(of(null));
+          element = await fixture(
+            html`<oryx-checkout-delivery></oryx-checkout-delivery>`
+          );
+        });
+
+        it('should auto-select the default shipping address', () => {
+          expect(checkoutStateService.set).toHaveBeenCalledWith(
+            'shippingAddress',
+            { valid: true, value: { id: 'bar', isDefaultShipping: true } }
+          );
+        });
       });
 
-      it('should auto-select the first address', () => {
-        expect(checkoutStateService.set).toHaveBeenCalledWith(
-          'shippingAddress',
-          { valid: true, value: mockAddress }
-        );
+      describe('and there is no default shipping address', () => {
+        beforeEach(async () => {
+          addressService.getAddresses.mockReturnValue([mockAddress, 2, 3]);
+          checkoutStateService.get.mockReturnValue(of(null));
+          element = await fixture(
+            html`<oryx-checkout-delivery></oryx-checkout-delivery>`
+          );
+        });
+
+        it('should auto-select the first address', () => {
+          expect(checkoutStateService.set).toHaveBeenCalledWith(
+            'shippingAddress',
+            { valid: true, value: mockAddress }
+          );
+        });
       });
     });
 

--- a/libs/domain/checkout/delivery/delivery.component.ts
+++ b/libs/domain/checkout/delivery/delivery.component.ts
@@ -10,14 +10,14 @@ import { html, LitElement, TemplateResult } from 'lit';
 import { query } from 'lit/decorators.js';
 import { when } from 'lit/directives/when.js';
 import { CheckoutAddressComponent } from '../address';
-import { styles } from './delivery.styles';
+import { checkoutDeliveryStyles } from './delivery.styles';
 
 @hydratable()
 export class CheckoutDeliveryComponent
   extends CheckoutMixin(LitElement)
   implements isValid
 {
-  static styles = [styles];
+  static styles = [checkoutDeliveryStyles];
 
   protected addressService = resolve(AddressService);
 
@@ -30,7 +30,8 @@ export class CheckoutDeliveryComponent
     const selected = this.selected();
 
     if (!selected || !addresses.find((address) => selected.id === address.id)) {
-      this.persist(addresses[0], true);
+      const defaultAddress = addresses.find((a) => a.isDefaultShipping);
+      this.persist(defaultAddress ?? addresses[0], true);
     }
   });
 
@@ -45,6 +46,7 @@ export class CheckoutDeliveryComponent
         () =>
           html`<oryx-checkout-manage-address
             @change=${this.onChange}
+            .selected=${this.selected()}
           ></oryx-checkout-manage-address>`
       )}
       <oryx-checkout-address

--- a/libs/domain/checkout/delivery/delivery.def.ts
+++ b/libs/domain/checkout/delivery/delivery.def.ts
@@ -1,9 +1,0 @@
-import { componentDef } from '@spryker-oryx/core';
-
-export const checkoutDeliveryComponent = componentDef({
-  name: 'oryx-checkout-delivery',
-  impl: () =>
-    import('./delivery.component').then((m) => m.CheckoutDeliveryComponent),
-  schema: () =>
-    import('./delivery.schema').then((m) => m.checkoutDeliverySchema),
-});

--- a/libs/domain/checkout/delivery/delivery.schema.ts
+++ b/libs/domain/checkout/delivery/delivery.schema.ts
@@ -1,6 +1,0 @@
-import { ContentComponentSchema } from '@spryker-oryx/experience';
-
-export const checkoutDeliverySchema: ContentComponentSchema = {
-  name: 'Checkout Delivery Step',
-  group: 'Checkout',
-};

--- a/libs/domain/checkout/delivery/index.ts
+++ b/libs/domain/checkout/delivery/index.ts
@@ -1,3 +1,0 @@
-export * from './delivery.component';
-export * from './delivery.schema';
-export * from './delivery.styles';

--- a/libs/domain/checkout/manage-address/manage-address.component.ts
+++ b/libs/domain/checkout/manage-address/manage-address.component.ts
@@ -12,11 +12,9 @@ import {
 } from '@spryker-oryx/user/address-edit';
 import { EditTarget } from '@spryker-oryx/user/address-list-item';
 import {
-  computed,
   hydratable,
   i18n,
-  signal,
-  signalAware,
+  signalProperty,
   Size,
 } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
@@ -26,27 +24,17 @@ import { when } from 'lit/directives/when.js';
 import { CheckoutMixin } from '../src/mixins';
 import { checkoutManageAddressStyles } from './manage-address.styles';
 
-@signalAware()
 @hydratable(['mouseover', 'focusin'])
 export class CheckoutManageAddressComponent extends AddressMixin(
   CheckoutMixin(LitElement)
 ) {
   static styles = checkoutManageAddressStyles;
 
+  @signalProperty() selected?: Address | null;
+
   @state() protected open?: boolean;
   @state() protected loading?: boolean;
   @state() protected preselected?: Address;
-
-  protected $selectedShippingAddress = signal(
-    this.checkoutStateService.get('shippingAddress')
-  );
-
-  protected selected = computed(() => {
-    return (
-      this.$addresses()?.find((address) => address.id === this.$addressId()) ||
-      this.$selectedShippingAddress()
-    );
-  });
 
   @query('oryx-user-address-edit') editComponent?: UserAddressEditComponent;
 
@@ -79,17 +67,15 @@ export class CheckoutManageAddressComponent extends AddressMixin(
   }
 
   protected renderList(): TemplateResult | void {
-    const addressId = this.selected()?.id;
     const action = this.$addressState().action;
     if (action !== CrudState.Read && action !== CrudState.Delete) return;
 
     return html`<oryx-user-address-add-button
-        .addressId=${addressId}
         .options=${{ target: Target.Inline }}
       ></oryx-user-address-add-button>
 
       <oryx-user-address-list
-        .addressId=${addressId}
+        .addressId=${this.preselected?.id ?? this.selected?.id}
         .options=${{
           selectable: true,
           editable: true,
@@ -161,6 +147,7 @@ export class CheckoutManageAddressComponent extends AddressMixin(
 
   protected onClose(): void {
     this.addressStateService.clear();
+    this.preselected = undefined;
     this.open = false;
   }
 

--- a/libs/domain/checkout/manage-address/manage-address.component.ts
+++ b/libs/domain/checkout/manage-address/manage-address.component.ts
@@ -34,7 +34,7 @@ export class CheckoutManageAddressComponent extends AddressMixin(
 
   @state() protected open?: boolean;
   @state() protected loading?: boolean;
-  @state() protected preselected?: Address;
+  @state() protected preselected: Address | null = null;
 
   @query('oryx-user-address-edit') editComponent?: UserAddressEditComponent;
 
@@ -147,7 +147,7 @@ export class CheckoutManageAddressComponent extends AddressMixin(
 
   protected onClose(): void {
     this.addressStateService.clear();
-    this.preselected = undefined;
+    this.preselected = null;
     this.open = false;
   }
 
@@ -157,7 +157,7 @@ export class CheckoutManageAddressComponent extends AddressMixin(
 
   protected onChange(e: CustomEvent<AddressEventDetail>): void {
     e.stopPropagation();
-    this.preselected = e.detail.address;
+    this.preselected = e.detail.address ?? null;
   }
 
   protected onSelect(): void {

--- a/libs/domain/checkout/shipping-address/index.ts
+++ b/libs/domain/checkout/shipping-address/index.ts
@@ -1,0 +1,3 @@
+export * from './shipping-address.component';
+export * from './shipping-address.schema';
+export * from './shipping-address.styles';

--- a/libs/domain/checkout/shipping-address/shipping-address.component.spec.ts
+++ b/libs/domain/checkout/shipping-address/shipping-address.component.spec.ts
@@ -15,8 +15,8 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { of } from 'rxjs';
 import { CheckoutAddressComponent } from '../address';
-import { CheckoutDeliveryComponent } from './delivery.component';
-import { checkoutDeliveryComponent } from './delivery.def';
+import { CheckoutShippingAddressComponent } from './shipping-address.component';
+import { checkoutShippingAddressComponent } from './shipping-address.def';
 
 export class MockCheckoutService implements Partial<CheckoutService> {
   getProcessState = vi.fn().mockReturnValue(of());
@@ -44,13 +44,13 @@ class MockComponent extends LitElement {
   isValid = vi.fn();
 }
 
-describe('CheckoutDeliveryComponent', () => {
-  let element: CheckoutDeliveryComponent;
+describe('CheckoutShippingAddressComponent', () => {
+  let element: CheckoutShippingAddressComponent;
   let checkoutStateService: MockCheckoutStateService;
   let addressService: MockAddressService;
 
   beforeAll(async () => {
-    await useComponent(checkoutDeliveryComponent);
+    await useComponent(checkoutShippingAddressComponent);
   });
 
   beforeEach(async () => {
@@ -88,12 +88,12 @@ describe('CheckoutDeliveryComponent', () => {
   describe('when the component is created', () => {
     beforeEach(async () => {
       element = await fixture(
-        html`<oryx-checkout-delivery></oryx-checkout-delivery>`
+        html`<oryx-checkout-shipping-address></oryx-checkout-shipping-address>`
       );
     });
 
     it('should be an instance of ', () => {
-      expect(element).toBeInstanceOf(CheckoutDeliveryComponent);
+      expect(element).toBeInstanceOf(CheckoutShippingAddressComponent);
     });
 
     it('should pass the a11y audit', async () => {
@@ -105,7 +105,7 @@ describe('CheckoutDeliveryComponent', () => {
     beforeEach(async () => {
       addressService.getAddresses.mockReturnValue([1, 2, 3]);
       element = await fixture(
-        html`<oryx-checkout-delivery></oryx-checkout-delivery>`
+        html`<oryx-checkout-shipping-address></oryx-checkout-shipping-address>`
       );
     });
 
@@ -127,7 +127,7 @@ describe('CheckoutDeliveryComponent', () => {
           ]);
           checkoutStateService.get.mockReturnValue(of(null));
           element = await fixture(
-            html`<oryx-checkout-delivery></oryx-checkout-delivery>`
+            html`<oryx-checkout-shipping-address></oryx-checkout-shipping-address>`
           );
         });
 
@@ -144,7 +144,7 @@ describe('CheckoutDeliveryComponent', () => {
           addressService.getAddresses.mockReturnValue([mockAddress, 2, 3]);
           checkoutStateService.get.mockReturnValue(of(null));
           element = await fixture(
-            html`<oryx-checkout-delivery></oryx-checkout-delivery>`
+            html`<oryx-checkout-shipping-address></oryx-checkout-shipping-address>`
           );
         });
 
@@ -181,7 +181,7 @@ describe('CheckoutDeliveryComponent', () => {
     beforeEach(async () => {
       addressService.getAddresses.mockReturnValue([]);
       element = await fixture(
-        html`<oryx-checkout-delivery></oryx-checkout-delivery>`
+        html`<oryx-checkout-shipping-address></oryx-checkout-shipping-address>`
       );
     });
 
@@ -216,7 +216,7 @@ describe('CheckoutDeliveryComponent', () => {
   describe('when the isValid method is called', () => {
     beforeEach(async () => {
       element = await fixture(
-        html`<oryx-checkout-delivery></oryx-checkout-delivery>`
+        html`<oryx-checkout-shipping-address></oryx-checkout-shipping-address>`
       );
       element.isValid(true);
     });

--- a/libs/domain/checkout/shipping-address/shipping-address.component.ts
+++ b/libs/domain/checkout/shipping-address/shipping-address.component.ts
@@ -40,7 +40,7 @@ export class CheckoutShippingAddressComponent
 
   protected override render(): TemplateResult {
     return html`
-      <h3>${i18n('checkout.steps.delivery')}</h3>
+      <h3>${i18n('checkout.steps.shipping-address')}</h3>
       ${when(
         this.addresses()?.length,
         () =>

--- a/libs/domain/checkout/shipping-address/shipping-address.component.ts
+++ b/libs/domain/checkout/shipping-address/shipping-address.component.ts
@@ -10,14 +10,14 @@ import { html, LitElement, TemplateResult } from 'lit';
 import { query } from 'lit/decorators.js';
 import { when } from 'lit/directives/when.js';
 import { CheckoutAddressComponent } from '../address';
-import { checkoutDeliveryStyles } from './delivery.styles';
+import { checkoutShippingAddressStyles } from './shipping-address.styles';
 
 @hydratable()
-export class CheckoutDeliveryComponent
+export class CheckoutShippingAddressComponent
   extends CheckoutMixin(LitElement)
   implements isValid
 {
-  static styles = [checkoutDeliveryStyles];
+  static styles = [checkoutShippingAddressStyles];
 
   protected addressService = resolve(AddressService);
 

--- a/libs/domain/checkout/shipping-address/shipping-address.def.ts
+++ b/libs/domain/checkout/shipping-address/shipping-address.def.ts
@@ -1,0 +1,13 @@
+import { componentDef } from '@spryker-oryx/core';
+
+export const checkoutShippingAddressComponent = componentDef({
+  name: 'oryx-checkout-shipping-address',
+  impl: () =>
+    import('./shipping-address.component').then(
+      (m) => m.CheckoutShippingAddressComponent
+    ),
+  schema: () =>
+    import('./shipping-address.schema').then(
+      (m) => m.checkoutShippingAddressSchema
+    ),
+});

--- a/libs/domain/checkout/shipping-address/shipping-address.schema.ts
+++ b/libs/domain/checkout/shipping-address/shipping-address.schema.ts
@@ -1,0 +1,8 @@
+import { ContentComponentSchema } from '@spryker-oryx/experience';
+import { CheckoutShippingAddressComponent } from './shipping-address.component';
+
+export const checkoutShippingAddressSchema: ContentComponentSchema<CheckoutShippingAddressComponent> =
+  {
+    name: 'Checkout Shipping Address',
+    group: 'Checkout',
+  };

--- a/libs/domain/checkout/shipping-address/shipping-address.styles.ts
+++ b/libs/domain/checkout/shipping-address/shipping-address.styles.ts
@@ -1,7 +1,7 @@
 import { HeadingTag, headingUtil } from '@spryker-oryx/ui/heading';
 import { css } from 'lit';
 
-export const checkoutDeliveryStyles = css`
+export const checkoutShippingAddressStyles = css`
   :host {
     display: grid;
     gap: 12px;

--- a/libs/domain/checkout/shipping-address/stories/demo.stories.ts
+++ b/libs/domain/checkout/shipping-address/stories/demo.stories.ts
@@ -26,7 +26,7 @@ interface Props {
 const Template: Story<Props> = (props): TemplateResult => {
   const service = resolve<MockAddressService>(AddressService);
   service.changeMockAddressType(props.addresses);
-  return html`<oryx-checkout-delivery></oryx-checkout-delivery> `;
+  return html`<oryx-checkout-shipping-address></oryx-checkout-shipping-address> `;
 };
 
 export const Demo = Template.bind({});

--- a/libs/domain/checkout/shipping-address/stories/static.stories.ts
+++ b/libs/domain/checkout/shipping-address/stories/static.stories.ts
@@ -14,7 +14,7 @@ const Template: Story<{ type: MockAddressType }> = (args: {
 }): TemplateResult => {
   const service = resolve<MockAddressService>(AddressService);
   service.changeMockAddressType(args.type);
-  return html`<oryx-checkout-delivery></oryx-checkout-delivery> `;
+  return html`<oryx-checkout-shipping-address></oryx-checkout-shipping-address> `;
 };
 
 export const None = Template.bind({});

--- a/libs/domain/checkout/src/components.ts
+++ b/libs/domain/checkout/src/components.ts
@@ -1,7 +1,6 @@
 export * from '../address/address.def';
 export * from '../billing-address/billing-address.def';
 export * from '../customer/customer.def';
-export * from '../delivery/delivery.def';
 export * from '../guest/guest.def';
 export * from '../link/link.def';
 export * from '../manage-address/manage-address.def';
@@ -9,3 +8,4 @@ export * from '../orchestrator/orchestrator.def';
 export * from '../payment/payment.def';
 export * from '../place-order/place-order.def';
 export * from '../shipment/shipment.def';
+export * from '../shipping-address/shipping-address.def';

--- a/libs/domain/checkout/src/components.ts
+++ b/libs/domain/checkout/src/components.ts
@@ -1,4 +1,5 @@
 export * from '../address/address.def';
+export * from '../billing-address/billing-address.def';
 export * from '../customer/customer.def';
 export * from '../delivery/delivery.def';
 export * from '../guest/guest.def';

--- a/libs/domain/checkout/src/services/state/default-checkout-state.service.ts
+++ b/libs/domain/checkout/src/services/state/default-checkout-state.service.ts
@@ -82,10 +82,6 @@ export class DefaultCheckoutStateService implements CheckoutStateService {
       if (!data.customer.firstName && data.shippingAddress?.firstName)
         data.customer.firstName = data.shippingAddress.firstName;
     }
-    // tmp: copy the billing address from the shipping address for
-    // as long as we have not implemented the component
-    data.billingAddress = data.shippingAddress;
-
     return data;
   }
 

--- a/libs/domain/user/src/mixins/address.mixin.ts
+++ b/libs/domain/user/src/mixins/address.mixin.ts
@@ -4,6 +4,7 @@ import {
   computed,
   signal,
   Signal,
+  signalAware,
   signalProperty,
 } from '@spryker-oryx/utilities';
 import { LitElement } from 'lit';
@@ -38,6 +39,7 @@ export declare class AddressMixinInterface {
 export const AddressMixin = <T extends Type<LitElement>>(
   superClass: T
 ): Type<AddressMixinInterface> & T => {
+  @signalAware()
   class AddressMixinClass extends superClass {
     protected addressService = resolve(AddressService);
     protected addressStateService = resolve(AddressStateService);

--- a/libs/template/presets/storefront/experience/pages/checkout-page.ts
+++ b/libs/template/presets/storefront/experience/pages/checkout-page.ts
@@ -27,7 +27,7 @@ export const checkoutPage: StaticComponent = {
           type: 'oryx-checkout-orchestrator',
           components: [
             { type: 'oryx-checkout-customer' },
-            { type: 'oryx-checkout-delivery' },
+            { type: 'oryx-checkout-shipping-address' },
             { type: 'oryx-checkout-billing-address' },
             { type: 'oryx-checkout-shipment' },
             { type: 'oryx-checkout-payment' },

--- a/libs/template/presets/storefront/experience/pages/checkout-page.ts
+++ b/libs/template/presets/storefront/experience/pages/checkout-page.ts
@@ -28,6 +28,7 @@ export const checkoutPage: StaticComponent = {
           components: [
             { type: 'oryx-checkout-customer' },
             { type: 'oryx-checkout-delivery' },
+            { type: 'oryx-checkout-billing-address' },
             { type: 'oryx-checkout-shipment' },
             { type: 'oryx-checkout-payment' },
           ],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,11 +29,11 @@
       "@spryker-oryx/checkout/address": [
         "libs/domain/checkout/address/index.ts"
       ],
+      "@spryker-oryx/checkout/billing-address": [
+        "libs/domain/checkout/billing-address/index.ts"
+      ],
       "@spryker-oryx/checkout/customer": [
         "libs/domain/checkout/customer/index.ts"
-      ],
-      "@spryker-oryx/checkout/delivery": [
-        "libs/domain/checkout/delivery/index.ts"
       ],
       "@spryker-oryx/checkout/guest": ["libs/domain/checkout/guest/index.ts"],
       "@spryker-oryx/checkout/link": ["libs/domain/checkout/link/index.ts"],
@@ -54,6 +54,9 @@
       ],
       "@spryker-oryx/checkout/shipment": [
         "libs/domain/checkout/shipment/index.ts"
+      ],
+      "@spryker-oryx/checkout/shipping-address": [
+        "libs/domain/checkout/shipping-address/index.ts"
       ],
       "@spryker-oryx/cli": ["libs/template/cli/src/index.ts"],
       "@spryker-oryx/content": ["libs/domain/content/src/index.ts"],


### PR DESCRIPTION
The billing address can be used to add or select a specific address. When there's no address list (default during anonymous checkout), the shipping address can be reused. 

closes [HRZ-2587](https://spryker.atlassian.net/browse/HRZ-2587)

Breaking changes
- renamed checkout delivery component to checkout shipping address
- auto select the default shipping address rather than the first address
- billing address is added to checkout steps

[HRZ-2587]: https://spryker.atlassian.net/browse/HRZ-2587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ