### PR TITLE
fix: firefox does not handle clicks in navigation's item dropdown

### DIFF
--- a/libs/base/ui/overlays/popover/src/controllers/toggle.controller.spec.ts
+++ b/libs/base/ui/overlays/popover/src/controllers/toggle.controller.spec.ts
@@ -223,6 +223,8 @@ describe('ToggleController', () => {
             element.dispatchEvent(new MouseEvent('mousedown'));
             vi.advanceTimersByTime(301);
             element.dispatchEvent(new MouseEvent('mouseup'));
+            //delay close-popover attr presence check
+            vi.advanceTimersByTime(1);
           });
 
           it('should not hide the popover', () => {
@@ -371,6 +373,8 @@ describe('ToggleController', () => {
             beforeEach(() => {
               vi.advanceTimersByTime(300 + 1);
               element.dispatchEvent(new Event('mouseup', { bubbles: true }));
+              //delay close-popover attr presence check
+              vi.advanceTimersByTime(1);
             });
             it('should not show the popover', () => {
               expect(utils.popover()?.hasAttribute('show')).toBe(false);
@@ -589,7 +593,8 @@ describe('ToggleController', () => {
         button?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
         button?.dispatchEvent(new Event('mouseup', { bubbles: true }));
 
-        vi.advanceTimersByTime(0);
+        //delay close-popover attr presence check
+        vi.advanceTimersByTime(1);
 
         expect(button?.matches(':focus')).toBe(true);
       });

--- a/libs/base/ui/overlays/popover/src/controllers/toggle.controller.ts
+++ b/libs/base/ui/overlays/popover/src/controllers/toggle.controller.ts
@@ -140,9 +140,9 @@ export class ToggleController implements ReactiveController {
     }
   }
 
-  protected handleMouseup(e: MouseEvent): void {
+  protected async handleMouseup(e: MouseEvent): Promise<void> {
     if (
-      this.shouldClosePopover(e) ||
+      (await this.shouldClosePopover(e)) ||
       (timePassed(this.timeStarted) && !this.emitterIsInsidePopover(e))
     ) {
       this.toggle(false);
@@ -174,7 +174,7 @@ export class ToggleController implements ReactiveController {
         break;
       default:
         // avoid toggle the element when the user cmd-tabs away from the browser
-        // or dispatching Tab key
+        // or dispatching Tab keyhandleMouseup
         if (!((e.key === 'Meta' && e.metaKey) || e.key === 'Tab')) {
           this.toggle(true);
         }
@@ -244,8 +244,8 @@ export class ToggleController implements ReactiveController {
     );
   }
 
-  protected shouldClosePopover(e: Event): boolean {
-    return e
+  protected shouldClosePopover(e: Event): Promise<boolean> {
+    const shouldBeClosed = e
       .composedPath()
       .some(
         (element, i, path) =>
@@ -253,6 +253,10 @@ export class ToggleController implements ReactiveController {
           element instanceof Element &&
           element.hasAttribute(CLOSE_POPOVER_ATTR)
       );
+    //add a delay to allow other click handlers being resolved
+    return new Promise((resolve) =>
+      setTimeout(() => resolve(shouldBeClosed), 0)
+    );
   }
 
   protected focusShouldBeFocusedMaybe(): void {

--- a/libs/base/ui/overlays/popover/src/controllers/toggle.controller.ts
+++ b/libs/base/ui/overlays/popover/src/controllers/toggle.controller.ts
@@ -141,14 +141,14 @@ export class ToggleController implements ReactiveController {
   }
 
   protected async handleMouseup(e: MouseEvent): Promise<void> {
+    this.focusShouldBeFocusedMaybe();
+
     if (
       (await this.shouldClosePopover(e)) ||
       (timePassed(this.timeStarted) && !this.emitterIsInsidePopover(e))
     ) {
       this.toggle(false);
     }
-
-    this.focusShouldBeFocusedMaybe();
   }
 
   protected handleKeydown(e: KeyboardEvent): void {


### PR DESCRIPTION
For some reason firefox changed it's behavior and closes the dropdown earlier than click handlers of the items inside be resolved. Fix is adding a delay before close

closes to [HRZ-3029](https://spryker.atlassian.net/browse/HRZ-3029)

[HRZ-3029]: https://spryker.atlassian.net/browse/HRZ-3029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ