### PR TITLE
ci: fixes smoke tests grouping error in netlify

### DIFF
--- a/tools/netlify-plugins/cypress-tests-runner/index.js
+++ b/tools/netlify-plugins/cypress-tests-runner/index.js
@@ -14,6 +14,8 @@ export const onSuccess = ({ inputs }) => {
   process.env.CYPRESS_BASE_URL = deployURL;
   process.env.CYPRESS_BUILD_ID = process.env.BUILD_ID;
 
+  console.log(process.env)
+
   // sync call is needed here, because if async is used -> netlify will kill child process
   // when the main process is over
   const childProcess = spawnSync('npx', ['nx', 'run', nxRunCommand], { stdio: 'inherit' });

--- a/tools/netlify-plugins/cypress-tests-runner/index.js
+++ b/tools/netlify-plugins/cypress-tests-runner/index.js
@@ -24,7 +24,7 @@ function updateCypressConfig(buildId, baseUrl) {
   console.log(`Deployed site URL: ${baseUrl}`);
   console.log(`Deployed build id: ${buildId}`);
 
-  const pathToProjectConfig = '../../../apps/storefront-e2e/project.json';
+  const pathToProjectConfig = '../../apps/storefront-e2e/project.json';
   const config = JSON.parse(readFileSync(pathToProjectConfig, 'utf8'));
 
   config.targets.e2e.configurations['headless-ci-smoke'].ciBuildId = buildId;

--- a/tools/netlify-plugins/cypress-tests-runner/index.js
+++ b/tools/netlify-plugins/cypress-tests-runner/index.js
@@ -1,24 +1,53 @@
 import { spawnSync } from 'child_process';
+import { readFileSync, writeFileSync } from 'fs';
 
 export const onSuccess = ({ inputs }) => {
   const { nxRunCommand } = inputs;
   const deployURL = process.env.DEPLOY_PRIME_URL;
+  const buildId = process.env.BUILD_ID;
 
-  console.log(`Deployed site URL: ${deployURL}`);
+  updateCypressConfig(buildId, deployURL);
+  executeNxCommand(nxRunCommand);
+};
+
+/**
+ * To be able to run smoke tests and have nice results in PR comments
+ * we have to pass deployed site url and build id to cypress
+ *
+ * it is not possible to do so using env variables, so we have to
+ * modify nx config a bit to add/edit missing values
+ *
+ * @param {string} buildId
+ * @param {string} baseUrl
+ */
+function updateCypressConfig(buildId, baseUrl) {
+  console.log(`Deployed site URL: ${baseUrl}`);
+  console.log(`Deployed build id: ${buildId}`);
+
+  const pathToProjectConfig = '../../../apps/storefront-e2e/project.json';
+  const config = JSON.parse(readFileSync(pathToProjectConfig, 'utf8'));
+
+  config.targets.e2e.configurations['headless-ci-smoke'].ciBuildId = buildId;
+  config.targets.e2e.configurations['headless-ci-smoke'].baseUrl = baseUrl;
+
+  writeFileSync(pathToProjectConfig, JSON.stringify(config, null, 2));
+}
+
+/**
+ * Executes given nx command from the root of the repository
+ *
+ * @param {string} nxRunCommand
+ */
+function executeNxCommand(nxRunCommand) {
   console.log(`Executing "npm run ${nxRunCommand}"...`);
 
-  // go to the root directory
   process.chdir('../../');
 
-  // override default Cypress variables
-  process.env.CYPRESS_BASE_URL = deployURL;
-  process.env.CYPRESS_BUILD_ID = process.env.BUILD_ID;
-
-  console.log(process.env)
-
   // sync call is needed here, because if async is used -> netlify will kill child process
-  // when the main process is over
-  const childProcess = spawnSync('npx', ['nx', 'run', nxRunCommand], { stdio: 'inherit' });
+  // when the main process is finished
+  const childProcess = spawnSync('npx', ['nx', 'run', nxRunCommand], {
+    stdio: 'inherit',
+  });
 
   if (childProcess.status === 0) {
     console.log(`"npx nx run ${nxRunCommand}" completed successfully.`);
@@ -26,4 +55,4 @@ export const onSuccess = ({ inputs }) => {
     console.error(`"npx nx run ${nxRunCommand}" failed.`);
     console.error(childProcess.error);
   }
-};
+}

--- a/tools/netlify-plugins/cypress-tests-runner/index.js
+++ b/tools/netlify-plugins/cypress-tests-runner/index.js
@@ -12,6 +12,7 @@ export const onSuccess = ({ inputs }) => {
 
   // override default Cypress variables
   process.env.CYPRESS_BASE_URL = deployURL;
+  process.env.CYPRESS_BUILD_ID = process.env.BUILD_ID;
 
   // sync call is needed here, because if async is used -> netlify will kill child process
   // when the main process is over


### PR DESCRIPTION
Fixes an issue with smoke tests run after adding grouping https://github.com/spryker/oryx/pull/563 
Cypress can't pick up build id on Netlify automatically, so we have to set that variable

closes: -

---

### Checklist before requesting a code review

- [x] PR title is aligned with [PR titles and conventional commits](https://spryker.atlassian.net/wiki/spaces/FA/pages/3821175291/PR+titles+and+conventional+commits)
- [x] I have performed a self-review of my code and have fixed all jobs failures
