### PR TITLE
fix: add escape string to meta service 

### DIFF
--- a/libs/platform/core/server/services/page-meta/server-page-meta.service.ts
+++ b/libs/platform/core/server/services/page-meta/server-page-meta.service.ts
@@ -57,7 +57,8 @@ export class ServerPageMetaService extends DefaultPageMetaService {
 
   protected setAttributes(attrs: ElementAttributes): string {
     return Object.entries(attrs).reduce(
-      (acc, [key, value]) => `${acc} ${key}="${value}"`,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (acc, [key, value]) => `${acc} ${key}="${this.escapeValue(value!)}"`,
       ''
     );
   }

--- a/libs/platform/core/src/services/page-meta/default-page-meta.service.spec.ts
+++ b/libs/platform/core/src/services/page-meta/default-page-meta.service.spec.ts
@@ -54,6 +54,19 @@ describe('DefaultPageMetaService', () => {
       expect(charsetMeta).toHaveProperty('content', 'b');
     });
 
+    it('should escape quote symbol', () => {
+      service.add([
+        {
+          name: 'og:img',
+          attrs: {
+            content: 'a"',
+          },
+        },
+      ]);
+      const imgMeta = document.head.querySelector('meta[name="og:img"]');
+      expect(imgMeta).toHaveProperty('content', 'a&quot;');
+    });
+
     it('should add attributes to the html tag', () => {
       service.add({
         name: 'html',

--- a/libs/platform/core/src/services/page-meta/default-page-meta.service.spec.ts
+++ b/libs/platform/core/src/services/page-meta/default-page-meta.service.spec.ts
@@ -59,12 +59,15 @@ describe('DefaultPageMetaService', () => {
         {
           name: 'og:img',
           attrs: {
-            content: 'a"',
+            content: `a"'–<>—`,
           },
         },
       ]);
       const imgMeta = document.head.querySelector('meta[name="og:img"]');
-      expect(imgMeta).toHaveProperty('content', 'a&quot;');
+      expect(imgMeta).toHaveProperty(
+        'content',
+        'a&quot;&apos;&ndash;&lt;&gt;&mdash;'
+      );
     });
 
     it('should add attributes to the html tag', () => {

--- a/libs/platform/core/src/services/page-meta/default-page-meta.service.ts
+++ b/libs/platform/core/src/services/page-meta/default-page-meta.service.ts
@@ -102,6 +102,13 @@ export class DefaultPageMetaService implements PageMetaService {
   }
 
   protected escapeValue(value: string): string {
-    return value.replace(/"/g, '&quot;');
+    return value
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;')
+      .replace(/'/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/—/g, '&mdash;')
+      .replace(/–/g, '&ndash;');
   }
 }

--- a/libs/platform/core/src/services/page-meta/default-page-meta.service.ts
+++ b/libs/platform/core/src/services/page-meta/default-page-meta.service.ts
@@ -102,6 +102,6 @@ export class DefaultPageMetaService implements PageMetaService {
   }
 
   protected escapeValue(value: string): string {
-    return value.replace(/"/g, '\\$&');
+    return value.replace(/"/g, '&quot;');
   }
 }

--- a/libs/platform/core/src/services/page-meta/default-page-meta.service.ts
+++ b/libs/platform/core/src/services/page-meta/default-page-meta.service.ts
@@ -69,7 +69,7 @@ export class DefaultPageMetaService implements PageMetaService {
       }
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      element.setAttribute(key, value!);
+      element.setAttribute(key, this.escapeValue(value!));
     }
   }
 
@@ -93,10 +93,15 @@ export class DefaultPageMetaService implements PageMetaService {
         continue;
       }
 
-      attrs += `[${key}="${value}"]`;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      attrs += `[${key}="${this.escapeValue(value!)}"]`;
     }
 
     const name = this.getTagName(definition.name);
     return document.head.querySelector(`${name}${attrs}`);
+  }
+
+  protected escapeValue(value: string): string {
+    return value.replace(/"/g, '\\');
   }
 }

--- a/libs/platform/core/src/services/page-meta/default-page-meta.service.ts
+++ b/libs/platform/core/src/services/page-meta/default-page-meta.service.ts
@@ -102,6 +102,6 @@ export class DefaultPageMetaService implements PageMetaService {
   }
 
   protected escapeValue(value: string): string {
-    return value.replace(/"/g, '\\');
+    return value.replace(/"/g, '\\$&');
   }
 }


### PR DESCRIPTION
escapes string in the meta service

closes [HRZ-3137](https://spryker.atlassian.net/browse/HRZ-3137)

[HRZ-3137]: https://spryker.atlassian.net/browse/HRZ-3137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ