### PR TITLE
fix: duplicated floating label

### DIFF
--- a/libs/base/ui/form/input/src/form-control/floating-label.styles.ts
+++ b/libs/base/ui/form/input/src/form-control/floating-label.styles.ts
@@ -38,6 +38,10 @@ const floatingLabelStyles = (attribute = true) => {
       max-width: calc(100% - 54px - var(--float-label-start-gap, 0px));
     }
 
+    :host(${floatLabel}) slot:not([name])::slotted(*)::placeholder {
+      color: var(--oryx-color-placeholder);
+    }
+
     :host(${floatLabel}),
     :host(${floatLabel}) ::slotted(select:invalid) {
       --oryx-color-placeholder: transparent;
@@ -57,6 +61,16 @@ const floatingLabelStyles = (attribute = true) => {
       inset-block-start: -10px;
       inset-inline-start: 20px;
       max-width: calc(100% - 56px);
+    }
+
+    :host(${floatLabel}[required]:is(:focus-within, [has-value]))
+      slot[name='label'] {
+      padding: 3px calc(8px + 0.5em) 3px 8px;
+    }
+
+    :host(${floatLabel}[required]:is(:focus-within, [has-value]))
+      slot[name='label']::after {
+      inset-inline-end: 0.5em;
     }
 
     :host(${floatLabel}[has-prefix]:is(:focus-within, [has-value]))

--- a/libs/base/ui/form/input/src/stories/static/common.ts
+++ b/libs/base/ui/form/input/src/stories/static/common.ts
@@ -9,6 +9,7 @@ export enum CategoryX {
   DEFAULT = 'Default',
   HOVERED = 'Hovered',
   FOCUSED = 'Focused',
+  REQUIRED = 'Required',
   DISABLED = 'Disabled',
   ERROR = 'Error',
   ERROR_WITHOUT_MESSAGE = 'Error without message',
@@ -20,6 +21,7 @@ export interface InputVariantOptions extends VariantOptions {
   isDisabled?: boolean;
   hasError?: boolean;
   floatLabel?: boolean;
+  required?: boolean;
   label?: string;
   value?: string | number;
 }
@@ -61,6 +63,13 @@ export const baseInputVariants: InputVariant[] = [
     categoryY: '',
     options: {
       className: 'pseudo-focus-within',
+    },
+  },
+  {
+    categoryX: CategoryX.REQUIRED,
+    categoryY: '',
+    options: {
+      required: true,
     },
   },
   {

--- a/libs/base/ui/form/input/src/stories/static/input-with-label.stories.ts
+++ b/libs/base/ui/form/input/src/stories/static/input-with-label.stories.ts
@@ -61,6 +61,7 @@ const Template: Story = (): TemplateResult => html`
               className,
               value,
               hasError,
+              required,
             },
           }) => html`
             <oryx-input
@@ -72,6 +73,7 @@ const Template: Story = (): TemplateResult => html`
               <input
                 placeholder="Placeholder"
                 value=${value}
+                ?required=${required}
                 ?disabled=${isDisabled}
                 class=${className}
               />


### PR DESCRIPTION
Also added a space after the asterisk for floating and required field.

closes: [HRZ-3061](https://spryker.atlassian.net/browse/HRZ-3061)

[HRZ-3061]: https://spryker.atlassian.net/browse/HRZ-3061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ