### PR TITLE
test: refactor wait for loaded methods

### DIFF
--- a/apps/storefront-e2e/src/support/page_objects/abstract.page.ts
+++ b/apps/storefront-e2e/src/support/page_objects/abstract.page.ts
@@ -13,6 +13,7 @@ export abstract class AbstractSFPage {
     }
 
     cy.visit(this.url);
+    this.waitForLoaded();
   }
 
   header = new HeaderFragment();
@@ -21,21 +22,11 @@ export abstract class AbstractSFPage {
 
   /**
    * Method should contain a check that will be TRUE
-   * when concrete page was successfully rendered in SPA mode
+   * when concrete page was successfully rendered
    *
    * It might be a simple element.should('be.visible') check
    * or something more complicated, like API requests interception
    * or Page Fragments initialization checks
    */
-  abstract waitForLoadedSPA(): void;
-
-  /**
-   * Method should contain a check that will be TRUE
-   * when concrete page was successfully rendered in SSR mode
-   *
-   * It might be a simple element.should('be.visible') check
-   * or something more complicated, like API requests interception
-   * or Page Fragments initialization checks
-   */
-  abstract waitForLoadedSSR(): void;
+  abstract waitForLoaded(): void;
 }

--- a/apps/storefront-e2e/src/support/page_objects/cart.page.ts
+++ b/apps/storefront-e2e/src/support/page_objects/cart.page.ts
@@ -11,17 +11,14 @@ export class CartPage extends AbstractSFPage {
     const homePage = new LandingPage();
     homePage.visit();
     homePage.header.getCartSummary().click();
+
+    this.waitForLoaded();
   }
 
   private cartTotals = new CartTotalsFragment();
 
-  waitForLoadedSSR(): void {
+  waitForLoaded(): void {
     this.getCartEntriesWrapper().should('be.visible');
-  }
-
-  waitForLoadedSPA(): void {
-    // TODO: add move accurate check
-    this.waitForLoadedSSR();
   }
 
   getCartEntriesWrapper = () => cy.get('oryx-cart-entries');

--- a/apps/storefront-e2e/src/support/page_objects/category.page.ts
+++ b/apps/storefront-e2e/src/support/page_objects/category.page.ts
@@ -13,12 +13,8 @@ export class CategoryPage extends AbstractSFPage {
     }
   }
 
-  waitForLoadedSSR(): void {
+  waitForLoaded(): void {
     this.getFacets().should('be.visible');
-  }
-
-  waitForLoadedSPA(): void {
-    this.waitForLoadedSSR();
   }
 
   getFacets = () => cy.get('oryx-search-facet');

--- a/apps/storefront-e2e/src/support/page_objects/checkout.page.ts
+++ b/apps/storefront-e2e/src/support/page_objects/checkout.page.ts
@@ -9,12 +9,8 @@ export class CheckoutPage extends AbstractSFPage {
   url = '/checkout';
   anonymousUrl = '/checkout';
 
-  waitForLoadedSPA(): void {
+  waitForLoaded(): void {
     this.getCartTotals.getTotalPrice().should('be.visible');
-  }
-
-  waitForLoadedSSR(): void {
-    this.waitForLoadedSPA();
   }
 
   checkoutAsGuestForm = new CheckoutAsGuestFormFragment();

--- a/apps/storefront-e2e/src/support/page_objects/contact.page.ts
+++ b/apps/storefront-e2e/src/support/page_objects/contact.page.ts
@@ -3,12 +3,8 @@ import { AbstractSFPage } from './abstract.page';
 export class ContactPage extends AbstractSFPage {
   url = '/contact';
 
-  waitForLoadedSSR(): void {
+  waitForLoaded(): void {
     this.getHeading().should('be.visible');
-  }
-
-  waitForLoadedSPA(): void {
-    this.waitForLoadedSSR();
   }
 
   getHeading = () => cy.contains('This is Contact Page element.');

--- a/apps/storefront-e2e/src/support/page_objects/landing.page.ts
+++ b/apps/storefront-e2e/src/support/page_objects/landing.page.ts
@@ -3,12 +3,8 @@ import { AbstractSFPage } from './abstract.page';
 export class LandingPage extends AbstractSFPage {
   url = '/';
 
-  waitForLoadedSSR(): void {
+  waitForLoaded(): void {
     this.getVideo().should('be.visible');
-  }
-
-  waitForLoadedSPA(): void {
-    this.waitForLoadedSSR();
   }
 
   getVideo = () => cy.get('oryx-video');

--- a/apps/storefront-e2e/src/support/page_objects/login.page.ts
+++ b/apps/storefront-e2e/src/support/page_objects/login.page.ts
@@ -4,12 +4,8 @@ import { AbstractSFPage } from './abstract.page';
 export class LoginPage extends AbstractSFPage {
   url = '/login';
 
-  waitForLoadedSSR(): void {
+  waitForLoaded(): void {
     this.loginForm.getWrapper().should('be.visible');
-  }
-
-  waitForLoadedSPA(): void {
-    this.waitForLoadedSSR();
   }
 
   loginForm = new LoginFragment();

--- a/apps/storefront-e2e/src/support/page_objects/product-details.page.ts
+++ b/apps/storefront-e2e/src/support/page_objects/product-details.page.ts
@@ -17,15 +17,8 @@ export class ProductDetailsPage extends AbstractSFPage {
     }
   }
 
-  waitForLoadedSSR(): void {
-    this.getQuantityComponent()
-      .getInput()
-      .should('be.visible')
-      .and('be.enabled');
-  }
-
-  waitForLoadedSPA(): void {
-    this.waitForLoadedSSR();
+  waitForLoaded(): void {
+    this.getQuantityComponent().getInput().should('be.visible');
   }
 
   hydrateAddToCart = () => {

--- a/apps/storefront-e2e/src/support/page_objects/search.page.ts
+++ b/apps/storefront-e2e/src/support/page_objects/search.page.ts
@@ -16,12 +16,8 @@ export class SearchPage extends AbstractSFPage {
     }
   }
 
-  waitForLoadedSSR(): void {
+  waitForLoaded(): void {
     this.getFacets().should('be.visible');
-  }
-
-  waitForLoadedSPA(): void {
-    this.waitForLoadedSSR();
   }
 
   getFacets = () => cy.get('oryx-search-facet');

--- a/apps/storefront-e2e/src/support/page_objects/thank-you.page.ts
+++ b/apps/storefront-e2e/src/support/page_objects/thank-you.page.ts
@@ -9,11 +9,7 @@ export class ThankYouPage extends AbstractSFPage {
     this.url = `/order/${orderId}`;
   }
 
-  waitForLoadedSPA(): void {
-    this.waitForLoadedSSR();
-  }
-
-  waitForLoadedSSR(): void {
+  waitForLoaded(): void {
     this.getHeading().should('be.visible');
   }
 


### PR DESCRIPTION
Replaces 2 different waitForLoaded methods with a generic one. This change is needed for further refactoring related to sessions and tests speedup.

closes: -