### PR TITLE
test: update products for sf

### DIFF
--- a/apps/storefront-e2e/src/integration/cart.cy.ts
+++ b/apps/storefront-e2e/src/integration/cart.cy.ts
@@ -15,8 +15,8 @@ describe('Cart', () => {
   });
 
   describe('when the cart page is not visited', () => {
-    describe('and items are added to cart on the product page', () => {
-      const productData = ProductStorage.getProductByEq(2);
+    describe('and discontinued items are added to cart on the product page', () => {
+      const productData = ProductStorage.getProductByEq(4);
       const pdp = new ProductDetailsPage(productData);
 
       beforeEach(() => {
@@ -34,14 +34,15 @@ describe('Cart', () => {
           cartPage.getCartEntriesHeading().should('contain.text', '1 items');
           checkCartEntry({
             quantity: 1,
-            subTotal: '€62.77',
-            originalPrice: '€70.00',
-            salesPrice: '€62.77',
+            subTotal: '€161.95',
+            originalPrice: '180.00',
+            salesPrice: '€179.94',
           });
           checkCartTotals({
-            subTotal: '€62.77',
-            taxTotal: '€4.11',
-            totalPrice: '€62.77',
+            subTotal: '€179.94',
+            taxTotal: '€10.59',
+            discountsTotal: '-€17.99',
+            totalPrice: '€161.95',
           });
         });
       });
@@ -75,14 +76,13 @@ describe('Cart', () => {
         cartPage.getCartEntriesHeading().should('contain.text', '1 items');
         checkCartEntry({
           quantity: 1,
-          subTotal: '€62.77',
-          originalPrice: '€70.00',
-          salesPrice: '€62.77',
+          subTotal: '€34.54',
+          salesPrice: '€34.54',
         });
         checkCartTotals({
-          subTotal: '€62.77',
-          taxTotal: '€4.11',
-          totalPrice: '€62.77',
+          subTotal: '€34.54',
+          taxTotal: '€5.51',
+          totalPrice: '€34.54',
         });
       });
 
@@ -113,15 +113,14 @@ describe('Cart', () => {
           cartPage.getCartEntriesHeading().should('contain.text', '4 items');
           checkCartEntry({
             quantity: 4,
-            subTotal: '€225.97',
-            originalPrice: '€70.00',
-            salesPrice: '€62.77',
+            subTotal: '€124.34',
+            salesPrice: '€34.54',
           });
           checkCartTotals({
-            subTotal: '€251.08',
-            discountsTotal: '-€25.11',
-            taxTotal: '€14.78',
-            totalPrice: '€225.97',
+            subTotal: '€138.16',
+            discountsTotal: '-€13.82',
+            taxTotal: '€19.85',
+            totalPrice: '€124.34',
           });
         });
       });
@@ -138,12 +137,12 @@ describe('Cart', () => {
           cartPage.getCartEntriesHeading().should('contain.text', '1 items');
           checkCartEntry({
             quantity: 2,
-            subTotal: '€62.77',
+            subTotal: '€34.54',
           });
           checkCartTotals({
-            subTotal: '€62.77',
-            taxTotal: '€4.11',
-            totalPrice: '€62.77',
+            subTotal: '€34.54',
+            taxTotal: '€5.51',
+            totalPrice: '€34.54',
           });
 
           cy.get('body').click();
@@ -152,13 +151,12 @@ describe('Cart', () => {
           cartPage.getCartEntriesHeading().should('contain.text', '2 items');
           checkCartEntry({
             quantity: 2,
-            subTotal: '€112.99',
+            subTotal: '€69.08',
           });
           checkCartTotals({
-            subTotal: '€125.54',
-            taxTotal: '€7.39',
-            discountsTotal: '-€12.55',
-            totalPrice: '€112.99',
+            subTotal: '€69.08',
+            taxTotal: '€11.03',
+            totalPrice: '€69.08',
           });
         });
       });

--- a/apps/storefront-e2e/src/integration/checkout.cy.ts
+++ b/apps/storefront-e2e/src/integration/checkout.cy.ts
@@ -27,7 +27,7 @@ describe('Checkout suite', () => {
     });
 
     it('must allow user to create a new order', () => {
-      const productData = ProductStorage.getProductByEq(2);
+      const productData = ProductStorage.getProductByEq(1);
 
       cy.fixture<TestCustomerData>('test-customer').then((customer) => {
         sccosApi.carts
@@ -93,7 +93,7 @@ describe('Checkout suite', () => {
     });
 
     it('must allow user to create a new order', () => {
-      sccosApi.guestCartItems.post(ProductStorage.getProductByEq(1), 1);
+      sccosApi.guestCartItems.post(ProductStorage.getProductByEq(4), 1);
 
       cy.intercept('POST', '/checkout?include=orders').as('checkout');
       cy.intercept('/customers/*/addresses').as('addresses');

--- a/apps/storefront-e2e/src/integration/product.cy.ts
+++ b/apps/storefront-e2e/src/integration/product.cy.ts
@@ -27,7 +27,7 @@ describe('Product Detail Page', () => {
   });
 
   describe('when product has reference products', () => {
-    const productData = ProductStorage.getProductByEq(5);
+    const productData = ProductStorage.getProductByEq(3);
     const pdp = new ProductDetailsPage(productData);
 
     beforeEach(() => {

--- a/apps/storefront-e2e/src/integration/search.cy.ts
+++ b/apps/storefront-e2e/src/integration/search.cy.ts
@@ -29,7 +29,7 @@ describe('Search suite', () => {
   });
 
   it('must go to PDP from search results', () => {
-    const productData = ProductStorage.getProductByEq(2);
+    const productData = ProductStorage.getProductByEq(3);
     const pdp = new ProductDetailsPage(productData);
 
     cy.intercept('**/concrete-products/**').as('productRequest');

--- a/apps/storefront-e2e/src/integration/ssr.cy.ts
+++ b/apps/storefront-e2e/src/integration/ssr.cy.ts
@@ -14,7 +14,7 @@ describe('SSR suite', () => {
   });
 
   it('must render Product details page', () => {
-    const productData = ProductStorage.getProductByEq(0);
+    const productData = ProductStorage.getProductByEq(1);
     const pdp = new ProductDetailsPage(productData);
 
     pdp.visit();
@@ -29,7 +29,7 @@ describe('SSR suite', () => {
 
     pdp.getImages().should('be.visible');
     pdp.getDescription().should('be.visible');
-    pdp.getAttributeTerms().should('have.length', 6);
+    pdp.getAttributeTerms().should('have.length', 7);
   });
 
   it('must render Contact us page', () => {

--- a/apps/storefront-e2e/src/support/page_objects/cart.page.ts
+++ b/apps/storefront-e2e/src/support/page_objects/cart.page.ts
@@ -37,7 +37,7 @@ export class CartPage extends AbstractSFPage {
   checkout = () => {
     // fixes possible test flakiness caused by hydration delay
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(500);
+    cy.wait(1000);
     this.getCheckoutBtn().click({ force: true });
   };
 }

--- a/apps/storefront-e2e/src/test-data/product.storage.ts
+++ b/apps/storefront-e2e/src/test-data/product.storage.ts
@@ -2,53 +2,34 @@ import { TestProductData } from '../types/product.type';
 
 const products: TestProductData[] = [
   {
-    id: '093_24495843',
-    title: 'Sony SmartWatch 3',
-    originalPrice: '248.99',
-    currentPrice: '248.99',
-    currentPriceWith10pDiscount: '224.09',
-    previewImageURL: '/img/norm/medium/24495843-7844.jpg',
-  },
-  {
-    id: '083_30964018',
-    title: 'Samsung Gear 2 Classic',
-    originalPrice: '332.53',
-    currentPrice: '332.53',
-    currentPriceWith10pDiscount: '299.28',
-    previewImageURL: '/img/gallery_mediums/33474193_2373746309.jpg',
-  },
-  {
-    id: '100_24675726',
-    title: 'Acer Liquid Leap',
+    id: '117_29890338',
+    title: 'Fujitsu ESPRIMO D556',
     originalPrice: '70.00',
-    currentPrice: '62.77',
-    currentPriceWith10pDiscount: '56.49',
-    previewImageURL:
-      '/img/gallery_mediums/img_24675726_medium_1483613008_9797_25362.jpg',
   },
   {
-    id: '086_30521602',
-    title: 'Samsung Gear S2',
-    originalPrice: '180.01',
-    currentPrice: '180.01',
-    currentPriceWith10pDiscount: '162.01',
-    previewImageURL: '/b2c/29889537_4485.jpg',
+    id: '021_21081475',
+    title: 'Sony Cyber-shot DSC-W830',
+    originalPrice: '106.80',
   },
   {
-    id: '082_22196536',
-    title: 'TomTom Multi-Sport Cardio',
-    originalPrice: '370.90',
-    currentPrice: '370.90',
-    currentPriceWith10pDiscount: '333.81',
-    previewImageURL: '/img/gallery_mediums/22196536_6541.jpg',
+    id: '139_24699831',
+    title: 'Asus Transformer Book T200TA',
+    originalPrice: '34.54',
   },
+  // product with product references
   {
     id: '138_30046855',
     title: 'Acer TravelMate P258-M',
     originalPrice: '264.32',
-    currentPrice: '264.32',
-    currentPriceWith10pDiscount: '237.89',
-    previewImageURL: '/img/gallery_mediums/30046855_5806.jpg',
+  },
+  // product with discount
+  {
+    id: '095_24235707',
+    title: 'TomTom Golf',
+    originalPrice: '180.00',
+    currentPrice: '179.94',
+    currentPriceWith10pDiscount: '161.95',
+    previewImageURL: '/img/norm/medium/24235707-6105.jpg',
   },
 ];
 

--- a/apps/storefront-e2e/src/types/product.type.ts
+++ b/apps/storefront-e2e/src/types/product.type.ts
@@ -2,7 +2,7 @@ export type TestProductData = {
   id: string;
   title: string;
   originalPrice: string;
-  currentPrice: string;
-  currentPriceWith10pDiscount: string;
+  currentPrice?: string;
+  currentPriceWith10pDiscount?: string;
   previewImageURL?: string;
 };


### PR DESCRIPTION
After the recent BE deployment product data was changed, so we have to use new data in e2e tests