### PR TITLE
ci: make test workflow more structured

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,12 @@
-\<Please include a summary of the changes>
+<Please include a summary of the changes>
 
-closes: \<add a Jira ticket link(s) here>
+closes: <Add a Jira ticket link(s) here>
 
-BREAKING CHANGE: \<add a description of breaking change, if any. If there are none - remove this line>
+BREAKING CHANGE: <Add a description of breaking change, if any. If none - remove this line completely>
 
 ---
 
-### Checklist before requesting a review
+### Checklist before requesting a code review
 
 - [ ] PR title is aligned with [PR titles and conventional commits](https://spryker.atlassian.net/wiki/spaces/FA/pages/3821175291/PR+titles+and+conventional+commits)
 - [ ] I have performed a self-review of my code

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,5 +9,4 @@ BREAKING CHANGE: <Add a description of breaking change, if any. If none - remove
 ### Checklist before requesting a code review
 
 - [ ] PR title is aligned with [PR titles and conventional commits](https://spryker.atlassian.net/wiki/spaces/FA/pages/3821175291/PR+titles+and+conventional+commits)
-- [ ] I have performed a self-review of my code
-- [ ] All Actions are green
+- [ ] I have performed a self-review of my code and have fixed all jobs failures

--- a/.github/workflows/test-pr-details.yml
+++ b/.github/workflows/test-pr-details.yml
@@ -1,18 +1,19 @@
 name: Test PR details workflow
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 on:
   # Triggers the workflow on pull request events
   pull_request:
-    - opened
-    - synchronize
-    - edited
-    - reopened
+    types:
+      - opened
+      - synchronize
+      - edited
+      - reopened
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-pr-title:

--- a/.github/workflows/test-pr-details.yml
+++ b/.github/workflows/test-pr-details.yml
@@ -1,0 +1,34 @@
+name: Test PR details workflow
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  # Triggers the workflow on pull request events
+  pull_request:
+    - opened
+    - synchronize
+    - edited
+    - reopened
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  test-pr-title:
+    permissions:
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aslafy-z/conventional-pr-title-action@v3
+        with:
+          preset: conventional-changelog-conventionalcommits@5.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  test-pr-checklist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/require-checklist-action@v2
+        with:
+          requireChecklist: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ env:
   IS_DEV: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/development' }}
 
 jobs:
+  # TODO - run this job when PR is edited
   test-pr-title:
     if: github.event_name == 'pull_request'
     permissions:
@@ -33,6 +34,9 @@ jobs:
 
   test-format:
     runs-on: ubuntu-latest
+    needs: [test-pr-title]
+    if: |
+      needs.test-pr-title.result == 'success' || needs.test-pr-title.result == 'skipped'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -44,6 +48,9 @@ jobs:
 
   test-lint:
     runs-on: ubuntu-latest
+    needs: [test-pr-title]
+    if: |
+      needs.test-pr-title.result == 'success' || needs.test-pr-title.result == 'skipped'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -59,6 +66,9 @@ jobs:
 
   test-stylelint:
     runs-on: ubuntu-latest
+    needs: [test-pr-title]
+    if: |
+      needs.test-pr-title.result == 'success' || needs.test-pr-title.result == 'skipped'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -74,6 +84,9 @@ jobs:
 
   test-tsconfig:
     runs-on: ubuntu-latest
+    needs: [test-pr-title]
+    if: |
+      needs.test-pr-title.result == 'success' || needs.test-pr-title.result == 'skipped'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -89,6 +102,7 @@ jobs:
 
   test-unit:
     runs-on: ubuntu-latest
+    needs: [test-format, test-lint, test-stylelint, test-tsconfig]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -107,8 +121,9 @@ jobs:
           isDev: ${{ env.IS_DEV }}
 
   test-visual-pr:
-    if: ${{ github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
+    needs: [test-format, test-lint, test-stylelint, test-tsconfig]
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -123,8 +138,9 @@ jobs:
         run: npx nx run storybook:visual-regression-pr
 
   test-visual-dev:
-    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
+    needs: [test-format, test-lint, test-stylelint, test-tsconfig]
+    if: ${{ github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -139,8 +155,8 @@ jobs:
         run: npx nx run storybook:visual-regression-branch
 
   test-e2e-storefront:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
+    needs: [test-format, test-lint, test-stylelint, test-tsconfig]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -159,8 +175,8 @@ jobs:
           isDev: ${{ env.IS_DEV }}
 
   test-e2e-fulfillment:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
+    needs: [test-format, test-lint, test-stylelint, test-tsconfig]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -180,6 +196,7 @@ jobs:
 
   test-build:
     runs-on: ubuntu-latest
+    needs: [test-format, test-lint, test-stylelint, test-tsconfig]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,24 +19,8 @@ env:
   IS_DEV: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/development' }}
 
 jobs:
-  # TODO - run this job when PR is edited
-  test-pr-title:
-    if: github.event_name == 'pull_request'
-    permissions:
-      statuses: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: aslafy-z/conventional-pr-title-action@v3
-        with:
-          preset: conventional-changelog-conventionalcommits@5.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-
   test-format:
     runs-on: ubuntu-latest
-    needs: [test-pr-title]
-    if: |
-      needs.test-pr-title.result == 'success' || needs.test-pr-title.result == 'skipped'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -48,9 +32,6 @@ jobs:
 
   test-lint:
     runs-on: ubuntu-latest
-    needs: [test-pr-title]
-    if: |
-      needs.test-pr-title.result == 'success' || needs.test-pr-title.result == 'skipped'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -66,9 +47,6 @@ jobs:
 
   test-stylelint:
     runs-on: ubuntu-latest
-    needs: [test-pr-title]
-    if: |
-      needs.test-pr-title.result == 'success' || needs.test-pr-title.result == 'skipped'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -84,9 +62,6 @@ jobs:
 
   test-tsconfig:
     runs-on: ubuntu-latest
-    needs: [test-pr-title]
-    if: |
-      needs.test-pr-title.result == 'success' || needs.test-pr-title.result == 'skipped'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Makes CI workflow more structured and organized, introduces a FAIL-FAST approach to checks and **reduces Cypress / Chromatic usage and costs**. Also, PR-creation rules are extracted in a separate workflow which is triggered not only on PR creation but also when the PR details (aka title / description / labels are edited).

---

From now we run heavy tests (e2e/ui regression) only if static **code analysis jobs are green**. 
Regarding smoke tests - they will be run on Netlify if the build and deployment succeed.

In the future, we might have another build step in the workflow to be sure that our packages/projects can be built successfully before any tests start.

 ---

closes: -

---

### Checklist before requesting a review

- [x] PR title is aligned with [PR titles and conventional commits](https://spryker.atlassian.net/wiki/spaces/FA/pages/3821175291/PR+titles+and+conventional+commits)
- [x] I have performed a self-review of my code
