### PR TITLE
test: reduce the number of retries for sf e2es

### DIFF
--- a/apps/storefront-e2e/cypress.ci.config.js
+++ b/apps/storefront-e2e/cypress.ci.config.js
@@ -4,5 +4,5 @@ const config = require('./cypress.config');
 module.exports = defineConfig({
   ...config,
   projectId: 'eothcy',
-  retries: 2,
+  retries: 1,
 });


### PR DESCRIPTION
To reduce the time for SF e2e run we have to reduce the number of retries for failed tests. Still, we will be able to detect flaky tests and fails, however, we will have the test results faster. 

closes: -

---

### Checklist before requesting a code review

- [x] PR title is aligned with [PR titles and conventional commits](https://spryker.atlassian.net/wiki/spaces/FA/pages/3821175291/PR+titles+and+conventional+commits)
- [x] I have performed a self-review of my code and have fixed all jobs failures
