### PR TITLE
fix: move margin to slotted content

### DIFF
--- a/libs/base/ui/form/styles/group-item.styles.ts
+++ b/libs/base/ui/form/styles/group-item.styles.ts
@@ -13,7 +13,6 @@ export const groupItemStyles = css`
   label {
     display: contents;
     outline: 0;
-    color: var(--oryx-color-inc);
   }
 
   slot[name='subtext'] {
@@ -22,6 +21,10 @@ export const groupItemStyles = css`
     display: block;
     grid-column: 2 / span 1;
     color: var(--oryx-color-neutral-9);
+  }
+
+  slot[name='subtext']::slotted(*:not(:empty)) {
+    display: block;
     margin-block-start: 4px;
   }
 


### PR DESCRIPTION
As long as https://github.com/w3c/csswg-drafts/issues/6867 is not in place we need to come up with an alternative solution to have conditional margin on slotted elements. 

fixes [HRZ-2960](https://spryker.atlassian.net/browse/HRZ-2960)

[HRZ-2960]: https://spryker.atlassian.net/browse/HRZ-2960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ