### PR TITLE
fix: avoid closing the search popover unexpectedly

### DIFF
--- a/libs/base/ui/overlays/popover/src/controllers/toggle.controller.ts
+++ b/libs/base/ui/overlays/popover/src/controllers/toggle.controller.ts
@@ -143,10 +143,10 @@ export class ToggleController implements ReactiveController {
   protected async handleMouseup(e: MouseEvent): Promise<void> {
     this.focusShouldBeFocusedMaybe();
 
-    const outside =
+    const isEmitterOutside =
       timePassed(this.timeStarted) && !this.emitterIsInsidePopover(e);
 
-    if ((await this.shouldClosePopover(e)) || outside) {
+    if ((await this.shouldClosePopover(e)) || isEmitterOutside) {
       this.toggle(false);
     }
   }

--- a/libs/base/ui/overlays/popover/src/controllers/toggle.controller.ts
+++ b/libs/base/ui/overlays/popover/src/controllers/toggle.controller.ts
@@ -143,10 +143,10 @@ export class ToggleController implements ReactiveController {
   protected async handleMouseup(e: MouseEvent): Promise<void> {
     this.focusShouldBeFocusedMaybe();
 
-    if (
-      (await this.shouldClosePopover(e)) ||
-      (timePassed(this.timeStarted) && !this.emitterIsInsidePopover(e))
-    ) {
+    const outside =
+      timePassed(this.timeStarted) && !this.emitterIsInsidePopover(e);
+
+    if ((await this.shouldClosePopover(e)) || outside) {
       this.toggle(false);
     }
   }

--- a/libs/domain/cart/add/src/add.component.ts
+++ b/libs/domain/cart/add/src/add.component.ts
@@ -63,12 +63,17 @@ export class CartAddComponent extends ProductMixin(
     >
       <button
         ?disabled=${this.isInvalid || !this.$hasStock()}
+        @mouseup=${this.onMouseUp}
         @click=${this.onSubmit}
       >
         <oryx-icon .type=${IconTypes.CartAdd} size=${Size.Lg}></oryx-icon>
         ${when(enableLabel, () => html`${i18n('cart.add-to-cart')}`)}
       </button>
     </oryx-button>`;
+  }
+
+  protected onMouseUp(e: Event): void {
+    e.stopPropagation();
   }
 
   @elementEffect()
@@ -110,6 +115,7 @@ export class CartAddComponent extends ProductMixin(
 
   protected onSubmit(e: Event | CustomEvent<QuantityEventDetail>): void {
     e.preventDefault();
+    e.stopPropagation();
     const sku = this.$product()?.sku;
     if (!sku || !this.button) return;
 

--- a/libs/domain/search/src/services/suggestion/renderer/suggestion.renderer.ts
+++ b/libs/domain/search/src/services/suggestion/renderer/suggestion.renderer.ts
@@ -23,6 +23,7 @@ export const productSuggestionRenderer: SuggestionRenderer<Product[]> = (
             button: true,
           }}
           .content=${{ text: i18n('search.box.view-all-products') }}
+          close-popover
         ></oryx-content-link>
       </section>
     `;


### PR DESCRIPTION
The popover no longer closes unexpectedly. When the user clicks inside the search popover, it must only close when a link is clicked. When the user clicks on the layout or interactive elements (i.e. add to cart), the popover must remain open. 

fixes: [HRZ-3163](https://spryker.atlassian.net/browse/HRZ-3163)

[HRZ-3163]: https://spryker.atlassian.net/browse/HRZ-3163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ