### PR TITLE
fix(order): move the order totals up in the layout

### DIFF
--- a/libs/domain/order/src/services/index.ts
+++ b/libs/domain/order/src/services/index.ts
@@ -1,5 +1,6 @@
 export * from './default-order.service';
 export * from './order-context';
 export * from './order.providers';
+export * from './order.routes';
 export * from './order.service';
 export * from './totals';

--- a/libs/domain/order/src/services/order.providers.ts
+++ b/libs/domain/order/src/services/order.providers.ts
@@ -1,7 +1,9 @@
+import { provideLitRoutes } from '@spryker-oryx/router/lit';
 import { DefaultOrderAdapter, OrderAdapter } from './adapter';
 import { orderNormalizer } from './adapter/normalizers';
 import { DefaultOrderService } from './default-order.service';
 import { OrderContextFallback } from './order-context';
+import { orderRoutes } from './order.routes';
 import { OrderService } from './order.service';
 import { OrderTotalsProvider } from './totals';
 
@@ -17,4 +19,5 @@ export const orderProviders = [
   OrderTotalsProvider,
   ...orderNormalizer,
   OrderContextFallback,
+  ...provideLitRoutes({ routes: orderRoutes }),
 ];

--- a/libs/domain/order/src/services/order.routes.ts
+++ b/libs/domain/order/src/services/order.routes.ts
@@ -1,0 +1,9 @@
+import { RouteType } from '@spryker-oryx/router';
+import { RouteConfig } from '@spryker-oryx/router/lit';
+
+export const orderRoutes: RouteConfig[] = [
+  {
+    path: '/order/:id',
+    type: RouteType.Order,
+  },
+];

--- a/libs/platform/experience/src/routes.ts
+++ b/libs/platform/experience/src/routes.ts
@@ -16,10 +16,6 @@ export const defaultExperienceRoutes: RouteConfig[] = [
     type: RouteType.Category,
   },
   {
-    path: '/order/:id',
-    type: RouteType.Order,
-  },
-  {
     path: '/:page',
     type: RouteType.Page,
   },

--- a/libs/template/presets/storefront/experience/pages/order-confirmation-page.ts
+++ b/libs/template/presets/storefront/experience/pages/order-confirmation-page.ts
@@ -1,7 +1,6 @@
-import { DiscountRowsAppearance } from '@spryker-oryx/cart/totals';
 import { StaticComponent } from '@spryker-oryx/experience';
 
-export const orderPage: StaticComponent = {
+export const orderConfirmationPage: StaticComponent = {
   type: 'Page',
   meta: {
     title: 'Order Confirmation Page',
@@ -12,30 +11,23 @@ export const orderPage: StaticComponent = {
     { type: 'oryx-order-confirmation-banner' },
     {
       type: 'oryx-composition',
-      options: {
-        rules: [{ layout: 'split-main', padding: '30px 0' }],
-      },
+      options: { rules: [{ layout: 'split-main', padding: '30px 0' }] },
       components: [
         {
           type: 'oryx-order-summary',
-          options: {
-            rules: [{ colSpan: 2 }],
-          },
         },
-        { type: 'oryx-order-entries' },
         {
           type: 'oryx-order-totals',
           components: [
             { type: 'oryx-cart-totals-subtotal' },
-            {
-              type: 'oryx-cart-totals-discount',
-              options: {
-                discountRowsAppearance: DiscountRowsAppearance.Collapsed,
-              },
-            },
+            { type: 'oryx-cart-totals-discount' },
             { type: 'oryx-cart-totals-tax' },
             { type: 'oryx-cart-totals-total' },
           ],
+        },
+        {
+          type: 'oryx-order-entries',
+          options: { rules: [{ colSpan: 2 }] },
         },
       ],
     },

--- a/libs/template/presets/storefront/experience/static-experience.ts
+++ b/libs/template/presets/storefront/experience/static-experience.ts
@@ -13,7 +13,7 @@ import {
   editAddressPage,
   homePage,
   loginPage,
-  orderPage,
+  orderConfirmationPage,
   productPage,
   searchPage,
 } from './pages';
@@ -29,7 +29,7 @@ export const StaticExperienceFeature: AppFeature = {
       contactPage,
       homePage,
       loginPage,
-      orderPage,
+      orderConfirmationPage,
       productPage,
       searchPage,
       addressBookPage,


### PR DESCRIPTION
Previously our designs had the order totals at the bottom of the page, the new design has moved them up. 

closes: [HRZ-3078](https://spryker.atlassian.net/browse/HRZ-3078)

[HRZ-3078]: https://spryker.atlassian.net/browse/HRZ-3078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ