### PR TITLE
refactor: move semantic link types into router config

### DIFF
--- a/libs/domain/cart/entry/src/entry.component.spec.ts
+++ b/libs/domain/cart/entry/src/entry.component.spec.ts
@@ -4,11 +4,7 @@ import { useComponent } from '@spryker-oryx/core/utilities';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
 import { ProductService } from '@spryker-oryx/product';
 import { MockProductService } from '@spryker-oryx/product/mocks';
-import {
-  PricingService,
-  SemanticLinkService,
-  siteProviders,
-} from '@spryker-oryx/site';
+import { PricingService, LinkService, siteProviders } from '@spryker-oryx/site';
 import { IconTypes } from '@spryker-oryx/ui/icon';
 import { html } from 'lit';
 import { BehaviorSubject, of } from 'rxjs';
@@ -27,7 +23,7 @@ class MockCartService implements Partial<CartService> {
   deleteEntry = vi.fn().mockReturnValue(of(null));
 }
 
-class MockSemanticLinkService implements Partial<SemanticLinkService> {
+class MockSemanticLinkService implements Partial<LinkService> {
   get = vi.fn().mockReturnValue(of('/cart'));
 }
 
@@ -62,7 +58,7 @@ describe('CartEntryComponent', () => {
           useClass: MockCartService,
         },
         {
-          provide: SemanticLinkService,
+          provide: LinkService,
           useClass: MockSemanticLinkService,
         },
         {

--- a/libs/domain/cart/entry/src/entry.component.ts
+++ b/libs/domain/cart/entry/src/entry.component.ts
@@ -10,7 +10,6 @@ import {
   NotificationService,
   PricingService,
   SemanticLinkService,
-  SemanticLinkType,
 } from '@spryker-oryx/site';
 import { AlertType } from '@spryker-oryx/ui';
 import { ButtonType } from '@spryker-oryx/ui/button';
@@ -38,6 +37,8 @@ import {
   RemoveByQuantity,
 } from './entry.model';
 import { cartEntryStyles } from './styles';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 /**
  * Supports updating the quantity as well as removing the entry entirely.
@@ -88,7 +89,7 @@ export class CartEntryComponent
 
   protected $productLink = computed(() => {
     return this.semanticLinkService.get({
-      type: SemanticLinkType.Product,
+      type: RouteLinkType.Product,
       id: this.$product()?.sku,
     });
   });
@@ -105,7 +106,7 @@ export class CartEntryComponent
     if (!this.$options()?.enableItemImage) return;
 
     return html`
-      <a href=${this.$productLink()}>
+      <a href=${ifDefined(this.$productLink())}>
         <oryx-product-media
           .options=${{ containerSize: ProductMediaContainerSize.Thumbnail }}
         ></oryx-product-media>

--- a/libs/domain/cart/entry/src/entry.component.ts
+++ b/libs/domain/cart/entry/src/entry.component.ts
@@ -37,7 +37,6 @@ import {
   RemoveByQuantity,
 } from './entry.model';
 import { cartEntryStyles } from './styles';
-import { ifDefined } from 'lit/directives/if-defined.js';
 import { RouteType } from '@spryker-oryx/router';
 
 /**
@@ -106,7 +105,7 @@ export class CartEntryComponent
     if (!this.$options()?.enableItemImage) return;
 
     return html`
-      <a href=${ifDefined(this.$productLink())}>
+      <a href=${this.$productLink()}>
         <oryx-product-media
           .options=${{ containerSize: ProductMediaContainerSize.Thumbnail }}
         ></oryx-product-media>

--- a/libs/domain/cart/entry/src/entry.component.ts
+++ b/libs/domain/cart/entry/src/entry.component.ts
@@ -9,7 +9,7 @@ import {
 import {
   NotificationService,
   PricingService,
-  SemanticLinkService,
+  LinkService,
 } from '@spryker-oryx/site';
 import { AlertType } from '@spryker-oryx/ui';
 import { ButtonType } from '@spryker-oryx/ui/button';
@@ -85,7 +85,7 @@ export class CartEntryComponent
 
   protected cartService = resolve(CartService);
   protected notificationService = resolve(NotificationService);
-  protected semanticLinkService = resolve(SemanticLinkService);
+  protected semanticLinkService = resolve(LinkService);
 
   protected $productLink = computed(() => {
     return this.semanticLinkService.get({

--- a/libs/domain/cart/entry/src/entry.component.ts
+++ b/libs/domain/cart/entry/src/entry.component.ts
@@ -38,7 +38,7 @@ import {
 } from './entry.model';
 import { cartEntryStyles } from './styles';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 /**
  * Supports updating the quantity as well as removing the entry entirely.
@@ -89,7 +89,7 @@ export class CartEntryComponent
 
   protected $productLink = computed(() => {
     return this.semanticLinkService.get({
-      type: RouteLinkType.Product,
+      type: RouteType.Product,
       id: this.$product()?.sku,
     });
   });

--- a/libs/domain/cart/package.json
+++ b/libs/domain/cart/package.json
@@ -26,6 +26,7 @@
     "@spryker-oryx/experience": "1.0.0-rc.0",
     "@spryker-oryx/product": "1.0.0-rc.0",
     "@spryker-oryx/site": "1.0.0-rc.0",
+    "@spryker-oryx/router": "1.0.0-rc.0",
     "@spryker-oryx/ui": "1.0.0-rc.0",
     "@spryker-oryx/utilities": "1.0.0-rc.0"
   },

--- a/libs/domain/checkout/account/account.component.spec.ts
+++ b/libs/domain/checkout/account/account.component.spec.ts
@@ -4,7 +4,7 @@ import { useComponent } from '@spryker-oryx/core/utilities';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
 import { FormRenderer } from '@spryker-oryx/form';
 import { RouterService } from '@spryker-oryx/router';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import { User, UserService } from '@spryker-oryx/user';
 import { html } from 'lit';
 import { of } from 'rxjs';
@@ -40,7 +40,7 @@ class MockAuthService implements Partial<AuthService> {
   isAuthenticated = vi.fn();
 }
 
-export class MockSemanticLinkService implements Partial<SemanticLinkService> {
+export class MockSemanticLinkService implements Partial<LinkService> {
   get = vi.fn().mockReturnValue('/login');
 }
 
@@ -71,7 +71,7 @@ describe('CheckoutAccountComponent', () => {
         { provide: CheckoutDataService, useClass: MockCheckoutDataService },
         { provide: CheckoutStateService, useClass: MockCheckoutStateService },
         { provide: RouterService, useClass: MockRouterService },
-        { provide: SemanticLinkService, useClass: MockSemanticLinkService },
+        { provide: LinkService, useClass: MockSemanticLinkService },
         { provide: AuthService, useClass: MockAuthService },
         { provide: UserService, useClass: MockUserService },
         { provide: FormRenderer, useClass: MockFormRenderer },

--- a/libs/domain/checkout/account/account.component.ts
+++ b/libs/domain/checkout/account/account.component.ts
@@ -4,13 +4,14 @@ import { resolve } from '@spryker-oryx/di';
 import { ContentMixin, defaultOptions } from '@spryker-oryx/experience';
 import { FormFieldType, FormRenderer } from '@spryker-oryx/form';
 import { RouterService } from '@spryker-oryx/router';
-import { SemanticLinkService, SemanticLinkType } from '@spryker-oryx/site';
+import { SemanticLinkService } from '@spryker-oryx/site';
 import { UserService } from '@spryker-oryx/user';
 import { elementEffect, hydrate, signal } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
 import { query, state } from 'lit/decorators.js';
 import { CheckoutAccountComponentOptions } from './account.model';
 import { checkoutAccountStyles } from './account.styles';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 @defaultOptions({ enableGuestCheckout: true })
 @hydrate({ event: 'window:load' })
@@ -31,7 +32,7 @@ export class CheckoutAccountComponent
   protected isAuthenticated = signal(this.authService.isAuthenticated());
   protected customer = signal(this.userService.getUser());
   protected loginRoute = signal(
-    this.linkService.get({ type: SemanticLinkType.Login })
+    this.linkService.get({ type: RouteLinkType.Login })
   );
   protected selected = signal(this.checkoutStateService.get('customer'));
 

--- a/libs/domain/checkout/account/account.component.ts
+++ b/libs/domain/checkout/account/account.component.ts
@@ -11,7 +11,7 @@ import { html, LitElement, TemplateResult } from 'lit';
 import { query, state } from 'lit/decorators.js';
 import { CheckoutAccountComponentOptions } from './account.model';
 import { checkoutAccountStyles } from './account.styles';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 @defaultOptions({ enableGuestCheckout: true })
 @hydrate({ event: 'window:load' })
@@ -32,7 +32,7 @@ export class CheckoutAccountComponent
   protected isAuthenticated = signal(this.authService.isAuthenticated());
   protected customer = signal(this.userService.getUser());
   protected loginRoute = signal(
-    this.linkService.get({ type: RouteLinkType.Login })
+    this.linkService.get({ type: RouteType.Login })
   );
   protected selected = signal(this.checkoutStateService.get('customer'));
 

--- a/libs/domain/checkout/account/account.component.ts
+++ b/libs/domain/checkout/account/account.component.ts
@@ -4,7 +4,7 @@ import { resolve } from '@spryker-oryx/di';
 import { ContentMixin, defaultOptions } from '@spryker-oryx/experience';
 import { FormFieldType, FormRenderer } from '@spryker-oryx/form';
 import { RouterService } from '@spryker-oryx/router';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import { UserService } from '@spryker-oryx/user';
 import { elementEffect, hydrate, signal } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
@@ -26,7 +26,7 @@ export class CheckoutAccountComponent
   protected fieldRenderer = resolve(FormRenderer);
   protected userService = resolve(UserService);
   protected authService = resolve(AuthService);
-  protected linkService = resolve(SemanticLinkService);
+  protected linkService = resolve(LinkService);
   protected routerService = resolve(RouterService);
 
   protected isAuthenticated = signal(this.authService.isAuthenticated());

--- a/libs/domain/checkout/link/link.component.spec.ts
+++ b/libs/domain/checkout/link/link.component.spec.ts
@@ -2,7 +2,7 @@ import { fixture } from '@open-wc/testing-helpers';
 import { CartService } from '@spryker-oryx/cart';
 import { useComponent } from '@spryker-oryx/core/utilities';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
-import { PricingService, SemanticLinkService } from '@spryker-oryx/site';
+import { PricingService, LinkService } from '@spryker-oryx/site';
 import { html } from 'lit';
 import { of } from 'rxjs';
 import { CheckoutLinkComponent } from './link.component';
@@ -19,7 +19,7 @@ class mockPricingService {
   format = vi.fn();
 }
 
-class MockSemanticLinkService implements Partial<SemanticLinkService> {
+class MockSemanticLinkService implements Partial<LinkService> {
   get = vi.fn().mockReturnValue(of('/checkout'));
 }
 
@@ -43,7 +43,7 @@ describe('CheckoutLinkComponent', () => {
           useClass: mockPricingService,
         },
         {
-          provide: SemanticLinkService,
+          provide: LinkService,
           useClass: MockSemanticLinkService,
         },
       ],

--- a/libs/domain/checkout/link/link.component.ts
+++ b/libs/domain/checkout/link/link.component.ts
@@ -1,6 +1,6 @@
 import { CartComponentMixin } from '@spryker-oryx/cart';
 import { resolve } from '@spryker-oryx/di';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 import { LinkService } from '@spryker-oryx/site';
 import { hydrate, I18nMixin, signal } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
@@ -13,7 +13,7 @@ export class CheckoutLinkComponent extends I18nMixin(
   protected semanticLinkService = resolve(LinkService);
 
   protected $link = signal(
-    this.semanticLinkService.get({ type: RouteLinkType.Checkout })
+    this.semanticLinkService.get({ type: RouteType.Checkout })
   );
 
   protected override render(): TemplateResult | void {

--- a/libs/domain/checkout/link/link.component.ts
+++ b/libs/domain/checkout/link/link.component.ts
@@ -1,7 +1,7 @@
 import { CartComponentMixin } from '@spryker-oryx/cart';
 import { resolve } from '@spryker-oryx/di';
 import { RouteLinkType } from '@spryker-oryx/router/lit';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import { hydrate, I18nMixin, signal } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -10,7 +10,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 export class CheckoutLinkComponent extends I18nMixin(
   CartComponentMixin(LitElement)
 ) {
-  protected semanticLinkService = resolve(SemanticLinkService);
+  protected semanticLinkService = resolve(LinkService);
 
   protected $link = signal(
     this.semanticLinkService.get({ type: RouteLinkType.Checkout })

--- a/libs/domain/checkout/link/link.component.ts
+++ b/libs/domain/checkout/link/link.component.ts
@@ -4,7 +4,6 @@ import { RouteType } from '@spryker-oryx/router';
 import { LinkService } from '@spryker-oryx/site';
 import { hydrate, I18nMixin, signal } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
-import { ifDefined } from 'lit/directives/if-defined.js';
 
 @hydrate({ event: ['window:load'] })
 export class CheckoutLinkComponent extends I18nMixin(
@@ -21,7 +20,7 @@ export class CheckoutLinkComponent extends I18nMixin(
 
     return html`
       <oryx-button ?loading=${this.$isBusy()}>
-        <a href=${ifDefined(this.$link())}>${this.i18n('cart.checkout')}</a>
+        <a href=${this.$link()}>${this.i18n('cart.checkout')}</a>
       </oryx-button>
     `;
   }

--- a/libs/domain/checkout/link/link.component.ts
+++ b/libs/domain/checkout/link/link.component.ts
@@ -1,8 +1,10 @@
 import { CartComponentMixin } from '@spryker-oryx/cart';
 import { resolve } from '@spryker-oryx/di';
-import { SemanticLinkService, SemanticLinkType } from '@spryker-oryx/site';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { SemanticLinkService } from '@spryker-oryx/site';
 import { hydrate, I18nMixin, signal } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 @hydrate({ event: ['window:load'] })
 export class CheckoutLinkComponent extends I18nMixin(
@@ -11,7 +13,7 @@ export class CheckoutLinkComponent extends I18nMixin(
   protected semanticLinkService = resolve(SemanticLinkService);
 
   protected $link = signal(
-    this.semanticLinkService.get({ type: SemanticLinkType.Checkout })
+    this.semanticLinkService.get({ type: RouteLinkType.Checkout })
   );
 
   protected override render(): TemplateResult | void {
@@ -19,7 +21,7 @@ export class CheckoutLinkComponent extends I18nMixin(
 
     return html`
       <oryx-button ?loading=${this.$isBusy()}>
-        <a href=${this.$link()}>${this.i18n('cart.checkout')}</a>
+        <a href=${ifDefined(this.$link())}>${this.i18n('cart.checkout')}</a>
       </oryx-button>
     `;
   }

--- a/libs/domain/checkout/src/services/default-checkout.service.spec.ts
+++ b/libs/domain/checkout/src/services/default-checkout.service.spec.ts
@@ -10,7 +10,7 @@ import {
 import { DefaultQueryService, QueryService } from '@spryker-oryx/core';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
 import { OrderService } from '@spryker-oryx/order';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import { BehaviorSubject, of, take } from 'rxjs';
 import { CheckoutAdapter } from './adapter';
 
@@ -22,7 +22,7 @@ class MockCartService implements Partial<CartService> {
 class MockCheckoutAdapter implements Partial<CheckoutAdapter> {
   placeOrder = vi.fn();
 }
-class MockSemanticLinkService implements Partial<SemanticLinkService> {
+class MockSemanticLinkService implements Partial<LinkService> {
   get = vi.fn().mockReturnValue(of('/link'));
 }
 
@@ -56,7 +56,7 @@ describe('DefaultCheckoutService', () => {
       providers: [
         { provide: CheckoutAdapter, useClass: MockCheckoutAdapter },
         { provide: CartService, useClass: MockCartService },
-        { provide: SemanticLinkService, useClass: MockSemanticLinkService },
+        { provide: LinkService, useClass: MockSemanticLinkService },
         { provide: CheckoutService, useClass: DefaultCheckoutService },
         { provide: OrderService, useClass: MockOrderService },
         { provide: CheckoutDataService, useClass: MockCheckoutDataService },
@@ -72,7 +72,7 @@ describe('DefaultCheckoutService', () => {
     checkoutService = injector.inject(CheckoutService);
     checkoutStateService =
       injector.inject<MockCheckoutStateService>(CheckoutStateService);
-    linkService = injector.inject<MockSemanticLinkService>(SemanticLinkService);
+    linkService = injector.inject<MockSemanticLinkService>(LinkService);
   });
 
   afterEach(() => {

--- a/libs/domain/checkout/src/services/default-checkout.service.ts
+++ b/libs/domain/checkout/src/services/default-checkout.service.ts
@@ -26,7 +26,7 @@ import {
   PlaceOrderStart,
   PlaceOrderSuccess,
 } from './state';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 export class DefaultCheckoutService implements CheckoutService {
   protected cartId$ = this.cartService
@@ -103,7 +103,7 @@ export class DefaultCheckoutService implements CheckoutService {
       ? of(response)
       : this.linkService
           .get({
-            type: RouteLinkType.Order,
+            type: RouteType.Order,
             id: response.orderReference,
           })
           .pipe(map((redirectUrl) => ({ ...response, redirectUrl })));

--- a/libs/domain/checkout/src/services/default-checkout.service.ts
+++ b/libs/domain/checkout/src/services/default-checkout.service.ts
@@ -2,7 +2,7 @@ import { CartService, CartsUpdated } from '@spryker-oryx/cart';
 import { createCommand, createEffect } from '@spryker-oryx/core';
 import { inject } from '@spryker-oryx/di';
 import { OrderService } from '@spryker-oryx/order';
-import { SemanticLinkService, SemanticLinkType } from '@spryker-oryx/site';
+import { SemanticLinkService } from '@spryker-oryx/site';
 import { AddressModificationSuccess } from '@spryker-oryx/user';
 import {
   combineLatest,
@@ -26,6 +26,7 @@ import {
   PlaceOrderStart,
   PlaceOrderSuccess,
 } from './state';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 export class DefaultCheckoutService implements CheckoutService {
   protected cartId$ = this.cartService
@@ -102,7 +103,7 @@ export class DefaultCheckoutService implements CheckoutService {
       ? of(response)
       : this.linkService
           .get({
-            type: SemanticLinkType.Order,
+            type: RouteLinkType.Order,
             id: response.orderReference,
           })
           .pipe(map((redirectUrl) => ({ ...response, redirectUrl })));

--- a/libs/domain/checkout/src/services/default-checkout.service.ts
+++ b/libs/domain/checkout/src/services/default-checkout.service.ts
@@ -2,7 +2,7 @@ import { CartService, CartsUpdated } from '@spryker-oryx/cart';
 import { createCommand, createEffect } from '@spryker-oryx/core';
 import { inject } from '@spryker-oryx/di';
 import { OrderService } from '@spryker-oryx/order';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import { AddressModificationSuccess } from '@spryker-oryx/user';
 import {
   combineLatest,
@@ -84,7 +84,7 @@ export class DefaultCheckoutService implements CheckoutService {
     protected stateService = inject(CheckoutStateService),
     protected cartService = inject(CartService),
     protected adapter = inject(CheckoutAdapter),
-    protected linkService = inject(SemanticLinkService),
+    protected linkService = inject(LinkService),
     protected orderService = inject(OrderService)
   ) {}
 

--- a/libs/domain/content/link/link.component.spec.ts
+++ b/libs/domain/content/link/link.component.spec.ts
@@ -1,7 +1,7 @@
 import { fixture } from '@open-wc/testing-helpers';
 import { useComponent } from '@spryker-oryx/core/utilities';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
-import { SemanticLinkService, SemanticLinkType } from '@spryker-oryx/site';
+import { SemanticLinkService } from '@spryker-oryx/site';
 import { IconComponent } from '@spryker-oryx/ui/icon';
 import { LinkComponent } from '@spryker-oryx/ui/link';
 import { html } from 'lit';
@@ -9,6 +9,7 @@ import { of } from 'rxjs';
 import { ContentLinkComponent } from './link.component';
 import { contentLinkComponent } from './link.def';
 import { ContentLinkContent, ContentLinkOptions } from './link.model';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 class MockSemanticLinkService implements Partial<SemanticLinkService> {
   get = vi.fn().mockReturnValue(of('/page'));
@@ -95,7 +96,7 @@ describe('ContentLinkComponent', () => {
       element = await fixture(
         html`<oryx-content-link
           .options=${{
-            type: SemanticLinkType.Product,
+            type: RouteLinkType.Product,
             id: '123',
             params: { foo: 'bar' },
           }}
@@ -105,7 +106,7 @@ describe('ContentLinkComponent', () => {
 
     it('should resolve the link from the SemanticLinkService', () => {
       expect(semanticLinkService.get).toHaveBeenCalledWith({
-        type: SemanticLinkType.Product,
+        type: RouteLinkType.Product,
         id: '123',
         params: { foo: 'bar' },
       });
@@ -131,7 +132,7 @@ describe('ContentLinkComponent', () => {
       element = await fixture(
         html`<oryx-content-link
           .options=${{
-            type: SemanticLinkType.Page,
+            type: RouteLinkType.Page,
             noopener: true,
           }}
         ></oryx-content-link>`
@@ -148,7 +149,7 @@ describe('ContentLinkComponent', () => {
       element = await fixture(
         html`<oryx-content-link
           .options=${{
-            type: SemanticLinkType.Page,
+            type: RouteLinkType.Page,
             nofollow: true,
           }}
         ></oryx-content-link>`
@@ -165,7 +166,7 @@ describe('ContentLinkComponent', () => {
       element = await fixture(
         html`<oryx-content-link
           .options=${{
-            type: SemanticLinkType.Page,
+            type: RouteLinkType.Page,
             noopener: true,
             nofollow: true,
           }}

--- a/libs/domain/content/link/link.component.spec.ts
+++ b/libs/domain/content/link/link.component.spec.ts
@@ -9,7 +9,7 @@ import { of } from 'rxjs';
 import { ContentLinkComponent } from './link.component';
 import { contentLinkComponent } from './link.def';
 import { ContentLinkContent, ContentLinkOptions } from './link.model';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 class MockSemanticLinkService implements Partial<LinkService> {
   get = vi.fn().mockReturnValue(of('/page'));
@@ -95,7 +95,7 @@ describe('ContentLinkComponent', () => {
       element = await fixture(
         html`<oryx-content-link
           .options=${{
-            type: RouteLinkType.Product,
+            type: RouteType.Product,
             id: '123',
             params: { foo: 'bar' },
           }}
@@ -105,7 +105,7 @@ describe('ContentLinkComponent', () => {
 
     it('should resolve the link from the LinkService', () => {
       expect(semanticLinkService.get).toHaveBeenCalledWith({
-        type: RouteLinkType.Product,
+        type: RouteType.Product,
         id: '123',
         params: { foo: 'bar' },
       });
@@ -131,7 +131,7 @@ describe('ContentLinkComponent', () => {
       element = await fixture(
         html`<oryx-content-link
           .options=${{
-            type: RouteLinkType.Page,
+            type: RouteType.Page,
             noopener: true,
           }}
         ></oryx-content-link>`
@@ -148,7 +148,7 @@ describe('ContentLinkComponent', () => {
       element = await fixture(
         html`<oryx-content-link
           .options=${{
-            type: RouteLinkType.Page,
+            type: RouteType.Page,
             nofollow: true,
           }}
         ></oryx-content-link>`
@@ -165,7 +165,7 @@ describe('ContentLinkComponent', () => {
       element = await fixture(
         html`<oryx-content-link
           .options=${{
-            type: RouteLinkType.Page,
+            type: RouteType.Page,
             noopener: true,
             nofollow: true,
           }}

--- a/libs/domain/content/link/link.component.spec.ts
+++ b/libs/domain/content/link/link.component.spec.ts
@@ -1,7 +1,7 @@
 import { fixture } from '@open-wc/testing-helpers';
 import { useComponent } from '@spryker-oryx/core/utilities';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import { IconComponent } from '@spryker-oryx/ui/icon';
 import { LinkComponent } from '@spryker-oryx/ui/link';
 import { html } from 'lit';
@@ -11,7 +11,7 @@ import { contentLinkComponent } from './link.def';
 import { ContentLinkContent, ContentLinkOptions } from './link.model';
 import { RouteLinkType } from '@spryker-oryx/router/lit';
 
-class MockSemanticLinkService implements Partial<SemanticLinkService> {
+class MockSemanticLinkService implements Partial<LinkService> {
   get = vi.fn().mockReturnValue(of('/page'));
 }
 
@@ -27,14 +27,13 @@ describe('ContentLinkComponent', () => {
     const injector = createInjector({
       providers: [
         {
-          provide: SemanticLinkService,
+          provide: LinkService,
           useClass: MockSemanticLinkService,
         },
       ],
     });
 
-    semanticLinkService =
-      injector.inject<MockSemanticLinkService>(SemanticLinkService);
+    semanticLinkService = injector.inject<MockSemanticLinkService>(LinkService);
   });
 
   afterEach(() => {
@@ -104,7 +103,7 @@ describe('ContentLinkComponent', () => {
       );
     });
 
-    it('should resolve the link from the SemanticLinkService', () => {
+    it('should resolve the link from the LinkService', () => {
       expect(semanticLinkService.get).toHaveBeenCalledWith({
         type: RouteLinkType.Product,
         id: '123',

--- a/libs/domain/content/link/link.component.ts
+++ b/libs/domain/content/link/link.component.ts
@@ -1,6 +1,6 @@
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin } from '@spryker-oryx/experience';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import { computed, hydrate } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -12,7 +12,7 @@ export class ContentLinkComponent extends ContentMixin<
   ContentLinkOptions,
   ContentLinkContent
 >(LitElement) {
-  protected semanticLinkService = resolve(SemanticLinkService);
+  protected semanticLinkService = resolve(LinkService);
 
   protected $link = computed(() => {
     const { url, type, id, params } = this.$options();

--- a/libs/domain/content/link/link.model.ts
+++ b/libs/domain/content/link/link.model.ts
@@ -1,4 +1,4 @@
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 import { ColorType } from '@spryker-oryx/ui/link';
 
 export interface ContentLinkContent {
@@ -7,7 +7,7 @@ export interface ContentLinkContent {
 
 export interface ContentLinkOptions {
   url?: string;
-  type?: RouteLinkType;
+  type?: RouteType;
   id?: string;
   params?: Record<string, string>;
 

--- a/libs/domain/content/link/link.model.ts
+++ b/libs/domain/content/link/link.model.ts
@@ -1,4 +1,4 @@
-import { SemanticLinkType } from '@spryker-oryx/site';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 import { ColorType } from '@spryker-oryx/ui/link';
 
 export interface ContentLinkContent {
@@ -7,7 +7,7 @@ export interface ContentLinkContent {
 
 export interface ContentLinkOptions {
   url?: string;
-  type?: SemanticLinkType;
+  type?: RouteLinkType;
   id?: string;
   params?: Record<string, string>;
 

--- a/libs/domain/content/link/stories/link-demo.stories.ts
+++ b/libs/domain/content/link/stories/link-demo.stories.ts
@@ -1,9 +1,9 @@
 import { getAppIcons } from '@/tools/storybook';
-import { SemanticLinkType } from '@spryker-oryx/site';
 import { Meta, Story } from '@storybook/web-components';
 import { html, TemplateResult } from 'lit';
 import { storybookPrefix } from '../../.constants';
 import { ContentLinkContent, ContentLinkOptions } from '../link.model';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 export default {
   title: `${storybookPrefix}/Link`,
@@ -23,9 +23,9 @@ export default {
     },
     type: {
       options: [
-        SemanticLinkType.Page,
-        SemanticLinkType.Category,
-        SemanticLinkType.Product,
+        RouteLinkType.Page,
+        RouteLinkType.Category,
+        RouteLinkType.Product,
       ],
       control: { type: 'select' },
     },

--- a/libs/domain/content/link/stories/link-demo.stories.ts
+++ b/libs/domain/content/link/stories/link-demo.stories.ts
@@ -3,7 +3,7 @@ import { Meta, Story } from '@storybook/web-components';
 import { html, TemplateResult } from 'lit';
 import { storybookPrefix } from '../../.constants';
 import { ContentLinkContent, ContentLinkOptions } from '../link.model';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 export default {
   title: `${storybookPrefix}/Link`,
@@ -22,11 +22,7 @@ export default {
       control: { type: 'select' },
     },
     type: {
-      options: [
-        RouteLinkType.Page,
-        RouteLinkType.Category,
-        RouteLinkType.Product,
-      ],
+      options: [RouteType.Page, RouteType.Category, RouteType.Product],
       control: { type: 'select' },
     },
     noopener: {

--- a/libs/domain/content/package.json
+++ b/libs/domain/content/package.json
@@ -17,6 +17,7 @@
     "@spryker-oryx/core": "1.0.0-rc.0",
     "@spryker-oryx/di": "1.0.0-rc.0",
     "@spryker-oryx/experience": "1.0.0-rc.0",
+    "@spryker-oryx/router": "1.0.0-rc.0",
     "@spryker-oryx/site": "1.0.0-rc.0",
     "@spryker-oryx/utilities": "1.0.0-rc.0"
   },

--- a/libs/domain/content/src/models/content.model.ts
+++ b/libs/domain/content/src/models/content.model.ts
@@ -1,5 +1,5 @@
 import { ContentEntities } from '../services';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 export interface ContentQualifier {
   type?: string;
@@ -9,7 +9,7 @@ export interface ContentQualifier {
 
 export interface Content {
   id?: string;
-  type?: RouteLinkType;
+  type?: RouteType;
   url?: string;
   heading: string;
   description: string;

--- a/libs/domain/content/src/models/content.model.ts
+++ b/libs/domain/content/src/models/content.model.ts
@@ -1,5 +1,5 @@
-import { SemanticLinkType } from '@spryker-oryx/site';
 import { ContentEntities } from '../services';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 export interface ContentQualifier {
   type?: string;
@@ -9,7 +9,7 @@ export interface ContentQualifier {
 
 export interface Content {
   id?: string;
-  type?: SemanticLinkType;
+  type?: RouteLinkType;
   url?: string;
   heading: string;
   description: string;

--- a/libs/domain/product/card/src/card.component.spec.ts
+++ b/libs/domain/product/card/src/card.component.spec.ts
@@ -10,6 +10,8 @@ import { of } from 'rxjs';
 import { SpyInstance } from 'vitest';
 import { ProductCardComponent } from './card.component';
 import { productCardComponent } from './card.def';
+import { RouterService } from '@spryker-oryx/router';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 const mockContext = {
   get: vi.fn().mockReturnValue(of('1')),
@@ -17,6 +19,17 @@ const mockContext = {
 };
 vi.spyOn(core, 'ContextController') as SpyInstance;
 (core.ContextController as unknown as SpyInstance).mockReturnValue(mockContext);
+
+const mockRouterService = {
+  getRoutes: vi.fn().mockReturnValue(
+    of([
+      {
+        path: '/product/:id',
+        type: RouteLinkType.Product,
+      },
+    ])
+  ),
+};
 
 describe('ProductCardComponent', () => {
   let element: ProductCardComponent;
@@ -27,7 +40,14 @@ describe('ProductCardComponent', () => {
 
   beforeEach(async () => {
     createInjector({
-      providers: [...mockProductProviders, ...siteProviders],
+      providers: [
+        ...mockProductProviders,
+        ...siteProviders,
+        {
+          provide: RouterService,
+          useValue: mockRouterService,
+        },
+      ],
     });
 
     element = await fixture(
@@ -178,7 +198,14 @@ describe('ProductCardComponent', () => {
       );
 
       createInjector({
-        providers: [...mockProductProviders, ...siteProviders],
+        providers: [
+          ...mockProductProviders,
+          ...siteProviders,
+          {
+            provide: RouterService,
+            useValue: mockRouterService,
+          },
+        ],
       });
 
       element = await fixture(html` <oryx-product-card></oryx-product-card> `);

--- a/libs/domain/product/card/src/card.component.spec.ts
+++ b/libs/domain/product/card/src/card.component.spec.ts
@@ -10,8 +10,7 @@ import { of } from 'rxjs';
 import { SpyInstance } from 'vitest';
 import { ProductCardComponent } from './card.component';
 import { productCardComponent } from './card.def';
-import { RouterService } from '@spryker-oryx/router';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouterService, RouteType } from '@spryker-oryx/router';
 
 const mockContext = {
   get: vi.fn().mockReturnValue(of('1')),
@@ -25,7 +24,7 @@ const mockRouterService = {
     of([
       {
         path: '/product/:id',
-        type: RouteLinkType.Product,
+        type: RouteType.Product,
       },
     ])
   ),

--- a/libs/domain/product/card/src/card.component.ts
+++ b/libs/domain/product/card/src/card.component.ts
@@ -21,7 +21,7 @@ import { ProductPriceOptions } from '../../price/src/price.model.js';
 import { ProductTitleOptions } from '../../title/src/title.model.js';
 import { ProductCardOptions } from './card.model';
 import { ProductCardStyles } from './card.styles';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 @defaultOptions({
   template: 'grid',
@@ -88,7 +88,7 @@ export class ProductCardComponent extends ProductMixin(
 
   protected $link = computed(() =>
     this.semanticLinkService.get({
-      type: RouteLinkType.Product,
+      type: RouteType.Product,
       id: this.$product()?.sku,
     })
   );

--- a/libs/domain/product/card/src/card.component.ts
+++ b/libs/domain/product/card/src/card.component.ts
@@ -6,7 +6,7 @@ import {
   ProductMediaContainerSize,
   ProductMixin,
 } from '@spryker-oryx/product';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import { HeadingTag } from '@spryker-oryx/ui/heading';
 import { IconTypes } from '@spryker-oryx/ui/icon';
 import {
@@ -41,7 +41,7 @@ export class ProductCardComponent extends ProductMixin(
   static styles = [ProductCardStyles];
 
   protected contextController = new ContextController(this);
-  protected semanticLinkService = resolve(SemanticLinkService);
+  protected semanticLinkService = resolve(LinkService);
 
   @elementEffect()
   protected setTemplate = (): void => {

--- a/libs/domain/product/card/src/card.component.ts
+++ b/libs/domain/product/card/src/card.component.ts
@@ -6,7 +6,7 @@ import {
   ProductMediaContainerSize,
   ProductMixin,
 } from '@spryker-oryx/product';
-import { SemanticLinkService, SemanticLinkType } from '@spryker-oryx/site';
+import { SemanticLinkService } from '@spryker-oryx/site';
 import { HeadingTag } from '@spryker-oryx/ui/heading';
 import { IconTypes } from '@spryker-oryx/ui/icon';
 import {
@@ -21,6 +21,7 @@ import { ProductPriceOptions } from '../../price/src/price.model.js';
 import { ProductTitleOptions } from '../../title/src/title.model.js';
 import { ProductCardOptions } from './card.model';
 import { ProductCardStyles } from './card.styles';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 @defaultOptions({
   template: 'grid',
@@ -87,7 +88,7 @@ export class ProductCardComponent extends ProductMixin(
 
   protected $link = computed(() =>
     this.semanticLinkService.get({
-      type: SemanticLinkType.Product,
+      type: RouteLinkType.Product,
       id: this.$product()?.sku,
     })
   );

--- a/libs/domain/product/title/src/title.component.spec.ts
+++ b/libs/domain/product/title/src/title.component.spec.ts
@@ -2,14 +2,14 @@ import { fixture } from '@open-wc/testing-helpers';
 import { useComponent } from '@spryker-oryx/core/utilities';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
 import { mockProductProviders } from '@spryker-oryx/product/mocks';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import { LinkType } from '@spryker-oryx/ui/link';
 import { html } from 'lit';
 import { of } from 'rxjs';
 import { ProductTitleComponent } from './title.component';
 import { productTitleComponent } from './title.def';
 
-class MockSemanticLinkService implements Partial<SemanticLinkService> {
+class MockSemanticLinkService implements Partial<LinkService> {
   get = vi.fn().mockReturnValue(of('/product/123'));
 }
 
@@ -25,7 +25,7 @@ describe('ProductTitleComponent', () => {
       providers: [
         ...mockProductProviders,
         {
-          provide: SemanticLinkService,
+          provide: LinkService,
           useClass: MockSemanticLinkService,
         },
       ],

--- a/libs/domain/product/title/src/title.component.ts
+++ b/libs/domain/product/title/src/title.component.ts
@@ -9,7 +9,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { html } from 'lit/static-html.js';
 import { ProductTitleOptions } from './title.model';
 import { styles } from './title.styles';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 @defaultOptions({
   linkType: 'none',
@@ -27,7 +27,7 @@ export class ProductTitleComponent extends ProductMixin(
       return null;
     }
     return this.semanticLinkService.get({
-      type: RouteLinkType.Product,
+      type: RouteType.Product,
       id: this.$product()?.sku,
     });
   });

--- a/libs/domain/product/title/src/title.component.ts
+++ b/libs/domain/product/title/src/title.component.ts
@@ -1,7 +1,7 @@
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin, defaultOptions } from '@spryker-oryx/experience';
 import { ProductContext, ProductMixin } from '@spryker-oryx/product';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import { LinkType } from '@spryker-oryx/ui/link';
 import { computed, hydrate } from '@spryker-oryx/utilities';
 import { LitElement, TemplateResult } from 'lit';
@@ -20,7 +20,7 @@ export class ProductTitleComponent extends ProductMixin(
 ) {
   static styles = styles;
 
-  protected semanticLinkService = resolve(SemanticLinkService);
+  protected semanticLinkService = resolve(LinkService);
 
   protected $link = computed(() => {
     if (!this.$options().linkType || this.$options().linkType === 'none') {

--- a/libs/domain/product/title/src/title.component.ts
+++ b/libs/domain/product/title/src/title.component.ts
@@ -1,7 +1,7 @@
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin, defaultOptions } from '@spryker-oryx/experience';
 import { ProductContext, ProductMixin } from '@spryker-oryx/product';
-import { SemanticLinkService, SemanticLinkType } from '@spryker-oryx/site';
+import { SemanticLinkService } from '@spryker-oryx/site';
 import { LinkType } from '@spryker-oryx/ui/link';
 import { computed, hydrate } from '@spryker-oryx/utilities';
 import { LitElement, TemplateResult } from 'lit';
@@ -9,6 +9,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { html } from 'lit/static-html.js';
 import { ProductTitleOptions } from './title.model';
 import { styles } from './title.styles';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 @defaultOptions({
   linkType: 'none',
@@ -26,7 +27,7 @@ export class ProductTitleComponent extends ProductMixin(
       return null;
     }
     return this.semanticLinkService.get({
-      type: SemanticLinkType.Product,
+      type: RouteLinkType.Product,
       id: this.$product()?.sku,
     });
   });

--- a/libs/domain/search/box/box.component.spec.ts
+++ b/libs/domain/search/box/box.component.spec.ts
@@ -10,7 +10,7 @@ import { html } from 'lit';
 import { of } from 'rxjs';
 import { SearchBoxComponent } from './box.component';
 import { searchBoxComponent } from './box.def';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 class MockRouterService implements Partial<RouterService> {
   navigate = vi.fn();
@@ -259,7 +259,7 @@ describe('SearchBoxComponent', () => {
 
       it('should get the link from service without params', () => {
         expect(linkService.get).toHaveBeenCalledWith({
-          type: RouteLinkType.ProductList,
+          type: RouteType.ProductList,
         });
       });
 
@@ -281,7 +281,7 @@ describe('SearchBoxComponent', () => {
 
       it('should get the link from service with params', () => {
         expect(linkService.get).toHaveBeenCalledWith({
-          type: RouteLinkType.ProductList,
+          type: RouteType.ProductList,
           params: { q },
         });
       });

--- a/libs/domain/search/box/box.component.spec.ts
+++ b/libs/domain/search/box/box.component.spec.ts
@@ -4,7 +4,7 @@ import { createInjector, destroyInjector } from '@spryker-oryx/di';
 import { I18nService } from '@spryker-oryx/i18n';
 import { RouterService } from '@spryker-oryx/router';
 import { SuggestionRendererService } from '@spryker-oryx/search';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import { typeheadComponent } from '@spryker-oryx/ui';
 import { html } from 'lit';
 import { of } from 'rxjs';
@@ -16,7 +16,7 @@ class MockRouterService implements Partial<RouterService> {
   navigate = vi.fn();
 }
 
-class MockSemanticLinkService implements Partial<SemanticLinkService> {
+class MockSemanticLinkService implements Partial<LinkService> {
   get = vi.fn().mockReturnValue(of(''));
 }
 
@@ -81,7 +81,7 @@ describe('SearchBoxComponent', () => {
           useClass: MockRouterService,
         },
         {
-          provide: SemanticLinkService,
+          provide: LinkService,
           useClass: MockSemanticLinkService,
         },
         {
@@ -94,9 +94,7 @@ describe('SearchBoxComponent', () => {
         },
       ],
     });
-    linkService = testInjector.inject(
-      SemanticLinkService
-    ) as MockSemanticLinkService;
+    linkService = testInjector.inject(LinkService) as MockSemanticLinkService;
     routerService = testInjector.inject(
       RouterService
     ) as unknown as MockRouterService;

--- a/libs/domain/search/box/box.component.spec.ts
+++ b/libs/domain/search/box/box.component.spec.ts
@@ -4,12 +4,13 @@ import { createInjector, destroyInjector } from '@spryker-oryx/di';
 import { I18nService } from '@spryker-oryx/i18n';
 import { RouterService } from '@spryker-oryx/router';
 import { SuggestionRendererService } from '@spryker-oryx/search';
-import { SemanticLinkService, SemanticLinkType } from '@spryker-oryx/site';
+import { SemanticLinkService } from '@spryker-oryx/site';
 import { typeheadComponent } from '@spryker-oryx/ui';
 import { html } from 'lit';
 import { of } from 'rxjs';
 import { SearchBoxComponent } from './box.component';
 import { searchBoxComponent } from './box.def';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 class MockRouterService implements Partial<RouterService> {
   navigate = vi.fn();
@@ -260,7 +261,7 @@ describe('SearchBoxComponent', () => {
 
       it('should get the link from service without params', () => {
         expect(linkService.get).toHaveBeenCalledWith({
-          type: SemanticLinkType.ProductList,
+          type: RouteLinkType.ProductList,
         });
       });
 
@@ -282,7 +283,7 @@ describe('SearchBoxComponent', () => {
 
       it('should get the link from service with params', () => {
         expect(linkService.get).toHaveBeenCalledWith({
-          type: SemanticLinkType.ProductList,
+          type: RouteLinkType.ProductList,
           params: { q },
         });
       });

--- a/libs/domain/search/box/box.component.ts
+++ b/libs/domain/search/box/box.component.ts
@@ -6,7 +6,7 @@ import {
   SuggestionField,
   SuggestionRendererService,
 } from '@spryker-oryx/search';
-import { SemanticLinkService, SemanticLinkType } from '@spryker-oryx/site';
+import { SemanticLinkService } from '@spryker-oryx/site';
 import { IconTypes } from '@spryker-oryx/ui/icon';
 import { SearchEventDetail } from '@spryker-oryx/ui/searchbox';
 import '@spryker-oryx/ui/typeahead';
@@ -28,6 +28,7 @@ import { html } from 'lit/static-html.js';
 import { BehaviorSubject, switchMap } from 'rxjs';
 import { searchBoxStyles } from './';
 import { SearchBoxOptions, SearchBoxProperties } from './box.model';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 @defaultOptions({
   minChars: 2,
@@ -84,7 +85,7 @@ export class SearchBoxComponent
 
   protected $link = computed(() =>
     this.semanticLinkService.get({
-      type: SemanticLinkType.ProductList,
+      type: RouteLinkType.ProductList,
       ...(this.query ? { params: { q: this.query } } : {}),
     })
   );

--- a/libs/domain/search/box/box.component.ts
+++ b/libs/domain/search/box/box.component.ts
@@ -6,7 +6,7 @@ import {
   SuggestionField,
   SuggestionRendererService,
 } from '@spryker-oryx/search';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import { IconTypes } from '@spryker-oryx/ui/icon';
 import { SearchEventDetail } from '@spryker-oryx/ui/searchbox';
 import '@spryker-oryx/ui/typeahead';
@@ -61,7 +61,7 @@ export class SearchBoxComponent
 
   protected suggestionRendererService = resolve(SuggestionRendererService);
   protected routerService = resolve(RouterService);
-  protected semanticLinkService = resolve(SemanticLinkService);
+  protected semanticLinkService = resolve(LinkService);
 
   // TODO: simplify it when we find easier way how to skip emission of initialValue for each observable recreation
   protected query$ = new BehaviorSubject(this.query);

--- a/libs/domain/search/box/box.component.ts
+++ b/libs/domain/search/box/box.component.ts
@@ -28,7 +28,7 @@ import { html } from 'lit/static-html.js';
 import { BehaviorSubject, switchMap } from 'rxjs';
 import { searchBoxStyles } from './';
 import { SearchBoxOptions, SearchBoxProperties } from './box.model';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 @defaultOptions({
   minChars: 2,
@@ -85,7 +85,7 @@ export class SearchBoxComponent
 
   protected $link = computed(() =>
     this.semanticLinkService.get({
-      type: RouteLinkType.ProductList,
+      type: RouteType.ProductList,
       ...(this.query ? { params: { q: this.query } } : {}),
     })
   );

--- a/libs/domain/search/src/mocks/src/suggestion/mock-suggestion.generator.ts
+++ b/libs/domain/search/src/mocks/src/suggestion/mock-suggestion.generator.ts
@@ -1,5 +1,5 @@
 import { Product } from '@spryker-oryx/product';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 import {
   Suggestion,
   SuggestionField,
@@ -17,7 +17,7 @@ const makeTheNameGreatAgain = (name: string): string =>
 const createResources = (
   completion: string[],
   resourceName: string,
-  type: RouteLinkType
+  type: RouteType
 ): SuggestionResource[] => {
   return completion.map((c) => ({
     name: `${makeTheNameGreatAgain(c)} ${resourceName}`,
@@ -67,12 +67,12 @@ export const createSuggestionMock = (
     [SuggestionField.Suggestions]: completion.map((name) => ({
       name,
       params: { q: name },
-      type: RouteLinkType.ProductList,
+      type: RouteType.ProductList,
     })),
     [SuggestionField.Categories]: createResources(
       completion,
       'Category',
-      RouteLinkType.Category
+      RouteType.Category
     ),
     [SuggestionField.Products]: createProducts(completion),
   };

--- a/libs/domain/search/src/mocks/src/suggestion/mock-suggestion.generator.ts
+++ b/libs/domain/search/src/mocks/src/suggestion/mock-suggestion.generator.ts
@@ -1,11 +1,11 @@
 import { Product } from '@spryker-oryx/product';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 import {
   Suggestion,
   SuggestionField,
   SuggestionQualifier,
   SuggestionResource,
 } from '@spryker-oryx/search';
-import { SemanticLinkType } from '@spryker-oryx/site';
 
 const dummyUrl = (): string => '#';
 const makeTheNameGreatAgain = (name: string): string =>
@@ -17,7 +17,7 @@ const makeTheNameGreatAgain = (name: string): string =>
 const createResources = (
   completion: string[],
   resourceName: string,
-  type: SemanticLinkType
+  type: RouteLinkType
 ): SuggestionResource[] => {
   return completion.map((c) => ({
     name: `${makeTheNameGreatAgain(c)} ${resourceName}`,
@@ -67,12 +67,12 @@ export const createSuggestionMock = (
     [SuggestionField.Suggestions]: completion.map((name) => ({
       name,
       params: { q: name },
-      type: SemanticLinkType.ProductList,
+      type: RouteLinkType.ProductList,
     })),
     [SuggestionField.Categories]: createResources(
       completion,
       'Category',
-      SemanticLinkType.Category
+      RouteLinkType.Category
     ),
     [SuggestionField.Products]: createProducts(completion),
   };

--- a/libs/domain/search/src/models/suggestion/model.ts
+++ b/libs/domain/search/src/models/suggestion/model.ts
@@ -1,12 +1,12 @@
 import { Product } from '@spryker-oryx/product';
 import { DirectiveResult } from 'lit/async-directive';
 import { SuggestionField } from '../../services';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 export interface SuggestionLinks {
   title?: DirectiveResult;
   options: SuggestionResource[];
-  type: RouteLinkType | string;
+  type: RouteType | string;
   id?: string;
 }
 
@@ -15,7 +15,7 @@ export interface SuggestionResource {
   url?: string;
   params?: Record<string, string>;
   id?: string;
-  type?: RouteLinkType | string;
+  type?: RouteType | string;
 }
 
 export interface Suggestion {

--- a/libs/domain/search/src/models/suggestion/model.ts
+++ b/libs/domain/search/src/models/suggestion/model.ts
@@ -1,12 +1,12 @@
 import { Product } from '@spryker-oryx/product';
-import { SemanticLinkType } from '@spryker-oryx/site';
 import { DirectiveResult } from 'lit/async-directive';
 import { SuggestionField } from '../../services';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 export interface SuggestionLinks {
   title?: DirectiveResult;
   options: SuggestionResource[];
-  type: SemanticLinkType;
+  type: RouteLinkType | string;
   id?: string;
 }
 
@@ -15,7 +15,7 @@ export interface SuggestionResource {
   url?: string;
   params?: Record<string, string>;
   id?: string;
-  type?: SemanticLinkType;
+  type?: RouteLinkType | string;
 }
 
 export interface Suggestion {

--- a/libs/domain/search/src/services/adapter/normalizers/suggestion/suggestion.normalizer.spec.ts
+++ b/libs/domain/search/src/services/adapter/normalizers/suggestion/suggestion.normalizer.spec.ts
@@ -6,14 +6,14 @@ import {
   suggestionAttributesNormalizer,
   suggestionProductNormalizer,
 } from './suggestion.normalizer';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 const mockDeserializedSuggestion = {
   completion: ['A'],
   categories: [
     {
       name: 'name',
-      type: RouteLinkType.Category,
+      type: RouteType.Category,
     },
   ],
   cmsPages: [
@@ -40,7 +40,7 @@ describe('Suggestion Normalizers', () => {
           {
             name: mockDeserializedSuggestion.completion[0],
             params: { q: mockDeserializedSuggestion.completion[0] },
-            type: RouteLinkType.ProductList,
+            type: RouteType.ProductList,
           },
         ],
         [SuggestionField.Categories]: mockDeserializedSuggestion.categories,

--- a/libs/domain/search/src/services/adapter/normalizers/suggestion/suggestion.normalizer.spec.ts
+++ b/libs/domain/search/src/services/adapter/normalizers/suggestion/suggestion.normalizer.spec.ts
@@ -1,5 +1,4 @@
 import { ConcreteProductsNormalizer } from '@spryker-oryx/product';
-import { SemanticLinkType } from '@spryker-oryx/site';
 import { of, take } from 'rxjs';
 import { SuggestionField } from '../../suggestion.adapter';
 import { DeserializedSuggestion } from './model';
@@ -7,13 +6,14 @@ import {
   suggestionAttributesNormalizer,
   suggestionProductNormalizer,
 } from './suggestion.normalizer';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 const mockDeserializedSuggestion = {
   completion: ['A'],
   categories: [
     {
       name: 'name',
-      type: SemanticLinkType.Category,
+      type: RouteLinkType.Category,
     },
   ],
   cmsPages: [
@@ -40,7 +40,7 @@ describe('Suggestion Normalizers', () => {
           {
             name: mockDeserializedSuggestion.completion[0],
             params: { q: mockDeserializedSuggestion.completion[0] },
-            type: SemanticLinkType.ProductList,
+            type: RouteLinkType.ProductList,
           },
         ],
         [SuggestionField.Categories]: mockDeserializedSuggestion.categories,

--- a/libs/domain/search/src/services/adapter/normalizers/suggestion/suggestion.normalizer.ts
+++ b/libs/domain/search/src/services/adapter/normalizers/suggestion/suggestion.normalizer.ts
@@ -10,7 +10,7 @@ import { map, Observable } from 'rxjs';
 import { Suggestion } from '../../../../models';
 import { SuggestionField } from '../../suggestion.adapter';
 import { DeserializedSuggestion } from './model';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 export const SuggestionNormalizer = 'oryx.SuggestionNormalizer*';
 
@@ -23,14 +23,14 @@ export function suggestionAttributesNormalizer(
     [SuggestionField.Suggestions]: completion.map((name) => ({
       name,
       params: { q: name },
-      type: RouteLinkType.ProductList,
+      type: RouteType.ProductList,
     })),
     [SuggestionField.Categories]: categories.map((category) => ({
       name: category.name,
       id: categoryCollection?.find(
         (collection) => category.name === collection.name
       )?.idCategory,
-      type: RouteLinkType.Category,
+      type: RouteType.Category,
     })),
   };
 }

--- a/libs/domain/search/src/services/adapter/normalizers/suggestion/suggestion.normalizer.ts
+++ b/libs/domain/search/src/services/adapter/normalizers/suggestion/suggestion.normalizer.ts
@@ -6,11 +6,11 @@ import {
   ConcreteProductsNormalizer,
   Product,
 } from '@spryker-oryx/product';
-import { SemanticLinkType } from '@spryker-oryx/site';
 import { map, Observable } from 'rxjs';
 import { Suggestion } from '../../../../models';
 import { SuggestionField } from '../../suggestion.adapter';
 import { DeserializedSuggestion } from './model';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 export const SuggestionNormalizer = 'oryx.SuggestionNormalizer*';
 
@@ -23,14 +23,14 @@ export function suggestionAttributesNormalizer(
     [SuggestionField.Suggestions]: completion.map((name) => ({
       name,
       params: { q: name },
-      type: SemanticLinkType.ProductList,
+      type: RouteLinkType.ProductList,
     })),
     [SuggestionField.Categories]: categories.map((category) => ({
       name: category.name,
       id: categoryCollection?.find(
         (collection) => category.name === collection.name
       )?.idCategory,
-      type: SemanticLinkType.Category,
+      type: RouteLinkType.Category,
     })),
   };
 }

--- a/libs/domain/search/src/services/suggestion/default-suggestion.service.spec.ts
+++ b/libs/domain/search/src/services/suggestion/default-suggestion.service.spec.ts
@@ -1,7 +1,6 @@
 import { DefaultQueryService, QueryService } from '@spryker-oryx/core';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
 import { createSuggestionMock } from '@spryker-oryx/search/mocks';
-import { SemanticLinkType } from '@spryker-oryx/site';
 import { Observable, of, switchMap, take } from 'rxjs';
 import { SpyInstance } from 'vitest';
 import { SuggestionQualifier } from '../../models';
@@ -11,6 +10,7 @@ import {
 } from '../adapter/suggestion.adapter';
 import { DefaultSuggestionService } from './default-suggestion.service';
 import { SuggestionService } from './suggestion.service';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 const completion = ['test', 'test 1', 'test 2', 'any', 'any test'];
 
@@ -71,7 +71,7 @@ describe('DefaultSuggestionService', () => {
           [SuggestionField.Suggestions]: completion.slice(0, 3).map((name) => ({
             name,
             params: { q: name },
-            type: SemanticLinkType.ProductList,
+            type: RouteLinkType.ProductList,
           })),
         })
       );

--- a/libs/domain/search/src/services/suggestion/default-suggestion.service.spec.ts
+++ b/libs/domain/search/src/services/suggestion/default-suggestion.service.spec.ts
@@ -10,7 +10,7 @@ import {
 } from '../adapter/suggestion.adapter';
 import { DefaultSuggestionService } from './default-suggestion.service';
 import { SuggestionService } from './suggestion.service';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 const completion = ['test', 'test 1', 'test 2', 'any', 'any test'];
 
@@ -71,7 +71,7 @@ describe('DefaultSuggestionService', () => {
           [SuggestionField.Suggestions]: completion.slice(0, 3).map((name) => ({
             name,
             params: { q: name },
-            type: RouteLinkType.ProductList,
+            type: RouteType.ProductList,
           })),
         })
       );

--- a/libs/domain/search/src/services/suggestion/renderer/suggestion.renderer.ts
+++ b/libs/domain/search/src/services/suggestion/renderer/suggestion.renderer.ts
@@ -1,11 +1,11 @@
 import { Product } from '@spryker-oryx/product';
 import { ProductCardOptions } from '@spryker-oryx/product/card';
-import { SemanticLinkType } from '@spryker-oryx/site';
 import { i18n } from '@spryker-oryx/utilities';
 import { html, TemplateResult } from 'lit';
 import { when } from 'lit/directives/when.js';
 import { SuggestionResource } from '../../../models';
 import { SuggestionRenderer } from './suggestion-renderer.service';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 export const productSuggestionRenderer: SuggestionRenderer<Product[]> = (
   products,
@@ -18,7 +18,7 @@ export const productSuggestionRenderer: SuggestionRenderer<Product[]> = (
 
         <oryx-content-link
           .options=${{
-            type: SemanticLinkType.ProductList,
+            type: RouteLinkType.ProductList,
             params: { q: query },
             button: true,
           }}

--- a/libs/domain/search/src/services/suggestion/renderer/suggestion.renderer.ts
+++ b/libs/domain/search/src/services/suggestion/renderer/suggestion.renderer.ts
@@ -5,7 +5,7 @@ import { html, TemplateResult } from 'lit';
 import { when } from 'lit/directives/when.js';
 import { SuggestionResource } from '../../../models';
 import { SuggestionRenderer } from './suggestion-renderer.service';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 export const productSuggestionRenderer: SuggestionRenderer<Product[]> = (
   products,
@@ -18,7 +18,7 @@ export const productSuggestionRenderer: SuggestionRenderer<Product[]> = (
 
         <oryx-content-link
           .options=${{
-            type: RouteLinkType.ProductList,
+            type: RouteType.ProductList,
             params: { q: query },
             button: true,
           }}

--- a/libs/domain/site/navigation-item/navigation-item.component.spec.ts
+++ b/libs/domain/site/navigation-item/navigation-item.component.spec.ts
@@ -2,7 +2,7 @@ import { fixture } from '@open-wc/testing-helpers';
 import { TokenResolver } from '@spryker-oryx/core';
 import { useComponent } from '@spryker-oryx/core/utilities';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import { modalComponent } from '@spryker-oryx/ui/modal';
 import { html } from 'lit';
 import { of } from 'rxjs';
@@ -20,7 +20,7 @@ class MockTokenResolver implements Partial<TokenResolver> {
   resolveToken = vi.fn().mockReturnValue(of('test'));
 }
 
-class MockSemanticLinkService implements Partial<SemanticLinkService> {
+class MockSemanticLinkService implements Partial<LinkService> {
   get = vi.fn().mockReturnValue(of('/test'));
 }
 
@@ -45,7 +45,7 @@ describe('SiteNavigationItemComponent', () => {
           useClass: MockTokenResolver,
         },
         {
-          provide: SemanticLinkService,
+          provide: LinkService,
           useClass: MockSemanticLinkService,
         },
       ],
@@ -55,7 +55,7 @@ describe('SiteNavigationItemComponent', () => {
       TokenResolver
     ) as unknown as MockTokenResolver;
     semanticService = testInjector.inject(
-      SemanticLinkService
+      LinkService
     ) as unknown as MockSemanticLinkService;
 
     element = await fixture(html`

--- a/libs/domain/site/navigation-item/navigation-item.component.ts
+++ b/libs/domain/site/navigation-item/navigation-item.component.ts
@@ -1,7 +1,7 @@
 import { TokenResolver } from '@spryker-oryx/core';
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin, defaultOptions } from '@spryker-oryx/experience';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import {
   computed,
   hydrate,
@@ -31,7 +31,7 @@ export class SiteNavigationItemComponent extends ContentMixin<SiteNavigationItem
   static styles = styles;
 
   protected tokenResolver = resolve(TokenResolver);
-  protected semanticLinkService = resolve(SemanticLinkService);
+  protected semanticLinkService = resolve(LinkService);
 
   protected $label = computed(() => {
     const label = this.$options().label;

--- a/libs/domain/site/navigation-item/navigation-item.model.ts
+++ b/libs/domain/site/navigation-item/navigation-item.model.ts
@@ -1,10 +1,10 @@
-import { SemanticLink } from '@spryker-oryx/site';
+import { LinkOptions } from '@spryker-oryx/site';
 
 export interface SiteNavigationItemOptions {
   icon?: string;
   label?: string;
   badge?: string;
-  url?: string | SemanticLink;
+  url?: string | LinkOptions;
   triggerType?: NavigationTriggerType;
   triggerBehavior?: NavigationTriggerBehavior;
   contentBehavior?: NavigationContentBehavior;

--- a/libs/domain/site/package.json
+++ b/libs/domain/site/package.json
@@ -23,6 +23,7 @@
     "@spryker-oryx/core": "1.0.0-rc.0",
     "@spryker-oryx/di": "1.0.0-rc.0",
     "@spryker-oryx/experience": "1.0.0-rc.0",
+    "@spryker-oryx/router": "1.0.0-rc.0",
     "@spryker-oryx/ui": "1.0.0-rc.0",
     "@spryker-oryx/utilities": "1.0.0-rc.0"
   },

--- a/libs/domain/site/src/mocks/src/mock-site.providers.ts
+++ b/libs/domain/site/src/mocks/src/mock-site.providers.ts
@@ -13,12 +13,12 @@ import {
   DefaultNotificationService,
   DefaultPricingService,
   DefaultSalutationService,
-  DefaultSemanticLinkService,
+  DefaultLinkService,
   NotificationService,
   PricingService,
   SalutationService,
   SapiLocaleAdapter,
-  SemanticLinkService,
+  LinkService,
   SiteErrorHandler,
   StoreService,
 } from '@spryker-oryx/site';
@@ -62,8 +62,8 @@ export const mockSiteProviders: Provider[] = [
     useClass: DefaultPricingService,
   },
   {
-    provide: SemanticLinkService,
-    useClass: DefaultSemanticLinkService,
+    provide: LinkService,
+    useClass: DefaultLinkService,
   },
   {
     provide: NotificationService,

--- a/libs/domain/site/src/services/index.ts
+++ b/libs/domain/site/src/services/index.ts
@@ -6,6 +6,6 @@ export * from './locale';
 export * from './notification';
 export * from './pricing';
 export * from './salutation';
-export * from './semantic-link';
+export * from './link';
 export * from './site.providers';
 export * from './store';

--- a/libs/domain/site/src/services/link/default-link.service.spec.ts
+++ b/libs/domain/site/src/services/link/default-link.service.spec.ts
@@ -1,26 +1,23 @@
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
 import { RouterService } from '@spryker-oryx/router';
 import { RouteLinkType } from '@spryker-oryx/router/lit';
-import {
-  DefaultSemanticLinkService,
-  SemanticLink,
-  SemanticLinkService,
-} from '@spryker-oryx/site';
 import { Observable, of } from 'rxjs';
+import { DefaultLinkService } from './default-link.service';
+import { LinkService, LinkOptions } from './link.service';
 
 const mockRouterService = {
   getRoutes: vi.fn(),
 };
 
 describe('DefaultLinkService', () => {
-  let service: SemanticLinkService;
+  let service: LinkService;
 
   beforeEach(() => {
     const testInjector = createInjector({
       providers: [
         {
-          provide: SemanticLinkService,
-          useClass: DefaultSemanticLinkService,
+          provide: LinkService,
+          useClass: DefaultLinkService,
         },
         {
           provide: RouterService,
@@ -29,7 +26,7 @@ describe('DefaultLinkService', () => {
       ],
     });
 
-    service = testInjector.inject(SemanticLinkService);
+    service = testInjector.inject(LinkService);
     mockRouterService.getRoutes.mockReturnValue(
       of([
         {
@@ -47,7 +44,7 @@ describe('DefaultLinkService', () => {
   });
 
   it('should be provided', () => {
-    expect(service).toBeInstanceOf(DefaultSemanticLinkService);
+    expect(service).toBeInstanceOf(DefaultLinkService);
   });
 
   describe('get method', () => {
@@ -60,7 +57,7 @@ describe('DefaultLinkService', () => {
 
     describe('when type equal "RouteLinkType.Page"', () => {
       beforeEach(() => {
-        const link: SemanticLink = { type: RouteLinkType.Page, id: 'about' };
+        const link: LinkOptions = { type: RouteLinkType.Page, id: 'about' };
         service.get(link).subscribe(callback);
       });
 
@@ -80,7 +77,7 @@ describe('DefaultLinkService', () => {
             },
           ])
         );
-        const link: SemanticLink = { type: RouteLinkType.Product, id: '1' };
+        const link: LinkOptions = { type: RouteLinkType.Product, id: '1' };
         service.get(link).subscribe(callback);
       });
 
@@ -100,7 +97,7 @@ describe('DefaultLinkService', () => {
             },
           ])
         );
-        const link: SemanticLink = {
+        const link: LinkOptions = {
           type: RouteLinkType.Category,
           id: 'laptops',
         };
@@ -113,7 +110,7 @@ describe('DefaultLinkService', () => {
 
       describe('and link contains params', () => {
         beforeEach(() => {
-          const link: SemanticLink = {
+          const link: LinkOptions = {
             type: RouteLinkType.Category,
             id: 'laptops',
             params: { param1: '1', param2: '2' },
@@ -131,7 +128,7 @@ describe('DefaultLinkService', () => {
 
     describe('when just type is defined', () => {
       beforeEach(() => {
-        const link: SemanticLink = {
+        const link: LinkOptions = {
           type: RouteLinkType.Cart,
         };
         service.get(link).subscribe(callback);
@@ -145,7 +142,7 @@ describe('DefaultLinkService', () => {
     describe('when type equal "RouteLinkType.ProductList"', () => {
       describe('and link contains params', () => {
         beforeEach(() => {
-          const link: SemanticLink = {
+          const link: LinkOptions = {
             type: RouteLinkType.ProductList,
             params: { param1: '1', param2: '2' },
           };
@@ -159,7 +156,7 @@ describe('DefaultLinkService', () => {
 
       describe('and "id" is not provided', () => {
         beforeEach(() => {
-          const link: SemanticLink = {
+          const link: LinkOptions = {
             type: RouteLinkType.ProductList,
           };
           service.get(link).subscribe(callback);

--- a/libs/domain/site/src/services/link/default-link.service.spec.ts
+++ b/libs/domain/site/src/services/link/default-link.service.spec.ts
@@ -1,6 +1,5 @@
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
-import { RouterService } from '@spryker-oryx/router';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouterService, RouteType } from '@spryker-oryx/router';
 import { Observable, of } from 'rxjs';
 import { DefaultLinkService } from './default-link.service';
 import { LinkService, LinkOptions } from './link.service';
@@ -32,7 +31,7 @@ describe('DefaultLinkService', () => {
         {
           path: '/:page',
           name: 'Page',
-          type: RouteLinkType.Page,
+          type: RouteType.Page,
         },
       ])
     );
@@ -51,13 +50,13 @@ describe('DefaultLinkService', () => {
     const callback = vi.fn();
 
     it('should return an observable', () => {
-      const link = { type: RouteLinkType.Page, id: 'about' };
+      const link = { type: RouteType.Page, id: 'about' };
       expect(service.get(link)).toBeInstanceOf(Observable);
     });
 
-    describe('when type equal "RouteLinkType.Page"', () => {
+    describe('when type equal "RouteType.Page"', () => {
       beforeEach(() => {
-        const link: LinkOptions = { type: RouteLinkType.Page, id: 'about' };
+        const link: LinkOptions = { type: RouteType.Page, id: 'about' };
         service.get(link).subscribe(callback);
       });
 
@@ -66,18 +65,18 @@ describe('DefaultLinkService', () => {
       });
     });
 
-    describe('when type equal "RouteLinkType.Product"', () => {
+    describe('when type equal "RouteType.Product"', () => {
       beforeEach(() => {
         mockRouterService.getRoutes.mockReturnValue(
           of([
             {
               path: '/product/:id',
               name: 'Page',
-              type: RouteLinkType.Product,
+              type: RouteType.Product,
             },
           ])
         );
-        const link: LinkOptions = { type: RouteLinkType.Product, id: '1' };
+        const link: LinkOptions = { type: RouteType.Product, id: '1' };
         service.get(link).subscribe(callback);
       });
 
@@ -86,19 +85,19 @@ describe('DefaultLinkService', () => {
       });
     });
 
-    describe('when type equal "RouteLinkType.Category"', () => {
+    describe('when type equal "RouteType.Category"', () => {
       beforeEach(() => {
         mockRouterService.getRoutes.mockReturnValue(
           of([
             {
               path: '/category/:id',
               name: 'Page',
-              type: RouteLinkType.Category,
+              type: RouteType.Category,
             },
           ])
         );
         const link: LinkOptions = {
-          type: RouteLinkType.Category,
+          type: RouteType.Category,
           id: 'laptops',
         };
         service.get(link).subscribe(callback);
@@ -111,7 +110,7 @@ describe('DefaultLinkService', () => {
       describe('and link contains params', () => {
         beforeEach(() => {
           const link: LinkOptions = {
-            type: RouteLinkType.Category,
+            type: RouteType.Category,
             id: 'laptops',
             params: { param1: '1', param2: '2' },
           };
@@ -129,7 +128,7 @@ describe('DefaultLinkService', () => {
     describe('when just type is defined', () => {
       beforeEach(() => {
         const link: LinkOptions = {
-          type: RouteLinkType.Cart,
+          type: RouteType.Cart,
         };
         service.get(link).subscribe(callback);
       });
@@ -139,11 +138,11 @@ describe('DefaultLinkService', () => {
       });
     });
 
-    describe('when type equal "RouteLinkType.ProductList"', () => {
+    describe('when type equal "RouteType.ProductList"', () => {
       describe('and link contains params', () => {
         beforeEach(() => {
           const link: LinkOptions = {
-            type: RouteLinkType.ProductList,
+            type: RouteType.ProductList,
             params: { param1: '1', param2: '2' },
           };
           service.get(link).subscribe(callback);
@@ -157,7 +156,7 @@ describe('DefaultLinkService', () => {
       describe('and "id" is not provided', () => {
         beforeEach(() => {
           const link: LinkOptions = {
-            type: RouteLinkType.ProductList,
+            type: RouteType.ProductList,
           };
           service.get(link).subscribe(callback);
         });

--- a/libs/domain/site/src/services/link/default-link.service.ts
+++ b/libs/domain/site/src/services/link/default-link.service.ts
@@ -1,8 +1,8 @@
 import { inject } from '@spryker-oryx/di';
-import { BASE_ROUTE, RouterService } from '@spryker-oryx/router';
+import { BASE_ROUTE, RouteType, RouterService } from '@spryker-oryx/router';
 import { Observable, of, switchMap, throwError } from 'rxjs';
 import { LinkOptions, LinkService } from './link.service';
-import { RouteLinkType, isRouterPath } from '@spryker-oryx/router/lit';
+import { isRouterPath } from '@spryker-oryx/router/lit';
 
 export class DefaultLinkService implements LinkService {
   constructor(
@@ -15,7 +15,7 @@ export class DefaultLinkService implements LinkService {
       switchMap((routes) => {
         const route =
           routes?.find((route) => route.type === link.type) ??
-          routes?.find((route) => route.type === RouteLinkType.Page);
+          routes?.find((route) => route.type === RouteType.Page);
 
         if (!route || !isRouterPath(route)) {
           return throwError(() => new Error('Link type is not supported'));
@@ -24,7 +24,7 @@ export class DefaultLinkService implements LinkService {
         const dynamicId =
           link.type && link.id
             ? encodeURIComponent(link.id)
-            : route.type === RouteLinkType.Page
+            : route.type === RouteType.Page
             ? encodeURIComponent(link.type)
             : encodeURIComponent(link.id ?? '');
         const dynamicParams = link.params

--- a/libs/domain/site/src/services/link/default-link.service.ts
+++ b/libs/domain/site/src/services/link/default-link.service.ts
@@ -1,16 +1,16 @@
 import { inject } from '@spryker-oryx/di';
 import { BASE_ROUTE, RouterService } from '@spryker-oryx/router';
 import { Observable, of, switchMap, throwError } from 'rxjs';
-import { SemanticLink, SemanticLinkService } from './semantic-link.service';
+import { LinkOptions, LinkService } from './link.service';
 import { RouteLinkType, isRouterPath } from '@spryker-oryx/router/lit';
 
-export class DefaultSemanticLinkService implements SemanticLinkService {
+export class DefaultLinkService implements LinkService {
   constructor(
     protected baseRoute = inject(BASE_ROUTE, ''),
     protected routerService = inject(RouterService)
   ) {}
 
-  get(link: SemanticLink): Observable<string | undefined> {
+  get(link: LinkOptions): Observable<string | undefined> {
     return this.routerService.getRoutes().pipe(
       switchMap((routes) => {
         const route =

--- a/libs/domain/site/src/services/link/index.ts
+++ b/libs/domain/site/src/services/link/index.ts
@@ -1,0 +1,2 @@
+export * from './default-link.service';
+export * from './link.service';

--- a/libs/domain/site/src/services/link/link.service.ts
+++ b/libs/domain/site/src/services/link/link.service.ts
@@ -1,8 +1,8 @@
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 import { Observable } from 'rxjs';
 
 export interface LinkOptions {
-  type: RouteLinkType | string;
+  type: RouteType | string;
   id?: string;
   params?: Record<string, string>;
 }

--- a/libs/domain/site/src/services/link/link.service.ts
+++ b/libs/domain/site/src/services/link/link.service.ts
@@ -1,20 +1,20 @@
 import { RouteLinkType } from '@spryker-oryx/router/lit';
 import { Observable } from 'rxjs';
 
-export interface SemanticLink {
+export interface LinkOptions {
   type: RouteLinkType | string;
   id?: string;
   params?: Record<string, string>;
 }
 
-export interface SemanticLinkService {
-  get(link: SemanticLink): Observable<string | undefined>;
+export interface LinkService {
+  get(link: LinkOptions): Observable<string | undefined>;
 }
 
-export const SemanticLinkService = 'oryx.SemanticLinkService';
+export const LinkService = 'oryx.LinkService';
 
 declare global {
   interface InjectionTokensContractMap {
-    [SemanticLinkService]: SemanticLinkService;
+    [LinkService]: LinkService;
   }
 }

--- a/libs/domain/site/src/services/semantic-link/default-semantic-link.service.spec.ts
+++ b/libs/domain/site/src/services/semantic-link/default-semantic-link.service.spec.ts
@@ -1,9 +1,9 @@
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 import {
   DefaultSemanticLinkService,
   SemanticLink,
   SemanticLinkService,
-  SemanticLinkType,
 } from '@spryker-oryx/site';
 import { Observable } from 'rxjs';
 
@@ -36,13 +36,13 @@ describe('DefaultLinkService', () => {
     let callback: any;
 
     it('should return an observable', () => {
-      const link: SemanticLink = { type: SemanticLinkType.Page, id: 'about' };
+      const link: SemanticLink = { type: RouteLinkType.Page, id: 'about' };
       expect(service.get(link)).toBeInstanceOf(Observable);
     });
 
-    describe('when type equal "SemanticLinkType.Page"', () => {
+    describe('when type equal "RouteLinkType.Page"', () => {
       beforeEach(() => {
-        const link: SemanticLink = { type: SemanticLinkType.Page, id: 'about' };
+        const link: SemanticLink = { type: RouteLinkType.Page, id: 'about' };
         callback = vi.fn();
         service.get(link).subscribe(callback);
       });
@@ -52,9 +52,9 @@ describe('DefaultLinkService', () => {
       });
     });
 
-    describe('when type equal "SemanticLinkType.Product"', () => {
+    describe('when type equal "RouteLinkType.Product"', () => {
       beforeEach(() => {
-        const link: SemanticLink = { type: SemanticLinkType.Product, id: '1' };
+        const link: SemanticLink = { type: RouteLinkType.Product, id: '1' };
         callback = vi.fn();
         service.get(link).subscribe(callback);
       });
@@ -64,10 +64,10 @@ describe('DefaultLinkService', () => {
       });
     });
 
-    describe('when type equal "SemanticLinkType.Category"', () => {
+    describe('when type equal "RouteLinkType.Category"', () => {
       beforeEach(() => {
         const link: SemanticLink = {
-          type: SemanticLinkType.Category,
+          type: RouteLinkType.Category,
           id: 'laptops',
         };
         callback = vi.fn();
@@ -81,7 +81,7 @@ describe('DefaultLinkService', () => {
       describe('and link contains params', () => {
         beforeEach(() => {
           const link: SemanticLink = {
-            type: SemanticLinkType.Category,
+            type: RouteLinkType.Category,
             id: 'laptops',
             params: { param1: '1', param2: '2' },
           };
@@ -97,10 +97,10 @@ describe('DefaultLinkService', () => {
       });
     });
 
-    describe('when type equal "SemanticLinkType.Cart"', () => {
+    describe('when type equal "RouteLinkType.Cart"', () => {
       beforeEach(() => {
         const link: SemanticLink = {
-          type: SemanticLinkType.Cart,
+          type: RouteLinkType.Cart,
         };
         callback = vi.fn();
         service.get(link).subscribe(callback);
@@ -111,10 +111,10 @@ describe('DefaultLinkService', () => {
       });
     });
 
-    describe('when type equal "SemanticLinkType.Checkout"', () => {
+    describe('when type equal "RouteLinkType.Checkout"', () => {
       beforeEach(() => {
         const link: SemanticLink = {
-          type: SemanticLinkType.Checkout,
+          type: RouteLinkType.Checkout,
         };
         callback = vi.fn();
         service.get(link).subscribe(callback);
@@ -125,10 +125,10 @@ describe('DefaultLinkService', () => {
       });
     });
 
-    describe('when type equal "SemanticLinkType.ProductList"', () => {
+    describe('when type equal "RouteLinkType.ProductList"', () => {
       beforeEach(() => {
         const link: SemanticLink = {
-          type: SemanticLinkType.ProductList,
+          type: RouteLinkType.ProductList,
           id: '?test=test',
         };
         callback = vi.fn();
@@ -142,7 +142,7 @@ describe('DefaultLinkService', () => {
       describe('and link contains params', () => {
         beforeEach(() => {
           const link: SemanticLink = {
-            type: SemanticLinkType.ProductList,
+            type: RouteLinkType.ProductList,
             params: { param1: '1', param2: '2' },
           };
           callback = vi.fn();
@@ -157,7 +157,7 @@ describe('DefaultLinkService', () => {
       describe('and "id" is not provided', () => {
         beforeEach(() => {
           const link: SemanticLink = {
-            type: SemanticLinkType.ProductList,
+            type: RouteLinkType.ProductList,
           };
           callback = vi.fn();
           service.get(link).subscribe(callback);

--- a/libs/domain/site/src/services/semantic-link/default-semantic-link.service.ts
+++ b/libs/domain/site/src/services/semantic-link/default-semantic-link.service.ts
@@ -1,47 +1,44 @@
 import { inject } from '@spryker-oryx/di';
 import { BASE_ROUTE, RouterService } from '@spryker-oryx/router';
-import { Observable, of, throwError } from 'rxjs';
+import { Observable, of, switchMap, throwError } from 'rxjs';
 import { SemanticLink, SemanticLinkService } from './semantic-link.service';
 import { RouteLinkType, isRouterPath } from '@spryker-oryx/router/lit';
 
 export class DefaultSemanticLinkService implements SemanticLinkService {
-  protected types = {
-    // [SemanticLinkType.AddressList]: (): string => `/my-account/addresses`,
-    // [SemanticLinkType.AddressBookCreate]: (): string =>
-    //   `/my-account/addresses/create`,
-    // [SemanticLinkType.AddressBookEdit]: (link: SemanticLink): string =>
-    //   `/my-account/addresses/edit/${link.id}`,
-  };
-
   constructor(
     protected baseRoute = inject(BASE_ROUTE, ''),
     protected routerService = inject(RouterService)
   ) {}
 
   get(link: SemanticLink): Observable<string | undefined> {
-    const routes = this.routerService.getRoutes();
-    const route =
-      routes?.find((route) => route.type === link.type) ??
-      routes?.find((route) => route.type === RouteLinkType.Page);
+    return this.routerService.getRoutes().pipe(
+      switchMap((routes) => {
+        const route =
+          routes?.find((route) => route.type === link.type) ??
+          routes?.find((route) => route.type === RouteLinkType.Page);
 
-    if (!route || !isRouterPath(route)) {
-      return throwError(() => new Error('Link type is not supported'));
-    }
+        if (!route || !isRouterPath(route)) {
+          return throwError(() => new Error('Link type is not supported'));
+        }
 
-    const dynamicId =
-      route.type === RouteLinkType.Page
-        ? encodeURIComponent(link.type)
-        : encodeURIComponent(link.id ?? '');
-    const dynamicParams = link.params
-      ? `?${this.getUrlParams(link.params)}`
-      : '';
-    const parts = route.path.split('/');
-    parts.pop();
-    const path = `${parts.join('/')}${
-      dynamicId ? `/${dynamicId}` : ''
-    }${dynamicParams}`;
+        const dynamicId =
+          link.type && link.id
+            ? encodeURIComponent(link.id)
+            : route.type === RouteLinkType.Page
+            ? encodeURIComponent(link.type)
+            : encodeURIComponent(link.id ?? '');
+        const dynamicParams = link.params
+          ? `?${this.getUrlParams(link.params)}`
+          : '';
+        const parts = route.path.split('/');
+        parts.pop();
+        const path = `${parts.join('/')}${
+          dynamicId ? `/${dynamicId}` : ''
+        }${dynamicParams}`;
 
-    return of(`${this.baseRoute}${path}`);
+        return of(`${this.baseRoute}${path}`);
+      })
+    );
   }
 
   private getUrlParams(params: Record<string, string>): string {

--- a/libs/domain/site/src/services/semantic-link/index.ts
+++ b/libs/domain/site/src/services/semantic-link/index.ts
@@ -1,2 +1,0 @@
-export * from './default-semantic-link.service';
-export * from './semantic-link.service';

--- a/libs/domain/site/src/services/semantic-link/semantic-link.service.ts
+++ b/libs/domain/site/src/services/semantic-link/semantic-link.service.ts
@@ -2,7 +2,7 @@ import { RouteLinkType } from '@spryker-oryx/router/lit';
 import { Observable } from 'rxjs';
 
 export interface SemanticLink {
-  type: RouteLinkType;
+  type: RouteLinkType | string;
   id?: string;
   params?: Record<string, string>;
 }

--- a/libs/domain/site/src/services/semantic-link/semantic-link.service.ts
+++ b/libs/domain/site/src/services/semantic-link/semantic-link.service.ts
@@ -1,24 +1,10 @@
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 import { Observable } from 'rxjs';
 
 export interface SemanticLink {
-  type: SemanticLinkType;
+  type: RouteLinkType;
   id?: string;
   params?: Record<string, string>;
-}
-
-export enum SemanticLinkType {
-  ProductList = 'search',
-  Page = 'page',
-  Product = 'product',
-  Category = 'category',
-  Checkout = 'checkout',
-  CheckoutLogin = 'checkoutLogin',
-  Order = 'order',
-  Cart = 'cart',
-  Login = 'login',
-  AddressList = 'address-list',
-  AddressBookCreate = 'address-book-create',
-  AddressBookEdit = 'address-book-edit',
 }
 
 export interface SemanticLinkService {

--- a/libs/domain/site/src/services/site.providers.ts
+++ b/libs/domain/site/src/services/site.providers.ts
@@ -21,10 +21,7 @@ import {
 } from './notification';
 import { DefaultPricingService, PricingService } from './pricing';
 import { DefaultSalutationService, SalutationService } from './salutation';
-import {
-  DefaultSemanticLinkService,
-  SemanticLinkService,
-} from './semantic-link';
+import { DefaultLinkService, LinkService } from './link';
 import { DefaultStoreService, StoreService } from './store';
 
 declare global {
@@ -44,8 +41,8 @@ export const siteProviders: Provider[] = [
     useFactory: () => injectEnv('STORE', ''),
   },
   {
-    provide: SemanticLinkService,
-    useClass: DefaultSemanticLinkService,
+    provide: LinkService,
+    useClass: DefaultLinkService,
   },
   {
     provide: StoreService,

--- a/libs/domain/user/address-add-button/address-add-button.component.spec.ts
+++ b/libs/domain/user/address-add-button/address-add-button.component.spec.ts
@@ -2,7 +2,7 @@ import { fixture } from '@open-wc/testing-helpers';
 import { useComponent } from '@spryker-oryx/core/utilities';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
 import { RouterService } from '@spryker-oryx/router';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import {
   Address,
   AddressService,
@@ -39,7 +39,7 @@ class MockAddressStateService implements Partial<AddressStateService> {
   get = vi.fn().mockReturnValue(mockState);
   clear = vi.fn();
 }
-class MockSemanticLinkService implements Partial<SemanticLinkService> {
+class MockSemanticLinkService implements Partial<LinkService> {
   get = vi.fn();
 }
 
@@ -67,7 +67,7 @@ describe('UserAddressAddButtonComponent', () => {
           useClass: MockRouterService,
         },
         {
-          provide: SemanticLinkService,
+          provide: LinkService,
           useClass: MockSemanticLinkService,
         },
       ],

--- a/libs/domain/user/address-add-button/address-add-button.component.ts
+++ b/libs/domain/user/address-add-button/address-add-button.component.ts
@@ -10,7 +10,7 @@ import {
   Target,
   UserAddressAddButtonOptions,
 } from './address-add-button.model';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 @defaultOptions({ target: Target.Link })
 @hydrate({ event: ['mouseover', 'focusin'] })
@@ -20,7 +20,7 @@ export class UserAddressAddButtonComponent extends AddressMixin(
   protected semanticLinkService = resolve(LinkService);
 
   protected $createLink = signal(
-    this.semanticLinkService.get({ type: RouteLinkType.AddressBookCreate })
+    this.semanticLinkService.get({ type: RouteType.AddressBookCreate })
   );
 
   protected render(): TemplateResult | void {

--- a/libs/domain/user/address-add-button/address-add-button.component.ts
+++ b/libs/domain/user/address-add-button/address-add-button.component.ts
@@ -1,6 +1,6 @@
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin, defaultOptions } from '@spryker-oryx/experience';
-import { SemanticLinkService, SemanticLinkType } from '@spryker-oryx/site';
+import { SemanticLinkService } from '@spryker-oryx/site';
 import { IconTypes } from '@spryker-oryx/ui/icon';
 import { hydrate, signal } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
@@ -10,6 +10,7 @@ import {
   Target,
   UserAddressAddButtonOptions,
 } from './address-add-button.model';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 @defaultOptions({ target: Target.Link })
 @hydrate({ event: ['mouseover', 'focusin'] })
@@ -19,7 +20,7 @@ export class UserAddressAddButtonComponent extends AddressMixin(
   protected semanticLinkService = resolve(SemanticLinkService);
 
   protected $createLink = signal(
-    this.semanticLinkService.get({ type: SemanticLinkType.AddressBookCreate })
+    this.semanticLinkService.get({ type: RouteLinkType.AddressBookCreate })
   );
 
   protected render(): TemplateResult | void {

--- a/libs/domain/user/address-add-button/address-add-button.component.ts
+++ b/libs/domain/user/address-add-button/address-add-button.component.ts
@@ -1,6 +1,6 @@
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin, defaultOptions } from '@spryker-oryx/experience';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import { IconTypes } from '@spryker-oryx/ui/icon';
 import { hydrate, signal } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
@@ -17,7 +17,7 @@ import { RouteLinkType } from '@spryker-oryx/router/lit';
 export class UserAddressAddButtonComponent extends AddressMixin(
   ContentMixin<UserAddressAddButtonOptions>(LitElement)
 ) {
-  protected semanticLinkService = resolve(SemanticLinkService);
+  protected semanticLinkService = resolve(LinkService);
 
   protected $createLink = signal(
     this.semanticLinkService.get({ type: RouteLinkType.AddressBookCreate })

--- a/libs/domain/user/address-edit-button/address-edit-button.component.spec.ts
+++ b/libs/domain/user/address-edit-button/address-edit-button.component.spec.ts
@@ -2,7 +2,7 @@ import { fixture } from '@open-wc/testing-helpers';
 import { useComponent } from '@spryker-oryx/core/utilities';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
 import { RouterService } from '@spryker-oryx/router';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import {
   Address,
   AddressService,
@@ -35,7 +35,7 @@ class MockAddressStateService implements Partial<AddressStateService> {
   get = vi.fn().mockReturnValue(mockState);
   clear = vi.fn();
 }
-class MockSemanticLinkService implements Partial<SemanticLinkService> {
+class MockSemanticLinkService implements Partial<LinkService> {
   get = vi.fn();
 }
 
@@ -63,7 +63,7 @@ describe('UserAddressEditButtonComponent', () => {
           useClass: MockRouterService,
         },
         {
-          provide: SemanticLinkService,
+          provide: LinkService,
           useClass: MockSemanticLinkService,
         },
       ],

--- a/libs/domain/user/address-edit-button/address-edit-button.component.ts
+++ b/libs/domain/user/address-edit-button/address-edit-button.component.ts
@@ -7,7 +7,7 @@ import { html, LitElement, TemplateResult } from 'lit';
 import { AddressMixin } from '../src/mixins';
 import { CrudState } from '../src/models';
 import { AddressEditButtonOptions, Target } from './address-edit-button.model';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 @defaultOptions({ target: Target.Link })
 @hydrate({ event: ['mouseover', 'focusin'] })
@@ -20,7 +20,7 @@ export class UserAddressEditButtonComponent extends AddressMixin(
     const id = this.$addressId();
     if (!id) return;
     return this.semanticLinkService.get({
-      type: RouteLinkType.AddressBookEdit,
+      type: RouteType.AddressBookEdit,
       id,
     });
   });

--- a/libs/domain/user/address-edit-button/address-edit-button.component.ts
+++ b/libs/domain/user/address-edit-button/address-edit-button.component.ts
@@ -1,6 +1,6 @@
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin, defaultOptions } from '@spryker-oryx/experience';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import { IconTypes } from '@spryker-oryx/ui/icon';
 import { computed, hydrate } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
@@ -14,7 +14,7 @@ import { RouteLinkType } from '@spryker-oryx/router/lit';
 export class UserAddressEditButtonComponent extends AddressMixin(
   ContentMixin<AddressEditButtonOptions>(LitElement)
 ) {
-  protected semanticLinkService = resolve(SemanticLinkService);
+  protected semanticLinkService = resolve(LinkService);
 
   protected editLink = computed(() => {
     const id = this.$addressId();

--- a/libs/domain/user/address-edit-button/address-edit-button.component.ts
+++ b/libs/domain/user/address-edit-button/address-edit-button.component.ts
@@ -1,12 +1,13 @@
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin, defaultOptions } from '@spryker-oryx/experience';
-import { SemanticLinkService, SemanticLinkType } from '@spryker-oryx/site';
+import { SemanticLinkService } from '@spryker-oryx/site';
 import { IconTypes } from '@spryker-oryx/ui/icon';
 import { computed, hydrate } from '@spryker-oryx/utilities';
 import { html, LitElement, TemplateResult } from 'lit';
 import { AddressMixin } from '../src/mixins';
 import { CrudState } from '../src/models';
 import { AddressEditButtonOptions, Target } from './address-edit-button.model';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 @defaultOptions({ target: Target.Link })
 @hydrate({ event: ['mouseover', 'focusin'] })
@@ -19,7 +20,7 @@ export class UserAddressEditButtonComponent extends AddressMixin(
     const id = this.$addressId();
     if (!id) return;
     return this.semanticLinkService.get({
-      type: SemanticLinkType.AddressBookEdit,
+      type: RouteLinkType.AddressBookEdit,
       id,
     });
   });

--- a/libs/domain/user/address-edit/address-edit.component.spec.ts
+++ b/libs/domain/user/address-edit/address-edit.component.spec.ts
@@ -2,7 +2,7 @@ import { fixture } from '@open-wc/testing-helpers';
 import { useComponent } from '@spryker-oryx/core/utilities';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
 import { RouterService } from '@spryker-oryx/router';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import {
   Address,
   AddressEventDetail,
@@ -42,7 +42,7 @@ class MockAddressStateService implements Partial<AddressStateService> {
   get = vi.fn().mockReturnValue(mockState);
   clear = vi.fn();
 }
-class MockSemanticLinkService implements Partial<SemanticLinkService> {
+class MockSemanticLinkService implements Partial<LinkService> {
   get = vi.fn().mockReturnValue(of('/link'));
 }
 
@@ -76,7 +76,7 @@ describe('UserAddressEditComponent', () => {
           useClass: MockRouterService,
         },
         {
-          provide: SemanticLinkService,
+          provide: LinkService,
           useClass: MockSemanticLinkService,
         },
       ],

--- a/libs/domain/user/address-edit/address-edit.component.ts
+++ b/libs/domain/user/address-edit/address-edit.component.ts
@@ -1,7 +1,7 @@
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin, defaultOptions } from '@spryker-oryx/experience';
 import { RouterService } from '@spryker-oryx/router';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import {
   Address,
   AddressEventDetail,
@@ -29,7 +29,7 @@ export class UserAddressEditComponent extends AddressMixin(
   static styles = styles;
 
   protected routerService = resolve(RouterService);
-  protected semanticLinkService = resolve(SemanticLinkService);
+  protected semanticLinkService = resolve(LinkService);
 
   protected $listPageRoute = signal(
     this.semanticLinkService.get({ type: RouteLinkType.AddressList })

--- a/libs/domain/user/address-edit/address-edit.component.ts
+++ b/libs/domain/user/address-edit/address-edit.component.ts
@@ -1,7 +1,7 @@
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin, defaultOptions } from '@spryker-oryx/experience';
 import { RouterService } from '@spryker-oryx/router';
-import { SemanticLinkService, SemanticLinkType } from '@spryker-oryx/site';
+import { SemanticLinkService } from '@spryker-oryx/site';
 import {
   Address,
   AddressEventDetail,
@@ -19,6 +19,7 @@ import {
   UserAddressEditComponentOptions,
 } from './address-edit.model';
 import { styles } from './address-edit.styles';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 @defaultOptions({ save: SaveOption.Save, inline: false })
 @hydrate({ event: ['mouseover', 'focusin'] })
@@ -31,7 +32,7 @@ export class UserAddressEditComponent extends AddressMixin(
   protected semanticLinkService = resolve(SemanticLinkService);
 
   protected $listPageRoute = signal(
-    this.semanticLinkService.get({ type: SemanticLinkType.AddressList })
+    this.semanticLinkService.get({ type: RouteLinkType.AddressList })
   );
 
   // TODO: move to central place

--- a/libs/domain/user/address-edit/address-edit.component.ts
+++ b/libs/domain/user/address-edit/address-edit.component.ts
@@ -19,7 +19,7 @@ import {
   UserAddressEditComponentOptions,
 } from './address-edit.model';
 import { styles } from './address-edit.styles';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 @defaultOptions({ save: SaveOption.Save, inline: false })
 @hydrate({ event: ['mouseover', 'focusin'] })
@@ -32,7 +32,7 @@ export class UserAddressEditComponent extends AddressMixin(
   protected semanticLinkService = resolve(LinkService);
 
   protected $listPageRoute = signal(
-    this.semanticLinkService.get({ type: RouteLinkType.AddressList })
+    this.semanticLinkService.get({ type: RouteType.AddressList })
   );
 
   // TODO: move to central place

--- a/libs/domain/user/address-list-item/address-list-item.component.spec.ts
+++ b/libs/domain/user/address-list-item/address-list-item.component.spec.ts
@@ -2,7 +2,7 @@ import { fixture } from '@open-wc/testing-helpers';
 import { useComponent } from '@spryker-oryx/core/utilities';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
 import { RouterService } from '@spryker-oryx/router';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import { ButtonComponent } from '@spryker-oryx/ui/button';
 import { IconComponent } from '@spryker-oryx/ui/icon';
 import {
@@ -46,7 +46,7 @@ class MockAddressStateService implements Partial<AddressStateService> {
   clear = vi.fn();
 }
 
-class MockSemanticLinkService implements Partial<SemanticLinkService> {
+class MockSemanticLinkService implements Partial<LinkService> {
   get = vi.fn().mockReturnValue(of('/link'));
 }
 
@@ -75,7 +75,7 @@ describe('UserAddressListItemComponent', () => {
           useClass: MockRouterService,
         },
         {
-          provide: SemanticLinkService,
+          provide: LinkService,
           useClass: MockSemanticLinkService,
         },
       ],

--- a/libs/domain/user/address-list-item/address-list-item.component.ts
+++ b/libs/domain/user/address-list-item/address-list-item.component.ts
@@ -1,6 +1,6 @@
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin } from '@spryker-oryx/experience';
-import { SemanticLinkService, SemanticLinkType } from '@spryker-oryx/site';
+import { SemanticLinkService } from '@spryker-oryx/site';
 import { AlertType } from '@spryker-oryx/ui';
 import { IconTypes } from '@spryker-oryx/ui/icon';
 import { AddressMixin, CrudState } from '@spryker-oryx/user';
@@ -13,6 +13,7 @@ import {
   UserAddressListItemOptions,
 } from './address-list-item.model';
 import { styles } from './address-list-item.styles';
+import { RouteLinkType } from '@spryker-oryx/router/lit';
 
 @hydrate({ event: 'window:load' })
 export class UserAddressListItemComponent extends AddressMixin(
@@ -25,7 +26,7 @@ export class UserAddressListItemComponent extends AddressMixin(
   protected editLink = computed(() => {
     const id = this.$address()?.id;
     return this.semanticLinkService.get({
-      type: SemanticLinkType.AddressBookEdit,
+      type: RouteLinkType.AddressBookEdit,
       id,
     });
   });

--- a/libs/domain/user/address-list-item/address-list-item.component.ts
+++ b/libs/domain/user/address-list-item/address-list-item.component.ts
@@ -1,6 +1,6 @@
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin } from '@spryker-oryx/experience';
-import { SemanticLinkService } from '@spryker-oryx/site';
+import { LinkService } from '@spryker-oryx/site';
 import { AlertType } from '@spryker-oryx/ui';
 import { IconTypes } from '@spryker-oryx/ui/icon';
 import { AddressMixin, CrudState } from '@spryker-oryx/user';
@@ -21,7 +21,7 @@ export class UserAddressListItemComponent extends AddressMixin(
 ) {
   static styles = styles;
 
-  protected semanticLinkService = resolve(SemanticLinkService);
+  protected semanticLinkService = resolve(LinkService);
 
   protected editLink = computed(() => {
     const id = this.$address()?.id;

--- a/libs/domain/user/address-list-item/address-list-item.component.ts
+++ b/libs/domain/user/address-list-item/address-list-item.component.ts
@@ -13,7 +13,7 @@ import {
   UserAddressListItemOptions,
 } from './address-list-item.model';
 import { styles } from './address-list-item.styles';
-import { RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
 
 @hydrate({ event: 'window:load' })
 export class UserAddressListItemComponent extends AddressMixin(
@@ -26,7 +26,7 @@ export class UserAddressListItemComponent extends AddressMixin(
   protected editLink = computed(() => {
     const id = this.$address()?.id;
     return this.semanticLinkService.get({
-      type: RouteLinkType.AddressBookEdit,
+      type: RouteType.AddressBookEdit,
       id,
     });
   });

--- a/libs/domain/user/package.json
+++ b/libs/domain/user/package.json
@@ -26,6 +26,7 @@
     "@spryker-oryx/experience": "1.0.0-rc.0",
     "@spryker-oryx/form": "1.0.0-rc.0",
     "@spryker-oryx/site": "1.0.0-rc.0",
+    "@spryker-oryx/router": "1.0.0-rc.0",
     "@spryker-oryx/ui": "1.0.0-rc.0",
     "@spryker-oryx/utilities": "1.0.0-rc.0"
   },

--- a/libs/platform/experience/src/index.ts
+++ b/libs/platform/experience/src/index.ts
@@ -7,3 +7,4 @@ export * from './mixins';
 export * from './models';
 export * from './plugins';
 export * from './services';
+export * from './routes';

--- a/libs/platform/experience/src/mocks/src/mock-router.service.ts
+++ b/libs/platform/experience/src/mocks/src/mock-router.service.ts
@@ -1,4 +1,6 @@
+import { defaultExperienceRoutes } from '@spryker-oryx/experience';
 import { RouteParams, RouterService } from '@spryker-oryx/router';
+import { RouteConfig } from '@spryker-oryx/router/lit';
 import { Observable, of, ReplaySubject } from 'rxjs';
 
 export class MockRouterService implements Partial<RouterService> {
@@ -40,5 +42,13 @@ export class MockRouterService implements Partial<RouterService> {
 
   previousRoute(): Observable<string | null> {
     return of(null);
+  }
+
+  setRoutes(routes: RouteConfig[]): void {
+    //
+  }
+
+  getRoutes(): Observable<RouteConfig[]> {
+    return of(defaultExperienceRoutes);
   }
 }

--- a/libs/platform/experience/src/routes.ts
+++ b/libs/platform/experience/src/routes.ts
@@ -1,4 +1,5 @@
-import { RouteConfig, RouteLinkType } from '@spryker-oryx/router/lit';
+import { RouteType } from '@spryker-oryx/router';
+import { RouteConfig } from '@spryker-oryx/router/lit';
 import { html, TemplateResult } from 'lit';
 import 'urlpattern-polyfill';
 
@@ -7,45 +8,30 @@ export const defaultExperienceRoutes: RouteConfig[] = [
     pattern: new URLPattern({ pathname: '/{index.html}?' }),
     render: (): TemplateResult =>
       html`<oryx-composition route="/"></oryx-composition>`,
-    name: 'Home',
   },
   {
     path: '/product/:sku',
-    render: (): TemplateResult => html`<oryx-composition
-      route="/product/:sku"
-    ></oryx-composition>`,
-    name: 'Product test',
-    type: RouteLinkType.Product,
+    type: RouteType.Product,
   },
   {
     path: '/category/:id',
-    render: (): TemplateResult => html`<oryx-composition
-      route="/category/:id"
-    ></oryx-composition>`,
-    name: 'Category test',
-    type: RouteLinkType.Category,
+    type: RouteType.Category,
   },
   {
     path: '/order/:id',
-    render: (): TemplateResult => html`<oryx-composition
-      route="/order/:id"
-    ></oryx-composition>`,
-    name: 'Order',
-    type: RouteLinkType.Order,
+    type: RouteType.Order,
   },
   {
     path: '/:page',
     render: ({ page }): TemplateResult => html`<oryx-composition
       route="/${page}"
     ></oryx-composition>`,
-    name: 'Page',
-    type: RouteLinkType.Page,
+    type: RouteType.Page,
   },
   {
     path: '/*',
     render: (): TemplateResult =>
       html`<oryx-heading><h1>Error 404</h1></oryx-heading>
         <p>Page not found</p>`,
-    name: '404',
   },
 ];

--- a/libs/platform/experience/src/routes.ts
+++ b/libs/platform/experience/src/routes.ts
@@ -34,14 +34,6 @@ export const defaultExperienceRoutes: RouteConfig[] = [
     type: RouteLinkType.Order,
   },
   {
-    path: '/my-account/addresses/edit/:id',
-    render: (): TemplateResult => html`<oryx-composition
-      route="/my-account/addresses/edit/:id"
-    ></oryx-composition>`,
-    name: 'Address Book Edit',
-    type: RouteLinkType.AddressBookEdit,
-  },
-  {
     path: '/:page',
     render: ({ page }): TemplateResult => html`<oryx-composition
       route="/${page}"

--- a/libs/platform/experience/src/routes.ts
+++ b/libs/platform/experience/src/routes.ts
@@ -1,4 +1,4 @@
-import { RouteConfig } from '@spryker-oryx/router/lit';
+import { RouteConfig, RouteLinkType } from '@spryker-oryx/router/lit';
 import { html, TemplateResult } from 'lit';
 import 'urlpattern-polyfill';
 
@@ -15,6 +15,7 @@ export const defaultExperienceRoutes: RouteConfig[] = [
       route="/product/:sku"
     ></oryx-composition>`,
     name: 'Product test',
+    type: RouteLinkType.Product,
   },
   {
     path: '/category/:id',
@@ -22,6 +23,7 @@ export const defaultExperienceRoutes: RouteConfig[] = [
       route="/category/:id"
     ></oryx-composition>`,
     name: 'Category test',
+    type: RouteLinkType.Category,
   },
   {
     path: '/order/:id',
@@ -29,6 +31,15 @@ export const defaultExperienceRoutes: RouteConfig[] = [
       route="/order/:id"
     ></oryx-composition>`,
     name: 'Order',
+    type: RouteLinkType.Order,
+  },
+  {
+    path: '/my-account/addresses/edit/:id',
+    render: (): TemplateResult => html`<oryx-composition
+      route="/my-account/addresses/edit/:id"
+    ></oryx-composition>`,
+    name: 'Address Book Edit',
+    type: RouteLinkType.AddressBookEdit,
   },
   {
     path: '/:page',
@@ -36,6 +47,7 @@ export const defaultExperienceRoutes: RouteConfig[] = [
       route="/${page}"
     ></oryx-composition>`,
     name: 'Page',
+    type: RouteLinkType.Page,
   },
   {
     path: '/*',

--- a/libs/platform/experience/src/routes.ts
+++ b/libs/platform/experience/src/routes.ts
@@ -6,8 +6,6 @@ import 'urlpattern-polyfill';
 export const defaultExperienceRoutes: RouteConfig[] = [
   {
     pattern: new URLPattern({ pathname: '/{index.html}?' }),
-    render: (): TemplateResult =>
-      html`<oryx-composition route="/"></oryx-composition>`,
   },
   {
     path: '/product/:sku',
@@ -23,9 +21,6 @@ export const defaultExperienceRoutes: RouteConfig[] = [
   },
   {
     path: '/:page',
-    render: ({ page }): TemplateResult => html`<oryx-composition
-      route="/${page}"
-    ></oryx-composition>`,
     type: RouteType.Page,
   },
   {

--- a/libs/platform/router/lit/lit-router.spec.ts
+++ b/libs/platform/router/lit/lit-router.spec.ts
@@ -17,6 +17,7 @@ const mockRouterService = {
   currentRoute: vi.fn(),
   acceptParams: vi.fn(),
   go: vi.fn(),
+  setRoutes: vi.fn(),
 };
 
 const awaiterResolver = vi.fn();

--- a/libs/platform/router/lit/lit-router.ts
+++ b/libs/platform/router/lit/lit-router.ts
@@ -72,6 +72,8 @@ export class LitRouter extends Routes {
 
     super(host, routes);
 
+    this.routerService.setRoutes(routes);
+
     if (baseRoute) {
       this.baseRoute = baseRoute;
     }

--- a/libs/platform/router/lit/lit-routes.ts
+++ b/libs/platform/router/lit/lit-routes.ts
@@ -279,13 +279,19 @@ export class Routes implements ReactiveController {
    * The result of calling the current route's render() callback.
    */
   outlet(): unknown {
-    if (!this._currentRoute?.render && isRouterPath(this._currentRoute)) {
-      return html`<oryx-composition
-        route=${this._currentRoute.path}
-      ></oryx-composition>`;
+    if (this._currentRoute?.render) {
+      return this._currentRoute?.render?.(this._currentParams);
     }
 
-    return this._currentRoute?.render?.(this._currentParams);
+    if (isRouterPath(this._currentRoute)) {
+      const path = this._currentParams.page
+        ? `/${this._currentParams.page}`
+        : this._currentRoute.path;
+
+      return html`<oryx-composition route=${path}></oryx-composition>`;
+    }
+
+    return html`<oryx-composition route="/"></oryx-composition>`;
   }
 
   /**

--- a/libs/platform/router/lit/lit-routes.ts
+++ b/libs/platform/router/lit/lit-routes.ts
@@ -6,23 +6,13 @@
 
 /// <reference types="urlpattern-polyfill" />
 
-import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import { RouteType } from '@spryker-oryx/router';
+import {
+  html,
+  type ReactiveController,
+  type ReactiveControllerHost,
+} from 'lit';
 import { lastValueFrom, Observable } from 'rxjs';
-
-export const enum RouteLinkType {
-  Page = 'page',
-  ProductList = 'search',
-  Product = 'product',
-  Category = 'category',
-  Checkout = 'checkout',
-  CheckoutLogin = 'checkoutLogin',
-  Order = 'order',
-  Cart = 'cart',
-  Login = 'login',
-  AddressList = 'address-list',
-  AddressBookCreate = 'address-book-create',
-  AddressBookEdit = 'address-book-edit',
-}
 
 export interface BaseRouteConfig {
   name?: string;
@@ -33,7 +23,7 @@ export interface BaseRouteConfig {
   leave?: (params: {
     [key: string]: string | undefined;
   }) => Observable<boolean>;
-  type?: RouteLinkType | string;
+  type?: RouteType | string;
 }
 
 /**
@@ -63,8 +53,8 @@ export interface URLPatternRouteConfig extends BaseRouteConfig {
 export type RouteConfig = PathRouteConfig | URLPatternRouteConfig;
 
 export const isRouterPath = (
-  route: PathRouteConfig | URLPatternRouteConfig
-): route is PathRouteConfig => !!(route as PathRouteConfig).path;
+  route: PathRouteConfig | URLPatternRouteConfig | undefined
+): route is PathRouteConfig => !!(route as PathRouteConfig)?.path;
 
 // A cache of URLPatterns created for PathRouteConfig.
 // Rather than converting all given RoutConfigs to URLPatternRouteConfig, this
@@ -289,6 +279,12 @@ export class Routes implements ReactiveController {
    * The result of calling the current route's render() callback.
    */
   outlet(): unknown {
+    if (!this._currentRoute?.render && isRouterPath(this._currentRoute)) {
+      return html`<oryx-composition
+        route=${this._currentRoute.path}
+      ></oryx-composition>`;
+    }
+
     return this._currentRoute?.render?.(this._currentParams);
   }
 

--- a/libs/platform/router/lit/lit-routes.ts
+++ b/libs/platform/router/lit/lit-routes.ts
@@ -9,8 +9,23 @@
 import type { ReactiveController, ReactiveControllerHost } from 'lit';
 import { lastValueFrom, Observable } from 'rxjs';
 
+export const enum RouteLinkType {
+  Page = 'page',
+  ProductList = 'search',
+  Product = 'product',
+  Category = 'category',
+  Checkout = 'checkout',
+  CheckoutLogin = 'checkoutLogin',
+  Order = 'order',
+  Cart = 'cart',
+  Login = 'login',
+  AddressList = 'address-list',
+  AddressBookCreate = 'address-book-create',
+  AddressBookEdit = 'address-book-edit',
+}
+
 export interface BaseRouteConfig {
-  name?: string | undefined;
+  name?: string;
   render?: (params: { [key: string]: string | undefined }) => unknown;
   enter?: (params: {
     [key: string]: string | undefined;
@@ -18,6 +33,7 @@ export interface BaseRouteConfig {
   leave?: (params: {
     [key: string]: string | undefined;
   }) => Observable<boolean>;
+  type?: RouteLinkType | string;
 }
 
 /**
@@ -45,6 +61,10 @@ export interface URLPatternRouteConfig extends BaseRouteConfig {
  * render() callback used to render a match to the outlet.
  */
 export type RouteConfig = PathRouteConfig | URLPatternRouteConfig;
+
+export const isRouterPath = (
+  route: PathRouteConfig | URLPatternRouteConfig
+): route is PathRouteConfig => !!(route as PathRouteConfig).path;
 
 // A cache of URLPatterns created for PathRouteConfig.
 // Rather than converting all given RoutConfigs to URLPatternRouteConfig, this

--- a/libs/platform/router/src/services/default-router.service.ts
+++ b/libs/platform/router/src/services/default-router.service.ts
@@ -16,6 +16,7 @@ import {
   RouterEventType,
   RouterService,
 } from './router.service';
+import { RouteConfig } from '../../lit/lit-routes';
 
 const CURRENT_PAGE = 'currentPage';
 const PREVIOUS_PAGE = 'previousPage';
@@ -29,6 +30,7 @@ export class DefaultRouterService implements RouterService {
   private routerEvents$ = new Subject<RouterEvent>();
   private storedRoute$ = new BehaviorSubject('');
 
+  protected routes?: RouteConfig[];
   protected storageService = inject(StorageService);
 
   go(route: string, extras?: NavigationExtras): void {
@@ -122,6 +124,14 @@ export class DefaultRouterService implements RouterService {
     return tokenIndex !== -1 && routeTokens.length > tokenIndex + 1
       ? routeTokens[tokenIndex + 1]
       : undefined;
+  }
+
+  setRoutes(routes: RouteConfig[]): void {
+    this.routes = routes;
+  }
+
+  getRoutes(): RouteConfig[] | undefined {
+    return this.routes;
   }
 
   protected createUrlParams(params?: {

--- a/libs/platform/router/src/services/default-router.service.ts
+++ b/libs/platform/router/src/services/default-router.service.ts
@@ -30,7 +30,7 @@ export class DefaultRouterService implements RouterService {
   private routerEvents$ = new Subject<RouterEvent>();
   private storedRoute$ = new BehaviorSubject('');
 
-  protected routes?: RouteConfig[];
+  protected routes$ = new ReplaySubject<RouteConfig[]>(1);
   protected storageService = inject(StorageService);
 
   go(route: string, extras?: NavigationExtras): void {
@@ -127,11 +127,11 @@ export class DefaultRouterService implements RouterService {
   }
 
   setRoutes(routes: RouteConfig[]): void {
-    this.routes = routes;
+    this.routes$.next(routes);
   }
 
-  getRoutes(): RouteConfig[] | undefined {
-    return this.routes;
+  getRoutes(): Observable<RouteConfig[] | undefined> {
+    return this.routes$.asObservable();
   }
 
   protected createUrlParams(params?: {

--- a/libs/platform/router/src/services/router.service.ts
+++ b/libs/platform/router/src/services/router.service.ts
@@ -1,3 +1,4 @@
+import { RouteConfig } from '@spryker-oryx/router/lit';
 import { Observable } from 'rxjs';
 
 export interface RouterService {
@@ -13,6 +14,8 @@ export interface RouterService {
   acceptParams(params: RouteParams): void;
   getUrl(route?: string, extras?: NavigationExtras): Observable<string>;
   getPathId(id: string): string | undefined;
+  setRoutes(routes: RouteConfig[]): void;
+  getRoutes(): RouteConfig[] | undefined;
 }
 
 export const RouterService = 'oryx.RouterService';

--- a/libs/platform/router/src/services/router.service.ts
+++ b/libs/platform/router/src/services/router.service.ts
@@ -30,6 +30,21 @@ export const enum RouterEventType {
   NavigationEnd,
 }
 
+export const enum RouteType {
+  Page = 'page',
+  ProductList = 'search',
+  Product = 'product',
+  Category = 'category',
+  Checkout = 'checkout',
+  CheckoutLogin = 'checkoutLogin',
+  Order = 'order',
+  Cart = 'cart',
+  Login = 'login',
+  AddressList = 'address-list',
+  AddressBookCreate = 'address-book-create',
+  AddressBookEdit = 'address-book-edit',
+}
+
 export interface RouterEvent {
   type: RouterEventType;
   route: string;

--- a/libs/platform/router/src/services/router.service.ts
+++ b/libs/platform/router/src/services/router.service.ts
@@ -15,7 +15,7 @@ export interface RouterService {
   getUrl(route?: string, extras?: NavigationExtras): Observable<string>;
   getPathId(id: string): string | undefined;
   setRoutes(routes: RouteConfig[]): void;
-  getRoutes(): RouteConfig[] | undefined;
+  getRoutes(): Observable<RouteConfig[] | undefined>;
 }
 
 export const RouterService = 'oryx.RouterService';

--- a/libs/template/application/oryx-app/oryx-app.component.spec.ts
+++ b/libs/template/application/oryx-app/oryx-app.component.spec.ts
@@ -3,7 +3,7 @@ import { ContextService, DefaultContextService } from '@spryker-oryx/core';
 import { useComponent } from '@spryker-oryx/core/utilities';
 import { createInjector, destroyInjector, getInjector } from '@spryker-oryx/di';
 import { RouteParams, RouterService } from '@spryker-oryx/router';
-import { LitRouter } from '@spryker-oryx/router/lit';
+import { LitRouter, RouteConfig } from '@spryker-oryx/router/lit';
 import { siteProviders } from '@spryker-oryx/site';
 import { html } from 'lit';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
@@ -25,6 +25,10 @@ class MockRouterService implements Partial<RouterService> {
   }
   acceptParams(params: RouteParams): void {
     this.params$.next(params);
+  }
+
+  setRoutes(routes: RouteConfig[]): void {
+    //
   }
 }
 

--- a/libs/template/labs/src/articles/article-routes.ts
+++ b/libs/template/labs/src/articles/article-routes.ts
@@ -1,22 +1,14 @@
-import { html, TemplateResult } from 'lit';
 import { ContentfulContentFields } from './contentful';
 import { StoryblokContentFields } from './storyblok';
+import { RouteConfig } from '@spryker-oryx/router/lit';
 
-export const articleRoutes = [
+export const articleRoutes: RouteConfig[] = [
   {
     path: '/faq/:id',
-    render: (): TemplateResult => html`<oryx-composition
-      route="/faq/:id"
-    ></oryx-composition>`,
-    name: 'FAQ',
     type: StoryblokContentFields.Faq,
   },
   {
     path: '/article/:id',
-    render: (): TemplateResult => html`<oryx-composition
-      route="/article/:id"
-    ></oryx-composition>`,
-    name: 'Article',
     type: ContentfulContentFields.Article,
   },
 ];

--- a/libs/template/labs/src/articles/article-routes.ts
+++ b/libs/template/labs/src/articles/article-routes.ts
@@ -1,26 +1,15 @@
 import { html, TemplateResult } from 'lit';
+import { ContentfulContentFields } from './contentful';
+import { StoryblokContentFields } from './storyblok';
 
 export const articleRoutes = [
-  {
-    path: '/faq',
-    render: (): TemplateResult => html`<oryx-composition
-      route="/faq"
-    ></oryx-composition>`,
-    name: 'FAQs',
-  },
   {
     path: '/faq/:id',
     render: (): TemplateResult => html`<oryx-composition
       route="/faq/:id"
     ></oryx-composition>`,
     name: 'FAQ',
-  },
-  {
-    path: '/article',
-    render: (): TemplateResult => html`<oryx-composition
-      route="/article"
-    ></oryx-composition>`,
-    name: 'Articles',
+    type: StoryblokContentFields.Faq,
   },
   {
     path: '/article/:id',
@@ -28,5 +17,6 @@ export const articleRoutes = [
       route="/article/:id"
     ></oryx-composition>`,
     name: 'Article',
+    type: ContentfulContentFields.Article,
   },
 ];

--- a/libs/template/labs/src/articles/contentful/contentful-suggestion.adapter.ts
+++ b/libs/template/labs/src/articles/contentful/contentful-suggestion.adapter.ts
@@ -29,9 +29,7 @@ export class DefaultContentfulSuggestionAdapter implements SuggestionAdapter {
             [SuggestionField.Contents]: data.items.map((entry) => ({
               name: entry.fields.heading,
               id: entry.fields.id,
-              url: `/${ContentfulContentFields.Article}/${encodeURIComponent(
-                entry.fields.id
-              )}`,
+              type: ContentfulContentFields.Article,
             })),
           }))
         );

--- a/libs/template/labs/src/articles/storyblok/storyblok-suggestion.adapter.ts
+++ b/libs/template/labs/src/articles/storyblok/storyblok-suggestion.adapter.ts
@@ -25,9 +25,7 @@ export class DefaultStoryblokSuggestionAdapter implements SuggestionAdapter {
           [SuggestionField.Contents]: data.stories?.map((story) => ({
             id: story.content.id,
             name: story.content.heading,
-            url: `/${StoryblokContentFields.Faq}/${encodeURIComponent(
-              story.content.id
-            )}`,
+            type: StoryblokContentFields.Faq,
           })),
         }))
       );


### PR DESCRIPTION
Moves semantic link types into router config.

closes: [HRZ-3205](https://spryker.atlassian.net/browse/HRZ-3205)


[HRZ-3205]: https://spryker.atlassian.net/browse/HRZ-3205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ