### PR TITLE
fix: fa e2e tests flakiness and speedup tests

### DIFF
--- a/apps/fulfillment-e2e/cypress.ci.config.js
+++ b/apps/fulfillment-e2e/cypress.ci.config.js
@@ -4,5 +4,5 @@ const config = require('./cypress.config');
 module.exports = defineConfig({
   ...config,
   projectId: 'bxiyv4',
-  retries: 2,
+  retries: 1,
 });

--- a/apps/fulfillment-e2e/src/support/commands.ts
+++ b/apps/fulfillment-e2e/src/support/commands.ts
@@ -24,7 +24,10 @@ Cypress.Commands.add('login', (user = defaultUser) => {
   loginPage.visit();
   loginPage.loginForm.login(user);
 
-  cy.wait('@token');
+  // we have to wait for 5++ seconds here
+  // because our bundle is huge and Cypress is not able
+  // to cache all 500++ files fast enough
+  cy.wait('@token', { timeout: 10000 });
 
   cy.intercept('GET', '**/picking-lists?include*').as('picking-lists');
   cy.wait('@picking-lists');


### PR DESCRIPTION
There were a lot of flaky e2es of FA lately, and they all are caused by 1 reason, which is fixed here. 
