### PR TITLE
chore: fix chromatic job command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           CHROMATIC_SHA: ${{ github.event.pull_request.head.sha }}
           CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: npx nx affected --target=visual-regression-pr
+        run: npx nx run storybook:visual-regression-pr
   test-visual-dev:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
With the enabled Chromatic turbosnap feature, we can run the Chromatic job on each PR and have the UI Review check as a Required check in Actions. 

This will allow us to have better UI regression reviews and not miss defects related to component styles