### PR TITLE
test: add an ability to login with api call

### DIFF
--- a/apps/storefront-e2e/src/fixtures/users.json
+++ b/apps/storefront-e2e/src/fixtures/users.json
@@ -1,0 +1,158 @@
+[
+  {
+    "id": "DE--1",
+    "email": "spencor.hopkin@spryker.com",
+    "name": "Spencor",
+    "password": "change123"
+  },
+  {
+    "id": "DE--2",
+    "email": "maria.williams@spryker.com",
+    "name": "Maria",
+    "password": "change123"
+  },
+  {
+    "id": "DE--3",
+    "email": "maggie.may@spryker.com",
+    "name": "Maggie",
+    "password": "change123"
+  },
+  {
+    "id": "DE--4",
+    "email": "bill.martin@spryker.com",
+    "name": "Bill",
+    "password": "change123"
+  },
+  {
+    "id": "DE--5",
+    "email": "george.freeman@spryker.com",
+    "name": "George",
+    "password": "change123"
+  },
+  {
+    "id": "DE--6",
+    "email": "henry.tudor@spryker.com",
+    "name": "Henry",
+    "password": "change123"
+  },
+  {
+    "id": "DE--7",
+    "email": "anne.boleyn@spryker.com",
+    "name": "Anne",
+    "password": "change123"
+  },
+  {
+    "id": "DE--8",
+    "email": "andrew@ottom.de",
+    "name": "Andrew",
+    "password": "change123"
+  },
+  {
+    "id": "DE--9",
+    "email": "Ahill@ottom.de",
+    "name": "Ahill",
+    "password": "change123"
+  },
+  {
+    "id": "DE--10",
+    "email": "Alexa@ottom.de",
+    "name": "Alexa",
+    "password": "change123"
+  },
+  {
+    "id": "DE--11",
+    "email": "Frida@ottom.de",
+    "name": "Frida",
+    "password": "change123"
+  },
+  {
+    "id": "DE--12",
+    "email": "Lisa@ottom.de",
+    "name": "Lisa",
+    "password": "change123"
+  },
+  {
+    "id": "DE--13",
+    "email": "Kim@ottom.de",
+    "name": "Kim",
+    "password": "change123"
+  },
+  {
+    "id": "DE--14",
+    "email": "Solomon@spryker.com",
+    "name": "Solomon",
+    "password": "change123"
+  },
+  {
+    "id": "DE--15",
+    "email": "Richi@spryker.com",
+    "name": "Armando",
+    "password": "change123"
+  },
+  {
+    "id": "DE--16",
+    "email": "karl@spryker.com",
+    "name": "Karl",
+    "password": "change123"
+  },
+  {
+    "id": "DE--17",
+    "email": "Sarah@spryker.com",
+    "name": "Sarah",
+    "password": "change123"
+  },
+  {
+    "id": "DE--18",
+    "email": "Elizabet@spryker.com",
+    "name": "Elizabet",
+    "password": "change123"
+  },
+  {
+    "id": "DE--19",
+    "email": "donald@spryker.com",
+    "name": "Donald",
+    "password": "change123"
+  },
+  {
+    "id": "DE--20",
+    "email": "Trever.m@spryker.com",
+    "name": "Trever",
+    "password": "change123"
+  },
+  {
+    "id": "DE--21",
+    "email": "sonia@spryker.com",
+    "name": "Sonia",
+    "password": "change123"
+  },
+  {
+    "id": "DE--30",
+    "email": "Lilu@ottom.de",
+    "name": "Lilu",
+    "password": "change123"
+  },
+  {
+    "id": "DE--31",
+    "email": "arnold@spryker.com",
+    "name": "Arnold",
+    "password": "change123"
+  },
+  {
+    "id": "DE--32",
+    "email": "sally@ottom.de",
+    "name": "Sally",
+    "password": "change123"
+  },
+  {
+    "id": "DE--33",
+    "email": "kevin@spryker.com",
+    "name": "Kevin",
+    "password": "change123"
+  },
+  {
+    "id": "DE--34",
+    "email": "emma@spryker.com",
+    "name": "Emma",
+    "password": "change123"
+  }
+]

--- a/apps/storefront-e2e/src/integration/checkout-addresses.cy.ts
+++ b/apps/storefront-e2e/src/integration/checkout-addresses.cy.ts
@@ -36,7 +36,7 @@ describe('User addresses suite', () => {
     beforeEach(() => {
       api = new SCCOSApi();
 
-      cy.login();
+      cy.loginApi();
 
       cy.fixture<TestCustomerData>('test-customer').then((customer) => {
         cy.customerCartsCleanup(api, customer);

--- a/apps/storefront-e2e/src/integration/checkout.cy.ts
+++ b/apps/storefront-e2e/src/integration/checkout.cy.ts
@@ -16,7 +16,7 @@ const checkoutPage = new CheckoutPage();
 describe('Checkout suite', { tags: 'smoke' }, () => {
   describe('Create a new order by authorized user without addresses', () => {
     beforeEach(() => {
-      cy.login();
+      cy.loginApi();
 
       sccosApi = new SCCOSApi();
 

--- a/apps/storefront-e2e/src/support/commands.ts
+++ b/apps/storefront-e2e/src/support/commands.ts
@@ -9,6 +9,7 @@ declare global {
   namespace Cypress {
     interface Chainable {
       login(): Chainable<void>;
+      loginApi(): Chainable<void>;
       goToCheckout(): Chainable<void>;
       goToCheckoutAsGuest(): Chainable<void>;
       waitUpdateComplete(
@@ -36,6 +37,22 @@ Cypress.Commands.add('login', () => {
     cy.wait('@profileRequest');
 
     loginPage.header.getUserSummaryHeading().should('contain', customer.name);
+  });
+});
+
+Cypress.Commands.add('loginApi', () => {
+  cy.fixture<TestCustomerData>('test-customer').then((customer) => {
+    const api = new SCCOSApi();
+
+    api.token.post(customer).then((res) => {
+      cy.window().then((win) => {
+        win.localStorage.setItem(
+          'oryx.oauth-state',
+          '{"authorizedBy":"spryker"}'
+        );
+        win.localStorage.setItem('oryx.oauth-token', JSON.stringify(res.body));
+      });
+    });
   });
 });
 

--- a/apps/storefront-e2e/src/support/index.ts
+++ b/apps/storefront-e2e/src/support/index.ts
@@ -1,36 +1,8 @@
 import './commands';
-import { SCCOSApi } from './sccos_api/sccos.api';
 import registerCypressGrep from '@cypress/grep/src/support';
+import { TestCustomerData } from '../types/user.type';
 
 registerCypressGrep();
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const createAUserBeforeTestsAreRun = () => {
-  const api = new SCCOSApi();
-  const email = `test-user-${Math.random()}@spryker.com`;
-
-  api.customer.post({
-    data: {
-      type: 'customers',
-      attributes: {
-        firstName: 'Test',
-        lastName: 'User',
-        salutation: 'Mr',
-        gender: 'Male',
-        email,
-        password: 'change123',
-        confirmPassword: 'change123',
-        acceptedTerms: true,
-      },
-    },
-  });
-
-  cy.wrap({
-    email,
-    password: 'change123',
-    name: 'Test',
-  }).as('testCustomer');
-};
 
 const removeUselessLogsFromCypressLogs = () => {
   const origLog = Cypress.log;
@@ -55,84 +27,15 @@ const removeUselessLogsFromCypressLogs = () => {
 };
 
 const getRandomCustomer = () => {
-  const customers = [
-    {
-      id: 'DE--1',
-      name: 'Spencor',
-      email: 'spencor.hopkin@spryker.com',
-      password: 'change123',
-    },
-    {
-      id: 'DE--2',
-      name: 'Maria',
-      email: 'maria.williams@spryker.com',
-      password: 'change123',
-    },
-    {
-      id: 'DE--3',
-      name: 'Maggie',
-      email: 'maggie.may@spryker.com',
-      password: 'change123',
-    },
-    {
-      id: 'DE--8',
-      name: 'Andrew',
-      email: 'andrew@ottom.de',
-      password: 'change123',
-    },
-    {
-      id: 'DE--10',
-      name: 'Alexa',
-      email: 'Alexa@ottom.de',
-      password: 'change123',
-    },
-    {
-      id: 'DE--13',
-      name: 'Kim',
-      email: 'Kim@ottom.de',
-      password: 'change123',
-    },
-    {
-      id: 'DE--15',
-      name: 'Armando',
-      email: 'Richi@spryker.com',
-      password: 'change123',
-    },
-    {
-      id: 'DE--19',
-      name: 'Donald',
-      email: 'donald@spryker.com',
-      password: 'change123',
-    },
-    {
-      id: 'DE--31',
-      name: 'Arnold',
-      email: 'arnold@spryker.com',
-      password: 'change123',
-    },
-    {
-      id: 'DE--33',
-      name: 'Kevin',
-      email: 'kevin@spryker.com',
-      password: 'change123',
-    },
-  ];
+  cy.fixture('users').then((users: TestCustomerData[]) => {
+    const randomUser = users[Math.floor(Math.random() * users.length)];
+    const path = './src/fixtures/test-customer.json';
 
-  const randomCustomer =
-    customers[Math.floor(Math.random() * customers.length)];
-  cy.writeFile(
-    './src/fixtures/test-customer.json',
-    JSON.stringify(randomCustomer)
-  );
+    cy.writeFile(path, JSON.stringify(randomUser));
+  });
 };
 
 before(() => {
   removeUselessLogsFromCypressLogs();
-  // customer creation is blocked by BE error
-  // that's why we will use random customers which is not perfect
-  // but will resolve our concurency issue in 95% of cases
-  //
-  // TODO: uncomment when BE issue is fixed, and remove randomizer
-  // createAUserBeforeTestsAreRun()
   getRandomCustomer();
 });

--- a/apps/storefront-e2e/src/support/sccos_api/sccos.api.ts
+++ b/apps/storefront-e2e/src/support/sccos_api/sccos.api.ts
@@ -1,5 +1,6 @@
 import { defaultAddress } from '../../test-data/default-address';
 import { TestProductData } from '../../types/product.type';
+import { TestCustomerData } from '../../types/user.type';
 
 export type ApiResponse<T> = {
   data: T;
@@ -13,22 +14,6 @@ export type CartData = {
   id: string;
   attributes: {
     name: string;
-  };
-};
-
-export type CustomersBody = {
-  data: {
-    type: 'customers';
-    attributes: {
-      firstName: string;
-      lastName: string;
-      salutation: string;
-      gender: string;
-      email: string;
-      password: string;
-      confirmPassword: string;
-      acceptedTerms: boolean;
-    };
   };
 };
 
@@ -243,14 +228,20 @@ export class SCCOSApi {
     },
   };
 
-  customer = {
-    post: (body: CustomersBody) => {
+  token = {
+    post: (user: TestCustomerData) => {
+      cy.log('SCCOSApi | POST token');
+
       return cy.request({
         method: 'POST',
-        url: `${this.apiUrl}/customers`,
+        url: `${this.apiUrl}/token`,
         headers: this.headers,
-        body,
-        failOnStatusCode: false,
+        form: true,
+        body: {
+          username: user.email,
+          password: user.password,
+          grant_type: 'password',
+        },
       });
     },
   };


### PR DESCRIPTION
1. Adds an ability to login in SF using an API call in e2e tests, improves test speed
2. The list of test customers is extended, which should make tests more stable and less flaky
3. Customer registration logic is removed, as it does not work (and won't work in the nearest future)

closes: https://spryker.atlassian.net/browse/HRZ-3219
