### PR TITLE
test: fix some sf e2e test flakiness

### DIFF
--- a/apps/storefront-e2e/src/integration/checkout-addresses.cy.ts
+++ b/apps/storefront-e2e/src/integration/checkout-addresses.cy.ts
@@ -1,4 +1,3 @@
-import { CartPage } from '../support/page_objects/cart.page';
 import { CheckoutPage } from '../support/page_objects/checkout.page';
 import { SCCOSApi } from '../support/sccos_api/sccos.api';
 import { ProductStorage } from '../test-data/product.storage';
@@ -6,7 +5,6 @@ import { TestCustomerData } from '../types/user.type';
 
 let api: SCCOSApi;
 
-const cartPage = new CartPage();
 const checkoutPage = new CheckoutPage();
 
 describe('User addresses', () => {
@@ -35,15 +33,13 @@ describe('User addresses', () => {
             customerCartsResponse.body.data[0].id
           );
         });
-
-        cartPage.visit();
       });
     });
 
     describe('and user does not have addresses yet', () => {
       describe('and user goes to checkout', () => {
         beforeEach(() => {
-          cartPage.checkout();
+          cy.goToCheckout();
         });
 
         it('then shipping address form is shown', () => {
@@ -78,7 +74,7 @@ describe('User addresses', () => {
 
       describe('and user goes to checkout', () => {
         beforeEach(() => {
-          cartPage.checkout();
+          cy.goToCheckout();
         });
 
         it('then the selected address is shown', () => {

--- a/apps/storefront-e2e/src/integration/checkout.cy.ts
+++ b/apps/storefront-e2e/src/integration/checkout.cy.ts
@@ -90,7 +90,7 @@ describe('Checkout suite', { tags: 'smoke' }, () => {
     it('must allow user to create a new order', () => {
       sccosApi.guestCartItems.post(ProductStorage.getProductByEq(4), 1);
 
-      cy.goToCheckout(true);
+      cy.goToCheckoutAsGuest();
       cy.location('pathname').should('be.eq', checkoutPage.anonymousUrl);
 
       checkoutPage.checkoutAsGuestForm.fillForm();

--- a/apps/storefront-e2e/src/integration/checkout.cy.ts
+++ b/apps/storefront-e2e/src/integration/checkout.cy.ts
@@ -40,18 +40,13 @@ describe('Checkout suite', { tags: 'smoke' }, () => {
         sccosApi.cartItems.post(productData, 1, cartId);
       });
 
-      cy.intercept('POST', '/checkout').as('checkout');
-      cy.intercept('/customers/*/addresses').as('addresses');
-
-      cartPage.visit();
-      cartPage.checkout();
-
+      cy.goToCheckout();
       cy.location('pathname').should('be.eq', checkoutPage.url);
-      cy.wait('@addresses');
 
       checkoutPage.shipping.addAddressForm.fillAddressForm();
-      checkoutPage.getPlaceOrderBtn().click();
 
+      cy.intercept('POST', '/checkout').as('checkout');
+      checkoutPage.getPlaceOrderBtn().click();
       cy.wait('@checkout')
         .its('response.body.data.attributes.orderReference')
         .as('createdOrderId');
@@ -95,18 +90,14 @@ describe('Checkout suite', { tags: 'smoke' }, () => {
     it('must allow user to create a new order', () => {
       sccosApi.guestCartItems.post(ProductStorage.getProductByEq(4), 1);
 
-      cy.intercept('POST', '/checkout?include=orders').as('checkout');
-      cy.intercept('/customers/*/addresses').as('addresses');
-
-      cartPage.visit();
-      cartPage.checkout();
-
+      cy.goToCheckout(true);
       cy.location('pathname').should('be.eq', checkoutPage.anonymousUrl);
 
       checkoutPage.checkoutAsGuestForm.fillForm();
       checkoutPage.shipping.addAddressForm.fillAddressForm();
-      checkoutPage.getPlaceOrderBtn().click();
 
+      cy.intercept('POST', '/checkout?include=orders').as('checkout');
+      checkoutPage.getPlaceOrderBtn().click();
       cy.wait('@checkout')
         .its('response.body.data.attributes.orderReference')
         .as('createdOrderId');

--- a/apps/storefront-e2e/src/support/commands.ts
+++ b/apps/storefront-e2e/src/support/commands.ts
@@ -9,7 +9,8 @@ declare global {
   namespace Cypress {
     interface Chainable {
       login(): Chainable<void>;
-      goToCheckout(isGuest?: boolean): Chainable<void>;
+      goToCheckout(): Chainable<void>;
+      goToCheckoutAsGuest(): Chainable<void>;
       waitUpdateComplete(
         element: Cypress.Chainable<JQuery<HTMLElement>>
       ): Chainable<boolean>;
@@ -38,17 +39,26 @@ Cypress.Commands.add('login', () => {
   });
 });
 
-Cypress.Commands.add('goToCheckout', (isGuest = false) => {
+Cypress.Commands.add('goToCheckout', () => {
   const cartPage = new CartPage();
-  const cartApiUrl = isGuest ? '/guest-carts?**' : '/customers/DE--**/carts?**';
 
-  cy.intercept(cartApiUrl).as('cartsRequest');
+  cy.intercept('/customers/DE--**/carts?**').as('cartsRequest');
   cartPage.visit();
   cy.wait('@cartsRequest');
 
   cy.intercept('/customers/*/addresses').as('addressesRequest');
   cartPage.checkout();
   cy.wait('@addressesRequest');
+});
+
+Cypress.Commands.add('goToCheckoutAsGuest', () => {
+  const cartPage = new CartPage();
+
+  cy.intercept('/guest-carts?**').as('cartsRequest');
+  cartPage.visit();
+  cy.wait('@cartsRequest');
+
+  cartPage.checkout();
 });
 
 Cypress.Commands.add('waitUpdateComplete', (element) => {

--- a/apps/storefront-e2e/src/support/page_fragments/add-edit-address-form.fragment.ts
+++ b/apps/storefront-e2e/src/support/page_fragments/add-edit-address-form.fragment.ts
@@ -52,8 +52,8 @@ export class AddEditAddressFormFragment {
 
     this.selectCoutry(address.iso2Code);
     this.selectSalutation(address.salutation);
-    this.getFirstNameInput().type(address.firstName);
-    this.getLastNameInput().type(address.lastName);
+    this.getFirstNameInput().clear().type(address.firstName, { force: true });
+    this.getLastNameInput().clear().type(address.lastName, { force: true });
     this.getCompanyInput().type(address.company);
     this.getAddress1Input().type(address.address1);
     this.getAddress2Input().type(address.address2);

--- a/apps/storefront-e2e/src/support/page_fragments/header.fragment.ts
+++ b/apps/storefront-e2e/src/support/page_fragments/header.fragment.ts
@@ -56,6 +56,8 @@ export class HeaderFragment {
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(500);
     this.getCurrencyButton().click();
-    this.getCurrencySelector().find(`oryx-option[value="${currency}"]`).click();
+    this.getCurrencySelector()
+      .find(`oryx-option[value="${currency}"]`)
+      .click({ force: true });
   };
 }

--- a/apps/storefront-e2e/src/support/page_objects/cart.page.ts
+++ b/apps/storefront-e2e/src/support/page_objects/cart.page.ts
@@ -1,9 +1,17 @@
 import { CartEntryFragment } from '../page_fragments/cart-entry.fragment';
 import { CartTotalsFragment } from '../page_fragments/cart-totals.fragment';
 import { AbstractSFPage } from './abstract.page';
+import { LandingPage } from './landing.page';
 
 export class CartPage extends AbstractSFPage {
   url = '/cart';
+
+  visit(): void {
+    // temporary fix of an issue with the Checkout button click in SSR cart
+    const homePage = new LandingPage();
+    homePage.visit();
+    homePage.header.getCartSummary().click();
+  }
 
   private cartTotals = new CartTotalsFragment();
 


### PR DESCRIPTION
Resolves some SF E2E tests flakiness related to login and checkout failures.
GLUE API interceptors were added + 2 different Cypress Actions for checkout, making code cleaner and more reliable.

Also, there is a workaround for issue 3157 (with Checkout Page not being rendered sometimes) - that should make tests more stable. We will remove it when the issue is fixed.