### PR TITLE
test: runs sf e2e tests in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        parallelism: [1, 2]
+        parallelism: [1, 2, 3]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,10 @@ jobs:
   test-e2e-storefront:
     runs-on: ubuntu-latest
     needs: [test-format, test-lint, test-stylelint, test-tsconfig]
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        parallelism: [1, 2]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/apps/storefront-e2e/project.json
+++ b/apps/storefront-e2e/project.json
@@ -20,6 +20,7 @@
           "cypressConfig": "apps/storefront-e2e/cypress.ci.config.js",
           "watch": false,
           "record": true,
+          "parallel": true,
           "tag": "regression",
           "group": "sf-regression"
         },


### PR DESCRIPTION
Runs sf e2e tests in parallel, which should decrease CI execution run by ~6 minutes in most cases.
Still, in the `development` it will take longer because of the unit tests job 

closes: -