### PR TITLE
feat: confirm registered user data on checkout page

### DIFF
--- a/libs/domain/checkout/customer/customer.component.spec.ts
+++ b/libs/domain/checkout/customer/customer.component.spec.ts
@@ -108,15 +108,21 @@ describe('CheckoutAuthComponent', () => {
   describe('when the user is authenticated', () => {
     beforeEach(async () => {
       authService.isAuthenticated.mockReturnValue(of(true));
-      userService.getUser.mockReturnValue(of({ email: 'foo@bar.com' } as User));
+      userService.getUser.mockReturnValue(
+        of({ firstName: 'Foo', lastName: 'Bar', email: 'foo@bar.com' } as User)
+      );
       element = await fixture(
         html`<oryx-checkout-customer></oryx-checkout-customer>`
       );
     });
 
-    it('should render the heading', () => {
-      const h1 = element.renderRoot.querySelector('h1');
-      expect(h1?.textContent).toBe('Checkout');
+    it('should render the user name', () => {
+      const h1 = element.renderRoot.querySelector('h3');
+      expect(h1?.textContent).toBe('Checking out as');
+
+      const customerData = element.renderRoot.querySelector('h3 + p');
+      expect(customerData?.textContent).contain('Foo Bar');
+      expect(customerData?.textContent).contain('foo@bar.com');
     });
 
     it('should not render the guest component', () => {

--- a/libs/domain/checkout/customer/customer.component.spec.ts
+++ b/libs/domain/checkout/customer/customer.component.spec.ts
@@ -120,7 +120,7 @@ describe('CheckoutAuthComponent', () => {
     });
 
     it('should render the user name', () => {
-      const customerData = element.renderRoot.querySelector('p');
+      const customerData = element.renderRoot.querySelector('p')?.textContent;
       expect(customerData).toContain(`${user.firstName} ${user.lastName}`);
       expect(customerData).toContain(user.email);
     });

--- a/libs/domain/checkout/customer/customer.component.spec.ts
+++ b/libs/domain/checkout/customer/customer.component.spec.ts
@@ -106,23 +106,23 @@ describe('CheckoutAuthComponent', () => {
   });
 
   describe('when the user is authenticated', () => {
+    const user = {
+      firstName: 'Foo',
+      lastName: 'Bar',
+      email: 'foo@bar.com',
+    } as User;
     beforeEach(async () => {
       authService.isAuthenticated.mockReturnValue(of(true));
-      userService.getUser.mockReturnValue(
-        of({ firstName: 'Foo', lastName: 'Bar', email: 'foo@bar.com' } as User)
-      );
+      userService.getUser.mockReturnValue(of(user));
       element = await fixture(
         html`<oryx-checkout-customer></oryx-checkout-customer>`
       );
     });
 
     it('should render the user name', () => {
-      const h1 = element.renderRoot.querySelector('h3');
-      expect(h1?.textContent).toBe('Checking out as');
-
-      const customerData = element.renderRoot.querySelector('h3 + p');
-      expect(customerData?.textContent).contain('Foo Bar');
-      expect(customerData?.textContent).contain('foo@bar.com');
+      const customerData = element.renderRoot.querySelector('p');
+      expect(customerData).toContain(`${user.firstName} ${user.lastName}`);
+      expect(customerData).toContain(user.email);
     });
 
     it('should not render the guest component', () => {

--- a/libs/domain/checkout/customer/customer.component.spec.ts
+++ b/libs/domain/checkout/customer/customer.component.spec.ts
@@ -111,6 +111,7 @@ describe('CheckoutAuthComponent', () => {
       lastName: 'Bar',
       email: 'foo@bar.com',
     } as User;
+
     beforeEach(async () => {
       authService.isAuthenticated.mockReturnValue(of(true));
       userService.getUser.mockReturnValue(of(user));
@@ -119,7 +120,7 @@ describe('CheckoutAuthComponent', () => {
       );
     });
 
-    it('should render the user name', () => {
+    it('should render the user data', () => {
       const customerData = element.renderRoot.querySelector('p')?.textContent;
       expect(customerData).toContain(`${user.firstName} ${user.lastName}`);
       expect(customerData).toContain(user.email);

--- a/libs/domain/checkout/customer/customer.component.ts
+++ b/libs/domain/checkout/customer/customer.component.ts
@@ -68,7 +68,13 @@ export class CheckoutCustomerComponent
 
   protected override render(): TemplateResult | void {
     if (this.isAuthenticated()) {
-      return html`<h1>${i18n('checkout.checkout')}</h1>`;
+      const { email, firstName, lastName } = this.customer() ?? {};
+
+      return html`<h3>${i18n('checkout.checking-out-as')}</h3>
+        <p>
+          ${firstName} ${lastName}<br />
+          ${email}
+        </p>`;
     } else if (this.$options().enableGuestCheckout) {
       return html`<oryx-checkout-guest></oryx-checkout-guest>`;
     }

--- a/libs/domain/user/address-form/address-form.component.spec.ts
+++ b/libs/domain/user/address-form/address-form.component.spec.ts
@@ -310,7 +310,7 @@ describe('UserAddressFormComponent', () => {
         ></oryx-user-address-form>`);
       });
 
-      it('should set isDefaultShipping to true in the default values', () => {
+      it('should not set isDefaultShipping to true in the default values', () => {
         expect(renderer.buildForm).toHaveBeenCalledWith(
           expect.anything(),
           expect.not.objectContaining({ isDefaultShipping: true })
@@ -361,7 +361,7 @@ describe('UserAddressFormComponent', () => {
         ></oryx-user-address-form>`);
       });
 
-      it('should set isDefaultBilling to true in the default values', () => {
+      it('should not set isDefaultBilling to true in the default values', () => {
         expect(renderer.buildForm).toHaveBeenCalledWith(
           expect.anything(),
           expect.not.objectContaining({ isDefaultBilling: true })

--- a/libs/domain/user/address-form/address-form.component.spec.ts
+++ b/libs/domain/user/address-form/address-form.component.spec.ts
@@ -403,21 +403,20 @@ describe('UserAddressFormComponent', () => {
   });
 
   describe('when a registered user creates a new address', () => {
+    const user = {
+      firstName: 'First',
+      lastName: 'Last',
+      salutation: 'Mr',
+    } as User;
     beforeEach(async () => {
-      userService.getUser.mockReturnValue(
-        of({ firstName: 'First', lastName: 'Last', salutation: 'Mr' } as User)
-      );
+      userService.getUser.mockReturnValue(of(user));
       element = await fixture(html`
         <oryx-user-address-form></oryx-user-address-form>
       `);
     });
 
-    it('should feed in the first name, last name and salutation', () => {
-      expect(renderer.buildForm).toHaveBeenCalledWith(expect.anything(), {
-        firstName: 'First',
-        lastName: 'Last',
-        salutation: 'Mr',
-      });
+    it('should feed in the user`s data', () => {
+      expect(renderer.buildForm).toHaveBeenCalledWith(expect.anything(), user);
     });
   });
 });

--- a/libs/domain/user/address-form/address-form.component.spec.ts
+++ b/libs/domain/user/address-form/address-form.component.spec.ts
@@ -3,7 +3,13 @@ import { useComponent } from '@spryker-oryx/core/utilities';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
 import { FormRenderer } from '@spryker-oryx/form';
 import { CountryService } from '@spryker-oryx/site';
-import { AddressFormService, AddressService } from '@spryker-oryx/user';
+import {
+  Address,
+  AddressFormService,
+  AddressService,
+  User,
+  UserService,
+} from '@spryker-oryx/user';
 import { html } from 'lit';
 import { of } from 'rxjs';
 import { UserAddressFormComponent } from './address-form.component';
@@ -26,6 +32,15 @@ const mockCountries = [
 
 class MockAddressService implements Partial<AddressService> {
   getCurrentAddress = vi.fn().mockReturnValue(of(null));
+  getAddresses = vi.fn().mockReturnValue(
+    of([
+      {
+        id: 'sampleAddress',
+        isDefaultBilling: true,
+        isDefaultShipping: true,
+      } as Address,
+    ])
+  );
 }
 
 class MockCountryService {
@@ -81,12 +96,17 @@ class MockAddressFormService implements Partial<AddressFormService> {
   getForm = vi.fn().mockReturnValue(of(mockForm));
 }
 
+class MockUserService implements Partial<UserService> {
+  getUser = vi.fn().mockReturnValue(of(null));
+}
+
 describe('UserAddressFormComponent', () => {
   let element: UserAddressFormComponent;
   let renderer: MockFormRenderer;
   let formService: MockAddressFormService;
   let countryService: MockCountryService;
   let addressService: MockAddressService;
+  let userService: MockUserService;
 
   let selectElement: HTMLSelectElement | undefined | null;
 
@@ -113,18 +133,18 @@ describe('UserAddressFormComponent', () => {
           provide: AddressService,
           useClass: MockAddressService,
         },
+        {
+          provide: UserService,
+          useClass: MockUserService,
+        },
       ],
     });
-    renderer = testInjector.inject(FormRenderer) as unknown as MockFormRenderer;
-    formService = testInjector.inject(
-      AddressFormService
-    ) as unknown as MockAddressFormService;
-    countryService = testInjector.inject(
-      CountryService
-    ) as unknown as MockCountryService;
-    addressService = testInjector.inject(
-      AddressService
-    ) as unknown as MockAddressService;
+    renderer = testInjector.inject<MockFormRenderer>(FormRenderer);
+    formService =
+      testInjector.inject<MockAddressFormService>(AddressFormService);
+    countryService = testInjector.inject<MockCountryService>(CountryService);
+    addressService = testInjector.inject<MockAddressService>(AddressService);
+    userService = testInjector.inject<MockUserService>(UserService);
   });
 
   afterEach(() => {
@@ -150,7 +170,7 @@ describe('UserAddressFormComponent', () => {
       });
       expect(renderer.buildForm).toHaveBeenCalledWith(
         mockForm.data.options,
-        undefined
+        {}
       );
     });
 
@@ -168,7 +188,7 @@ describe('UserAddressFormComponent', () => {
       element = await fixture(
         html`<oryx-user-address-form
           country="FR"
-          fallbackCountry="PT"
+          .options=${{ fallbackCountry: 'PT' }}
         ></oryx-user-address-form>`
       );
     });
@@ -183,7 +203,7 @@ describe('UserAddressFormComponent', () => {
     it('should render fallback country form', () => {
       expect(renderer.buildForm).toHaveBeenCalledWith(
         mockFallbackForm.data.options,
-        undefined
+        {}
       );
     });
   });
@@ -276,25 +296,93 @@ describe('UserAddressFormComponent', () => {
         expect.arrayContaining([
           expect.objectContaining({ id: 'isDefaultShipping' }),
         ]),
-        undefined
+        {}
       );
+    });
+
+    describe('and there is an address available with is set to default shipping', () => {
+      beforeEach(async () => {
+        addressService.getAddresses.mockReturnValue(
+          of([{ isDefaultShipping: true } as Address])
+        );
+        element = await fixture(html` <oryx-user-address-form
+          enableDefaultShipping
+        ></oryx-user-address-form>`);
+      });
+
+      it('should set isDefaultShipping to true in the default values', () => {
+        expect(renderer.buildForm).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.not.objectContaining({ isDefaultShipping: true })
+        );
+      });
+    });
+
+    describe('and there is no address available with is set to default billing', () => {
+      beforeEach(async () => {
+        addressService.getAddresses.mockReturnValue(of([]));
+        element = await fixture(html` <oryx-user-address-form
+          enableDefaultShipping
+        ></oryx-user-address-form>`);
+      });
+
+      it('should set isDefaultShipping to true in the default values', () => {
+        expect(renderer.buildForm).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({ isDefaultShipping: true })
+        );
+      });
     });
   });
 
-  describe('when enableDefaultBilling prop is provided', () => {
+  describe('when enableDefaultBilling property is provided', () => {
     beforeEach(async () => {
       element = await fixture(html` <oryx-user-address-form
         enableDefaultBilling
       ></oryx-user-address-form>`);
     });
 
-    it('should merge the field with the form schema', () => {
+    it('should add the field to the form model', () => {
       expect(renderer.buildForm).toHaveBeenCalledWith(
         expect.arrayContaining([
           expect.objectContaining({ id: 'isDefaultBilling' }),
         ]),
-        undefined
+        {}
       );
+    });
+
+    describe('and there is an address available with is set to default billing', () => {
+      beforeEach(async () => {
+        addressService.getAddresses.mockReturnValue(
+          of([{ isDefaultBilling: true } as Address])
+        );
+        element = await fixture(html` <oryx-user-address-form
+          enableDefaultBilling
+        ></oryx-user-address-form>`);
+      });
+
+      it('should set isDefaultBilling to true in the default values', () => {
+        expect(renderer.buildForm).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.not.objectContaining({ isDefaultBilling: true })
+        );
+      });
+    });
+
+    describe('and there is no address available with is set to default billing', () => {
+      beforeEach(async () => {
+        addressService.getAddresses.mockReturnValue(of([]));
+        element = await fixture(html` <oryx-user-address-form
+          enableDefaultBilling
+        ></oryx-user-address-form>`);
+      });
+
+      it('should set isDefaultBilling to true in the default values', () => {
+        expect(renderer.buildForm).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({ isDefaultBilling: true })
+        );
+      });
     });
   });
 
@@ -311,6 +399,25 @@ describe('UserAddressFormComponent', () => {
         mockForm.data.options,
         values
       );
+    });
+  });
+
+  describe('when a registered user creates a new address', () => {
+    beforeEach(async () => {
+      userService.getUser.mockReturnValue(
+        of({ firstName: 'First', lastName: 'Last', salutation: 'Mr' } as User)
+      );
+      element = await fixture(html`
+        <oryx-user-address-form></oryx-user-address-form>
+      `);
+    });
+
+    it('should feed in the first name, last name and salutation', () => {
+      expect(renderer.buildForm).toHaveBeenCalledWith(expect.anything(), {
+        firstName: 'First',
+        lastName: 'Last',
+        salutation: 'Mr',
+      });
     });
   });
 });

--- a/libs/domain/user/address-form/address-form.component.ts
+++ b/libs/domain/user/address-form/address-form.component.ts
@@ -85,23 +85,23 @@ export class UserAddressFormComponent
     const values = this.values ?? {};
     const { firstName, lastName, salutation } = this.$user() ?? {};
 
-    const a = this.$addresses();
+    const addresses = this.$addresses();
     if (
       this.enableDefaultBilling &&
-      !a?.find((address) => address.isDefaultBilling)
+      !addresses?.find((address) => address.isDefaultBilling)
     ) {
       values.isDefaultBilling = true;
     }
     if (
       this.enableDefaultShipping &&
-      !a?.find((address) => address.isDefaultShipping)
+      !addresses?.find((address) => address.isDefaultShipping)
     ) {
       values.isDefaultShipping = true;
     }
 
-    if (firstName) values.firstName ??= firstName;
-    if (lastName) values.lastName ??= lastName;
-    if (salutation) values.salutation ??= salutation;
+    values.firstName ??= firstName;
+    values.lastName ??= lastName;
+    values.salutation ??= salutation;
     return values;
   }
 

--- a/libs/domain/user/address-form/address-form.component.ts
+++ b/libs/domain/user/address-form/address-form.component.ts
@@ -6,6 +6,7 @@ import {
   FormMixin,
   FormRenderer,
   formStyles,
+  FormValues,
 } from '@spryker-oryx/form';
 import { CountryService } from '@spryker-oryx/site';
 import {
@@ -13,6 +14,7 @@ import {
   AddressEventDetail,
   AddressFormService,
   AddressService,
+  UserService,
 } from '@spryker-oryx/user';
 import {
   computed,
@@ -42,45 +44,69 @@ export class UserAddressFormComponent
   protected addressService = resolve(AddressService);
   protected addressFormService = resolve(AddressFormService);
   protected fieldRenderer = resolve(FormRenderer);
+  protected userService = resolve(UserService);
 
   @property({ type: Boolean }) enableDefaultShipping?: boolean;
   @property({ type: Boolean }) enableDefaultBilling?: boolean;
 
   @signalProperty() country?: string;
-  @signalProperty() fallbackCountry?: string;
 
-  protected countries = signal(this.countryService.getAll());
-  protected currentAddress = signal(this.addressService.getCurrentAddress());
-  protected activeCountry = computed(() => {
+  protected $countries = signal(this.countryService.getAll());
+  protected $currentAddress = signal(this.addressService.getCurrentAddress());
+  protected $user = signal(this.userService.getUser());
+  protected $addresses = signal(this.addressService.getAddresses());
+  protected $currentCountry = computed(() => {
     if (this.country) return this.country;
-    return this.currentAddress()?.iso2Code ?? this.countries()?.[0].iso2Code;
+    return this.$currentAddress()?.iso2Code ?? this.$countries()?.[0].iso2Code;
   });
-
-  protected formModel = computed(() => {
-    const country = this.activeCountry();
-    const fallbackCountry =
-      this.fallbackCountry ?? this.$options().fallbackCountry;
-
+  protected $formModel = computed(() => {
+    const country = this.$currentCountry();
     if (!country) return;
 
     return this.addressFormService.getForm({
       country,
-      fallbackCountry,
+      fallbackCountry: this.$options().fallbackCountry,
     }) as unknown as AddressForm;
   });
 
-  @query('form')
-  protected form?: HTMLFormElement;
+  @query('form') protected form?: HTMLFormElement;
 
   protected override render(): TemplateResult | void {
     return html`<form @change=${this.onChange}>
       ${this.renderCountrySelector()}
-      ${this.fieldRenderer.buildForm(this.getFormFields(), this.values)}
+      ${this.fieldRenderer.buildForm(
+        this.getFormFields(),
+        this.getFormValues()
+      )}
     </form>`;
   }
 
+  protected getFormValues(): FormValues {
+    const values = this.values ?? {};
+    const { firstName, lastName, salutation } = this.$user() ?? {};
+
+    const a = this.$addresses();
+    if (
+      this.enableDefaultBilling &&
+      !a?.find((address) => address.isDefaultBilling)
+    ) {
+      values.isDefaultBilling = true;
+    }
+    if (
+      this.enableDefaultShipping &&
+      !a?.find((address) => address.isDefaultShipping)
+    ) {
+      values.isDefaultShipping = true;
+    }
+
+    if (firstName) values.firstName ??= firstName;
+    if (lastName) values.lastName ??= lastName;
+    if (salutation) values.salutation ??= salutation;
+    return values;
+  }
+
   protected getFormFields(): FormFieldDefinition[] {
-    const form = this.formModel();
+    const form = this.$formModel();
 
     const formFields = [...(form?.data.options ?? [])];
     if (this.enableDefaultShipping) {
@@ -104,8 +130,8 @@ export class UserAddressFormComponent
   }
 
   protected renderCountrySelector(): TemplateResult | void {
-    const countries = this.countries();
-    const activeCountry = this.activeCountry();
+    const countries = this.$countries();
+    const activeCountry = this.$currentCountry();
     if (!countries?.length || countries?.length < 2) return;
 
     return html` <oryx-select

--- a/libs/domain/user/address-form/address-form.model.ts
+++ b/libs/domain/user/address-form/address-form.model.ts
@@ -10,14 +10,30 @@ export interface AddressForm {
 
 export interface AddressFormOptions {
   /**
-   * In case some country has no based address, should fallback to this country address format.
+   * Used to fallback to a specific country, when there's no country specific address
+   * form model found.
    */
   fallbackCountry?: string;
 }
 
 export interface AddressFormAttributes {
+  /**
+   * The country isocode is used to resolve a country specific form model. This is used
+   * to support address formats for different countries.
+   */
   country?: string;
-  fallbackCountry?: string;
+
+  /**
+   * Indicates whether a checkbox is added to the form to set the address as the
+   * default shipping address. When there's no default shipping address available
+   * in the list of addresses, we set the value to true.
+   */
   enableDefaultShipping?: boolean;
+
+  /**
+   * Indicates whether a checkbox is added to the form to set the address as the
+   * default billing address. When there's no default billing address available
+   * in the list of addresses, we set the value to true.
+   */
   enableDefaultBilling?: boolean;
 }

--- a/libs/domain/user/address-form/stories/demo.stories.ts
+++ b/libs/domain/user/address-form/stories/demo.stories.ts
@@ -47,7 +47,7 @@ const Template: Story<Props> = (props): TemplateResult => {
     .country="${props.country}"
     .enableDefaultShipping=${props.enableDefaultShipping}
     .enableDefaultBilling=${props.enableDefaultBilling}
-    .fallbackCountry="${props.fallbackCountry}"
+    .options=${{ fallbackCountry: props.fallbackCountry }}
   ></oryx-user-address-form>`;
 };
 


### PR DESCRIPTION
When a registered user lands at the checkout page, we confirm the name and email address. 

Additionally, we've added some default values that can be resolved from the user and the users address book:
- copy first name over to new address
- copy last name over to new address
- copy salutation over to new address
- set default shipping address to true if there's no default shipping address
- set default billing address to true if there's no default billing address

closes [HRZ-3057](https://spryker.atlassian.net/browse/HRZ-3057)


[HRZ-3057]: https://spryker.atlassian.net/browse/HRZ-3057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ