### PR TITLE
fix(presets): centered search box

### DIFF
--- a/libs/domain/site/navigation-button/navigation-button.component.ts
+++ b/libs/domain/site/navigation-button/navigation-button.component.ts
@@ -35,7 +35,10 @@ export class NavigationButtonComponent extends ContentMixin<NavigationButtonAttr
       <oryx-button>
         ${when(
           this.url,
-          () => html`<a href=${this.url!}>${innerContent}</a>`,
+          () =>
+            html`<a href=${this.url!} aria-label=${this.text}
+              >${innerContent}</a
+            >`,
           () => html`<button>${innerContent}</button>`
         )}
       </oryx-button>

--- a/libs/template/presets/storefront/experience/header.ts
+++ b/libs/template/presets/storefront/experience/header.ts
@@ -59,8 +59,12 @@ export const HeaderTemplate: StaticComponent = {
           content: { data: { graphic: 'logo' } },
           options: {
             data: {
-              rules: [{ width: 'max-content', height: '42px' }],
+              rules: [
+                { colSpan: 3, height: '42px' },
+                { query: { breakpoint: 'md' }, colSpan: 2 },
+              ],
               link: '/',
+              linkLabel: 'Spryker logo',
             },
           },
         },
@@ -68,30 +72,46 @@ export const HeaderTemplate: StaticComponent = {
           type: 'oryx-search-box',
           options: {
             data: {
-              rules: [{ margin: 'auto', width: '580px' }],
+              rules: [
+                { colSpan: 6, width: 'auto' },
+                { query: { breakpoint: 'md' }, colSpan: 4 },
+              ],
             },
           },
         },
         {
-          type: 'oryx-site-navigation-item',
-          options: {
-            data: {
-              contentBehavior: 'dropdown',
-              label: 'USER.NAME',
-              icon: IconTypes.User,
+          type: 'oryx-composition',
+          components: [
+            {
+              type: 'oryx-site-navigation-item',
+              options: {
+                data: {
+                  contentBehavior: 'dropdown',
+                  label: 'USER.NAME',
+                  icon: IconTypes.User,
+                },
+              },
+              components: [{ type: 'oryx-auth-login-link' }],
             },
-          },
-          components: [{ type: 'oryx-auth-login-link' }],
-        },
-        {
-          type: 'oryx-site-navigation-item',
-          id: 'mini-cart',
+            {
+              type: 'oryx-site-navigation-item',
+              id: 'mini-cart',
+              options: {
+                data: {
+                  label: 'cart',
+                  badge: 'CART.SUMMARY',
+                  icon: IconTypes.Cart,
+                  url: { type: 'cart' },
+                },
+              },
+            },
+          ],
           options: {
             data: {
-              label: 'cart',
-              badge: 'CART.SUMMARY',
-              icon: IconTypes.Cart,
-              url: { type: 'cart' },
+              rules: [
+                { colSpan: 3, layout: 'flex', justify: 'end' },
+                { query: { breakpoint: 'md' }, colSpan: 2 },
+              ],
             },
           },
         },
@@ -100,10 +120,10 @@ export const HeaderTemplate: StaticComponent = {
         data: {
           rules: [
             {
-              layout: 'flex',
+              layout: 'column',
               background: 'var(--oryx-color-primary-9)',
               align: 'center',
-              zIndex: '2',
+              zIndex: '1',
               padding: '5px 0',
               gap: '5px',
               sticky: true,

--- a/libs/template/presets/storefront/experience/pages/home-page.ts
+++ b/libs/template/presets/storefront/experience/pages/home-page.ts
@@ -4,7 +4,7 @@ const brand = (name: string, rules?: any) => ({
   type: 'oryx-content-banner',
   name,
   content: { data: { graphic: name } },
-  options: { data: { link: `/search?q=${name}`, rules } },
+  options: { data: { link: `/search?q=${name}`, linkLabel: name, rules } },
 });
 
 export const homePage: StaticComponent = {


### PR DESCRIPTION
We've changed the layout of the header so that the search box is centered  and aligned with the grid system. It takes 6 columns (out of 12) on desktop, and 4 columns (out of 8) on tablet.

closes: [HRZ-3213](https://spryker.atlassian.net/browse/HRZ-3213)

[HRZ-3213]: https://spryker.atlassian.net/browse/HRZ-3213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ