### PR TITLE
fix(order): Order confirmation page layout requires margin before footer

### DIFF
--- a/libs/domain/order/summary/summary.styles.ts
+++ b/libs/domain/order/summary/summary.styles.ts
@@ -18,7 +18,7 @@ export const orderSummaryStyles = css`
   }
 
   h2 {
-    margin: 32px 0;
+    margin-block-end: 32px;
   }
 
   section {

--- a/libs/template/presets/storefront/experience/pages/index.ts
+++ b/libs/template/presets/storefront/experience/pages/index.ts
@@ -5,6 +5,6 @@ export * from './contact-page';
 export * from './home-page';
 export * from './login-page';
 export * from './my-account';
-export * from './order-page';
+export * from './order-confirmation-page';
 export * from './product-page';
 export * from './search-page';

--- a/libs/template/presets/storefront/experience/pages/order-confirmation-page.ts
+++ b/libs/template/presets/storefront/experience/pages/order-confirmation-page.ts
@@ -13,7 +13,7 @@ export const orderPage: StaticComponent = {
     {
       type: 'oryx-composition',
       options: {
-        data: { rules: [{ layout: 'split-column', splitColumnFactor: 2 / 3 }] },
+        data: { rules: [{ layout: 'split-main', padding: '30px 0' }] },
       },
       components: [
         {


### PR DESCRIPTION
The order confirmation layout had a few small glitches. There was no bottom margin as well as the split layout was not following the latest version. 

closes: [HRZ-3169](https://spryker.atlassian.net/browse/HRZ-3169)

[HRZ-3169]: https://spryker.atlassian.net/browse/HRZ-3169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ