### PR TITLE
fix: open terms & conditions in new window

### DIFF
--- a/libs/base/ui/action/link/src/styles/storefront.styles.ts
+++ b/libs/base/ui/action/link/src/styles/storefront.styles.ts
@@ -30,7 +30,7 @@ export const storefrontLinkStyles = css`
   }
 
   :host(:hover) ::slotted(a) {
-    text-decoration: solid underline var(--oryx-color-primary-9) 1px;
+    text-decoration: solid underline currentColor 1px;
     text-underline-offset: 5px;
   }
 

--- a/libs/base/ui/overlays/notification-center/src/notification-center.styles.ts
+++ b/libs/base/ui/overlays/notification-center/src/notification-center.styles.ts
@@ -108,7 +108,7 @@ export const notificationCenterBaseStyles = css`
     margin-inline: calc(2 * var(--gap, 10px));
   }
 
-  :host([stackable]) > *:nth-child(n + 2) span[slot='subtext'] {
+  :host([stackable]) > *:nth-of-type(n + 2) span[slot='subtext'] {
     opacity: 0;
     transition: all var(--oryx-transition-time) var(--delay) ease;
   }
@@ -121,7 +121,7 @@ export const notificationCenterBaseStyles = css`
     margin-inline: 0;
   }
 
-  :host([stackable]:hover) > *:nth-child(n + 2) span[slot='subtext'] {
+  :host([stackable]:hover) > *:nth-of-type(n + 2) span[slot='subtext'] {
     opacity: 1;
   }
 `;

--- a/libs/base/ui/structure/text/text.styles.ts
+++ b/libs/base/ui/structure/text/text.styles.ts
@@ -83,8 +83,6 @@ export const textStyles = css`
 
   a:active {
     color: var(--oryx-color-primary-9);
-    /* stylelint-disable-next-line */
-    /* text-decoration-color: currentColor; */
   }
 
   a:focus-visible {

--- a/libs/base/ui/structure/text/text.styles.ts
+++ b/libs/base/ui/structure/text/text.styles.ts
@@ -77,14 +77,14 @@ export const textStyles = css`
   }
 
   a:hover {
-    text-decoration: solid underline var(--oryx-color-primary-9) 1px;
+    text-decoration: solid underline currentColor 1px;
     text-underline-offset: 5px;
   }
 
   a:active {
     color: var(--oryx-color-primary-9);
     /* stylelint-disable-next-line */
-    text-decoration-color: currentColor;
+    /* text-decoration-color: currentColor; */
   }
 
   a:focus-visible {

--- a/libs/template/presets/storefront/experience/header.ts
+++ b/libs/template/presets/storefront/experience/header.ts
@@ -70,7 +70,7 @@ export const HeaderTemplate: StaticComponent = {
                   colSpan: 3,
                   height: '42px',
                   justify: 'start',
-                  style: 'color: white',
+                  style: 'color: var(--oryx-color-primary-0, white)',
                 },
                 { query: { breakpoint: 'md' }, colSpan: 2 },
               ],

--- a/libs/template/presets/storefront/experience/pages/cart-page.ts
+++ b/libs/template/presets/storefront/experience/pages/cart-page.ts
@@ -35,20 +35,7 @@ export const cartPage: StaticComponent = {
         },
         { type: 'oryx-checkout-link' },
       ],
-      options: {
-        data: {
-          rules: [
-            {
-              layout: 'flex',
-              vertical: true,
-              align: 'stretch',
-              gap: '20px',
-              sticky: true,
-              top: '108px',
-            },
-          ],
-        },
-      },
+      options: { data: { rules: [{ sticky: true, top: '108px' }] } },
     },
   ],
 };

--- a/libs/template/presets/storefront/experience/pages/checkout-page.ts
+++ b/libs/template/presets/storefront/experience/pages/checkout-page.ts
@@ -53,7 +53,6 @@ export const checkoutPage: StaticComponent = {
         data: {
           rules: [
             {
-              gap: '20px',
               sticky: true,
               top: '108px',
             },
@@ -82,7 +81,7 @@ export const checkoutPage: StaticComponent = {
           type: 'oryx-content-text',
           content: {
             data: {
-              text: '<p>The <a href="/article/terms-and-conditions" data-color="primary">Terms and conditions</a> apply.<br/>Please also see our <a href="/article/privacy" data-color="primary">Privacy notice</a>.</p>',
+              text: '<p>The <a href="/article/terms-and-conditions" target="_blank" data-color="primary">Terms and conditions</a> apply.<br/>Please also see our <a href="/article/privacy" target="_blank"  data-color="primary">Privacy notice</a>.</p>',
             },
           },
         },

--- a/libs/template/themes/design-tokens/src/color.tokens.ts
+++ b/libs/template/themes/design-tokens/src/color.tokens.ts
@@ -2,7 +2,7 @@ import { ColorDesignTokens, colorPalette } from '@spryker-oryx/experience';
 
 export const color: ColorDesignTokens = {
   neutral: colorPalette.grays.sprykerSfGray,
-  primary: colorPalette.colors.red,
+  primary: colorPalette.colors.spryker,
   secondary: colorPalette.colors.amber,
 
   highlight: colorPalette.colors.red,

--- a/libs/template/themes/design-tokens/src/color.tokens.ts
+++ b/libs/template/themes/design-tokens/src/color.tokens.ts
@@ -2,7 +2,7 @@ import { ColorDesignTokens, colorPalette } from '@spryker-oryx/experience';
 
 export const color: ColorDesignTokens = {
   neutral: colorPalette.grays.sprykerSfGray,
-  primary: colorPalette.colors.spryker,
+  primary: colorPalette.colors.red,
   secondary: colorPalette.colors.amber,
 
   highlight: colorPalette.colors.red,

--- a/libs/template/themes/design-tokens/src/layout.tokens.ts
+++ b/libs/template/themes/design-tokens/src/layout.tokens.ts
@@ -14,7 +14,7 @@ export const layoutTokens: ThemeToken = {
     grid: '4',
     split: { equal: '6', aside: '3', main: '8' },
   },
-  row: { gap: '10px' },
+  row: { gap: '20px' },
   divider: { width: '1px' },
 };
 


### PR DESCRIPTION
The T&C now opens in a new window, using the _blank target. 
Additionally, we've fixed a few small (unrelated) things in this PR:
- the notification center no longer hides the text of the first notification when rendered on the server
- underline color on hovered links use the currentColor rather than the primary color
- fix the stickiness of the cart totals
- default the vertical gap size to `20px` as this seems to be the standard in our UI

closes:  [HRZ-3179](https://spryker.atlassian.net/browse/HRZ-3179), [HRZ-3167](https://spryker.atlassian.net/browse/HRZ-3167)


[HRZ-3179]: https://spryker.atlassian.net/browse/HRZ-3179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HRZ-3167]: https://spryker.atlassian.net/browse/HRZ-3167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ