### PR TITLE
test: improve empty cart checks

### DIFF
--- a/apps/storefront-e2e/src/integration/cart.cy.ts
+++ b/apps/storefront-e2e/src/integration/cart.cy.ts
@@ -61,7 +61,7 @@ describe('Cart', () => {
       });
 
       it('should render an empty message', () => {
-        cartPage.hasEmptyCart();
+        cartPage.checkEmptyCart();
       });
     });
 
@@ -69,6 +69,7 @@ describe('Cart', () => {
       beforeEach(() => {
         scosApi.guestCartItems.post(ProductStorage.getProductByEq(2), 1);
         cy.goToCartAsGuest();
+        cartPage.checkNotEmptyCart();
       });
 
       it('should render the cart entries and totals', () => {
@@ -94,7 +95,7 @@ describe('Cart', () => {
         });
 
         it('should have an empty cart', () => {
-          cartPage.hasEmptyCart();
+          cartPage.checkEmptyCart();
         });
       });
 
@@ -172,7 +173,7 @@ describe('Cart', () => {
         });
 
         it('should have an empty cart', () => {
-          cartPage.hasEmptyCart();
+          cartPage.checkEmptyCart();
         });
       });
 
@@ -191,7 +192,7 @@ describe('Cart', () => {
         });
 
         it('should have an empty cart', () => {
-          cartPage.hasEmptyCart();
+          cartPage.checkEmptyCart();
         });
       });
 

--- a/apps/storefront-e2e/src/integration/checkout.cy.ts
+++ b/apps/storefront-e2e/src/integration/checkout.cy.ts
@@ -77,8 +77,7 @@ describe('Checkout suite', () => {
         thankYouPage.header.getCartCount().should('not.exist');
         thankYouPage.header.getCartSummary().click();
 
-        cartPage.visit();
-        cartPage.hasEmptyCart();
+        cartPage.checkEmptyCart();
       });
     });
 
@@ -146,7 +145,7 @@ describe('Checkout suite', () => {
         thankYouPage.header.getCartCount().should('not.exist');
         thankYouPage.header.getCartSummary().click();
 
-        cartPage.hasEmptyCart();
+        cartPage.checkEmptyCart();
       });
     });
   });

--- a/apps/storefront-e2e/src/support/page-objects/cart.page.ts
+++ b/apps/storefront-e2e/src/support/page-objects/cart.page.ts
@@ -8,11 +8,11 @@ export class CartPage extends AbstractSFPage {
   private cartTotals = new CartTotalsFragment();
 
   waitForLoaded(): void {
-    this.getEmptyCartMessage().should('be.visible');
+    this.getCartEntriesWrapper().should('exist');
   }
 
   getCartEntriesWrapper = () => cy.get('oryx-cart-entries');
-  getEmptyCartMessage = () => cy.get('oryx-content-text');
+  getEmptyCartMessage = () => cy.contains('Your shopping cart is empty');
   getCartEntries = () =>
     this.getCartEntriesWrapper()
       .find('oryx-cart-entry')
@@ -33,11 +33,15 @@ export class CartPage extends AbstractSFPage {
     this.getCheckoutBtn().click();
   };
 
-  hasEmptyCart = () => {
-    this.getEmptyCartMessage()
-      .contains('Your shopping cart is empty')
-      .should('be.visible');
+  checkEmptyCart = () => {
+    this.getEmptyCartMessage().should('be.visible');
     this.getCartEntriesWrapper().should('not.be.visible');
     this.getCartTotals().getWrapper().should('not.be.visible');
+  };
+
+  checkNotEmptyCart = () => {
+    this.getEmptyCartMessage().should('not.exist');
+    this.getCartEntriesWrapper().should('be.visible');
+    this.getCartTotals().getWrapper().should('be.visible');
   };
 }


### PR DESCRIPTION
Improves cart emptiness check and prevents a regression with empty cart block shown above the cart entries

closes: -