### PR TITLE
fix: use infinite max quantity when product isNeverOutOfStock

### DIFF
--- a/libs/domain/cart/add/src/add.component.spec.ts
+++ b/libs/domain/cart/add/src/add.component.spec.ts
@@ -127,6 +127,13 @@ describe('CartAddComponent', () => {
       expect(element).toContainElement('button:not([disabled])');
     });
 
+    it('should have a max quantity of 10', () => {
+      const quantityInput = element.renderRoot.querySelector(
+        'oryx-cart-quantity-input'
+      ) as QuantityInputComponent;
+      expect(quantityInput.max).toBe(10);
+    });
+
     describe('and when an update is dispatched with an invalid quantity', () => {
       beforeEach(() => {
         const input = element.shadowRoot?.querySelector(
@@ -156,6 +163,13 @@ describe('CartAddComponent', () => {
     it('should disable the button', () => {
       expect(element).toContainElement('button[disabled]');
     });
+
+    it('should have max quantity of 0', () => {
+      const quantityInput = element.renderRoot.querySelector(
+        'oryx-cart-quantity-input'
+      ) as QuantityInputComponent;
+      expect(quantityInput.max).toBe(0);
+    });
   });
 
   describe('when isNeverOutOfStock = true', () => {
@@ -171,6 +185,13 @@ describe('CartAddComponent', () => {
 
     it('should enable the button', () => {
       expect(element).toContainElement('button:not([disabled])');
+    });
+
+    it('should have an infinite max quantity', () => {
+      const quantityInput = element.renderRoot.querySelector(
+        'oryx-cart-quantity-input'
+      ) as QuantityInputComponent;
+      expect(quantityInput.max).toBe(Infinity);
     });
   });
 

--- a/libs/domain/cart/add/src/add.component.ts
+++ b/libs/domain/cart/add/src/add.component.ts
@@ -82,15 +82,18 @@ export class CartAddComponent extends ProductMixin(
   });
 
   protected $max = computed(() => {
-    const qty = this.$product()?.availability?.quantity;
-    const sku = this.$product()?.sku;
-    return qty
-      ? qty -
-          this.$entries()
-            .filter((entry) => entry.sku === sku)
-            .map((entry) => entry.quantity)
-            .reduce((a: number, b) => a + b, 0)
-      : 0;
+    const { availability, sku } = this.$product() ?? {};
+
+    if (availability?.isNeverOutOfStock) return Infinity;
+    if (availability?.quantity)
+      return (
+        availability?.quantity -
+        this.$entries()
+          .filter((entry) => entry.sku === sku)
+          .map((entry) => entry.quantity)
+          .reduce((a: number, b) => a + b, 0)
+      );
+    return 0;
   });
 
   protected onUpdate(e: CustomEvent<QuantityEventDetail>): void {


### PR DESCRIPTION
The max quantity should become infinite when the product availability is marked never out of stock. 

fixes [HRZ-3109](https://spryker.atlassian.net/browse/HRZ-3109)

[HRZ-3109]: https://spryker.atlassian.net/browse/HRZ-3109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ