### PR TITLE
refactor: context selector is hidden behind the header

### DIFF
--- a/libs/platform/experience/composition/src/composition-preview.component.ts
+++ b/libs/platform/experience/composition/src/composition-preview.component.ts
@@ -18,15 +18,12 @@ import {
 } from 'rxjs';
 
 import { CompositionComponent } from './composition.component';
-import {
-  compositionPreviewStyles,
-  compositionStyles,
-} from './composition.styles';
+import { compositionPreviewStyles } from './composition.styles';
 
 const EB_PREVIEW_FOCUS_CLASS = 'eb-preview-focus';
 
 export class CompositionPreviewComponent extends CompositionComponent {
-  static styles = [compositionStyles, compositionPreviewStyles];
+  static styles = [compositionPreviewStyles];
 
   @query(`.${EB_PREVIEW_FOCUS_CLASS}`)
   protected focusedComponent?: HTMLElement;

--- a/libs/platform/experience/composition/src/composition.component.ts
+++ b/libs/platform/experience/composition/src/composition.component.ts
@@ -22,15 +22,12 @@ import { html, LitElement, TemplateResult } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { when } from 'lit/directives/when.js';
-import { compositionStyles } from './composition.styles';
 
 @signalAware()
 @hydratable()
 export class CompositionComponent extends LayoutMixin(
   ContentMixin<CompositionProperties>(LitElement)
 ) {
-  static styles = [compositionStyles];
-
   @signalProperty({ reflect: true }) uid?: string;
   @signalProperty({ reflect: true }) route?: string;
 

--- a/libs/platform/experience/composition/src/composition.styles.ts
+++ b/libs/platform/experience/composition/src/composition.styles.ts
@@ -1,11 +1,5 @@
 import { css } from 'lit';
 
-export const compositionStyles = css`
-  :host {
-    isolation: isolate;
-  }
-`;
-
 export const compositionPreviewStyles = css`
   .eb-preview-focus {
     position: relative;

--- a/libs/template/presets/storefront/experience/pages/home-page.ts
+++ b/libs/template/presets/storefront/experience/pages/home-page.ts
@@ -35,7 +35,7 @@ export const homePage: StaticComponent = {
               rules: [
                 {
                   width: '100%',
-                  style: 'position:absolute;left:0;z-index:-1',
+                  style: 'position:absolute;left:0',
                 },
               ],
             },
@@ -61,7 +61,7 @@ export const homePage: StaticComponent = {
                   background: 'rgba(35, 35, 35, 0.56);',
                   margin: '30px 0',
                   radius: 4,
-                  style: 'color: white;gap:20px',
+                  style: 'color: white;gap:20px;z-index:0',
                 },
               ],
             },


### PR DESCRIPTION
We fixed an issue with the language and currency that were hidden behind the header 

closes: [HRZ-3227](https://spryker.atlassian.net/browse/HRZ-3227)

[HRZ-3227]: https://spryker.atlassian.net/browse/HRZ-3227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ