### PR TITLE
test: refactor sf e2e actions

### DIFF
--- a/apps/storefront-e2e/src/support/commands.ts
+++ b/apps/storefront-e2e/src/support/commands.ts
@@ -1,131 +1,25 @@
-import { RouteMatcherOptions } from 'node_modules/cypress/types/net-stubbing';
-import { AbstractSFPage } from './page-objects/abstract.page';
-import { CartPage } from './page-objects/cart.page';
-import { LoginPage } from './page-objects/login.page';
-import { SCCOSApi } from './sccos-api/sccos.api';
-import { Customer } from './types/user.type';
+import './cy-actions/api.actions';
+import './cy-actions/cart.actions';
+import './cy-actions/checkout.actions';
+import './cy-actions/login.actions';
 
 export {};
 
 declare global {
   namespace Cypress {
     interface Chainable {
-      login(): Chainable<void>;
-      loginApi(): Chainable<void>;
-      goToCheckout(): Chainable<void>;
-      goToCheckoutAsGuest(): Chainable<void>;
-      goToCart(): Chainable<void>;
-      goToCartAsGuest(): Chainable<void>;
       hydrateElemenet(assetPath: string, triggerHydrationFn): Chainable<void>;
-      customerCartsCleanup(sccosApi: SCCOSApi, user: Customer): void;
-      customerAddressesCleanup(sccosApi: SCCOSApi, user: Customer): void;
       checkCurrencyFormatting(locale: string): void;
-      failApiCall(routeMatcherOptions: RouteMatcherOptions, actionFn): void;
-      checkGlobalNotificationAfterFailedApiCall(page: AbstractSFPage): void;
     }
   }
 }
 
-Cypress.Commands.add('login', () => {
-  cy.fixture<Customer>('test-customer').then((customer) => {
-    const loginPage = new LoginPage();
-
-    loginPage.visit();
-
-    cy.intercept('/customers/DE--**').as('profileRequest');
-    loginPage.loginForm.login(customer);
-    cy.wait('@profileRequest');
-
-    loginPage.header.getUserSummaryHeading().should('contain', customer.name);
-  });
-});
-
-Cypress.Commands.add('loginApi', () => {
-  cy.fixture<Customer>('test-customer').then((customer) => {
-    const api = new SCCOSApi();
-
-    api.token.post(customer).then((res) => {
-      cy.window().then((win) => {
-        win.localStorage.setItem(
-          'oryx.oauth-state',
-          '{"authorizedBy":"spryker"}'
-        );
-        win.localStorage.setItem('oryx.oauth-token', JSON.stringify(res.body));
-      });
-    });
-  });
-});
-
-Cypress.Commands.add('goToCart', () => {
-  const cartPage = new CartPage();
-
-  cy.intercept('/customers/DE--**/carts?**').as('cartsRequest');
-  cartPage.visit();
-  cy.wait('@cartsRequest');
-});
-
-Cypress.Commands.add('goToCheckout', () => {
-  const cartPage = new CartPage();
-
-  cy.goToCart();
-
-  // carts request is not enought to be sure
-  // that checkout button is clickable
-  // we have to wait for other elements, and even with them
-  // there is no 100% guarranty that checkout btn is ready
-  cartPage.getCartTotals().getTotalPrice().should('be.visible');
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(250);
-
-  cy.intercept({
-    method: 'GET',
-    url: '/customers/*/addresses',
-  }).as('addressesRequest');
-  cartPage.checkout();
-  cy.wait('@addressesRequest');
-});
-
-Cypress.Commands.add('goToCartAsGuest', () => {
-  const cartPage = new CartPage();
-
-  cy.intercept('/guest-carts?**').as('cartsRequest');
-  cartPage.visit();
-  cy.wait('@cartsRequest');
-});
-
-Cypress.Commands.add('goToCheckoutAsGuest', () => {
-  const cartPage = new CartPage();
-
-  cy.goToCartAsGuest();
-
-  // carts request is not enough to be sure
-  // that checkout button is clickable
-  // we have to wait for other elements, and even with them
-  // there is no 100% guaranty that checkout btn is ready
-  cartPage.getCartTotals().getTotalPrice().should('be.visible');
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(250);
-
-  cy.intercept('/assets/addresses/*.json').as('addressesRequest');
-  cartPage.checkout();
-  cy.wait('@addressesRequest');
-});
-
-// this action is temporarily changed
-// because of constant hydation issues and instability
-//
-// All tests, including regression, will be run against SPA build
-// till SSR is not fixed completely
-//
-// still, smoke tests should run against SSR build
 Cypress.Commands.add(
   'hydrateElemenet',
   (assetPath: string, triggerHydrationFn) => {
     if (Cypress.env('isSSR')) {
       cy.intercept(assetPath).as(`${assetPath}Request`);
-
       triggerHydrationFn();
-
       cy.wait(`@${assetPath}Request`);
 
       // wait till hydrated elements are re-rendered
@@ -136,101 +30,33 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
-  'customerCartsCleanup',
-  (sccosApi: SCCOSApi, user: Customer) => {
-    sccosApi.carts.customersGet(user.id).then((response) => {
-      const carts = response.body.data;
-
-      // remove last cart id from the list
-      // because it can't be deleted
-      carts.pop();
-
-      carts.map((cart) => cart.id).forEach((id) => sccosApi.carts.delete(id));
-    });
-
-    // create new, empty cart
-    sccosApi.carts.post();
-  }
-);
-
-Cypress.Commands.add(
-  'customerAddressesCleanup',
-  (sccosApi: SCCOSApi, user: Customer) => {
-    sccosApi.addresses.get(user.id).then((response) => {
-      const addresses = response.body.data;
-
-      addresses
-        .map((address) => address.id)
-        .forEach((id) => sccosApi.addresses.delete(user.id, id));
-    });
-  }
-);
-
-const failApiCallResponse = {
-  statusCode: 500,
-  body: 'Internal Server Error',
-  forceError: false,
-};
-const apiErrorMessage = `${failApiCallResponse.statusCode} ${failApiCallResponse.body}`;
-
-Cypress.Commands.add('failApiCall', (options, actionFn) => {
-  // prevents test from failing
-  // if unhandled 500 error occurs
-  Cypress.on('uncaught:exception', (err) => {
-    return !err.message.includes(apiErrorMessage);
-  });
-
-  cy.intercept(options, failApiCallResponse).as('failedRequest');
-  actionFn();
-  cy.wait('@failedRequest');
-});
-
-Cypress.Commands.add(
-  'checkGlobalNotificationAfterFailedApiCall',
-  (page: AbstractSFPage) => {
-    page.globalNotificationCenter.getCenter().should('be.visible');
-    page.globalNotificationCenter.getNotifications().then((notifications) => {
-      // only 1 notification is shown
-      expect(notifications.length).to.be.eq(1);
-
-      // this notification is an expected API error
-      notifications[0].getType().should('be.eq', 'error');
-      notifications[0].getWrapper().should('contain.text', 'Error');
-      notifications[0].getSubtext().should('have.text', apiErrorMessage);
-
-      // close notification
-      notifications[0].getCloseBtn().click();
-
-      // check if notification disappeared
-      notifications[0].getWrapper().should('not.exist');
-      page.globalNotificationCenter.getWrapper().should('not.be.visible');
-    });
-  }
-);
-
-Cypress.Commands.add(
   'checkCurrencyFormatting',
   { prevSubject: true },
-  (subject, locale: string) => {
+  (subject, locale: 'en' | 'de') => {
     switch (locale) {
       case 'en':
-        return cy
-          .wrap(subject)
-          .invoke('text')
-          .then((price) => {
-            const currencySymbolPosition = price.indexOf('€');
-            expect(currencySymbolPosition).to.eq(0);
-          });
+        return checkCurrencyFormatting(subject, 'start');
       case 'de':
-        return cy
-          .wrap(subject)
-          .invoke('text')
-          .then((price) => {
-            const currencySymbolPosition = price.indexOf('€');
-            expect(currencySymbolPosition).to.eq(price.length - 1);
-          });
-      default:
-        throw new Error(`locale "${locale}" is not supported`);
+        return checkCurrencyFormatting(subject, 'end');
     }
   }
 );
+
+function checkCurrencyFormatting(
+  subject,
+  expectedSignPosition: 'start' | 'end'
+) {
+  cy.wrap(subject)
+    .invoke('text')
+    .then((price) => {
+      const symbolPosition = price.indexOf('€');
+
+      if (expectedSignPosition === 'start') {
+        expect(symbolPosition).to.eq(0);
+      }
+
+      if (expectedSignPosition === 'end') {
+        expect(symbolPosition).to.eq(price.length - 1);
+      }
+    });
+}

--- a/apps/storefront-e2e/src/support/cy-actions/api.actions.ts
+++ b/apps/storefront-e2e/src/support/cy-actions/api.actions.ts
@@ -1,0 +1,109 @@
+import { RouteMatcherOptions } from 'node_modules/cypress/types/net-stubbing';
+import { AbstractSFPage } from '../page-objects/abstract.page';
+import { CartData, SCCOSApi } from '../sccos-api/sccos.api';
+import { Customer } from '../types/user.type';
+
+export {};
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      customerCartsCleanup(sccosApi: SCCOSApi, user: Customer): void;
+      customerAddressesCleanup(sccosApi: SCCOSApi, user: Customer): void;
+      failApiCall(routeMatcherOptions: RouteMatcherOptions, actionFn): void;
+      checkGlobalNotificationAfterFailedApiCall(page: AbstractSFPage): void;
+    }
+  }
+}
+
+Cypress.Commands.add(
+  'customerCartsCleanup',
+  (sccosApi: SCCOSApi, user: Customer) => {
+    sccosApi.carts.customersGet(user.id).then((response) => {
+      const carts = response.body.data;
+
+      removeLastCart(carts);
+      deleteCarts(sccosApi, carts);
+    });
+
+    createNewCart(sccosApi);
+  }
+);
+
+Cypress.Commands.add(
+  'customerAddressesCleanup',
+  (sccosApi: SCCOSApi, user: Customer) => {
+    sccosApi.addresses.get(user.id).then((response) => {
+      const addresses = response.body.data;
+
+      addresses
+        .map((address) => address.id)
+        .forEach((id) => sccosApi.addresses.delete(user.id, id));
+    });
+  }
+);
+
+Cypress.Commands.add('failApiCall', (options, actionFn) => {
+  const data = getFailedApiCallData();
+
+  // prevents test from failing
+  // if unhandled 500 error occurs
+  Cypress.on('uncaught:exception', (err) => {
+    return !err.message.includes(data.apiErrorMessage);
+  });
+
+  cy.intercept(options, data.failApiCallResponse).as('failedRequest');
+  actionFn();
+  cy.wait('@failedRequest');
+});
+
+Cypress.Commands.add(
+  'checkGlobalNotificationAfterFailedApiCall',
+  (page: AbstractSFPage) => {
+    page.globalNotificationCenter.getCenter().should('be.visible');
+    page.globalNotificationCenter.getNotifications().then((notifications) => {
+      // only 1 notification is shown
+      expect(notifications.length).to.be.eq(1);
+
+      // this notification is an expected API error
+      notifications[0].getType().should('be.eq', 'error');
+      notifications[0].getWrapper().should('contain.text', 'Error');
+      notifications[0]
+        .getSubtext()
+        .should('have.text', getFailedApiCallData().apiErrorMessage);
+
+      // when we close notification
+      notifications[0].getCloseBtn().click();
+
+      // it disappears
+      notifications[0].getWrapper().should('not.exist');
+      page.globalNotificationCenter.getWrapper().should('not.be.visible');
+    });
+  }
+);
+
+function removeLastCart(carts: CartData[]) {
+  carts.pop();
+}
+
+function deleteCarts(sccosApi: SCCOSApi, carts: CartData[]) {
+  carts.map((cart) => cart.id).forEach((id) => sccosApi.carts.delete(id));
+}
+
+function createNewCart(sccosApi: SCCOSApi) {
+  sccosApi.carts.post();
+}
+
+function getFailedApiCallData() {
+  const failApiCallResponse = {
+    statusCode: 500,
+    body: 'Internal Server Error',
+    forceError: false,
+  };
+  const apiErrorMessage = `${failApiCallResponse.statusCode} ${failApiCallResponse.body}`;
+
+  return {
+    failApiCallResponse,
+    apiErrorMessage,
+  };
+}

--- a/apps/storefront-e2e/src/support/cy-actions/cart.actions.ts
+++ b/apps/storefront-e2e/src/support/cy-actions/cart.actions.ts
@@ -1,0 +1,28 @@
+import { CartPage } from '../page-objects/cart.page';
+
+export {};
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      goToCart(): Chainable<void>;
+      goToCartAsGuest(): Chainable<void>;
+    }
+  }
+}
+
+Cypress.Commands.add('goToCart', () => {
+  openCartPage('/customers/DE--**/carts?**');
+});
+
+Cypress.Commands.add('goToCartAsGuest', () => {
+  openCartPage('/guest-carts?**');
+});
+
+function openCartPage(getCartsUrl: string) {
+  const cartPage = new CartPage();
+
+  cy.intercept(getCartsUrl).as('cartsRequest');
+  cartPage.visit();
+  cy.wait('@cartsRequest');
+}

--- a/apps/storefront-e2e/src/support/cy-actions/checkout.actions.ts
+++ b/apps/storefront-e2e/src/support/cy-actions/checkout.actions.ts
@@ -1,0 +1,45 @@
+import { CartPage } from '../page-objects/cart.page';
+
+export {};
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      goToCheckout(): Chainable<void>;
+      goToCheckoutAsGuest(): Chainable<void>;
+    }
+  }
+}
+
+const cartPage = new CartPage();
+
+Cypress.Commands.add('goToCheckout', () => {
+  cy.goToCart();
+  waitForNonEmptyCartToBeLoaded();
+
+  cy.intercept('/customers/*/addresses').as('customerAddressesRequest');
+  cartPage.checkout();
+  cy.wait('@customerAddressesRequest');
+});
+
+Cypress.Commands.add('goToCheckoutAsGuest', () => {
+  cy.goToCartAsGuest();
+  waitForNonEmptyCartToBeLoaded();
+
+  cy.intercept('/assets/addresses/*.json').as('addressFormDataRequest');
+  cartPage.checkout();
+  cy.wait('@addressFormDataRequest');
+});
+
+// just open a cart page is not enought to be sure
+// that checkout button is clickable
+//
+// we have to wait for other elements, and even with them
+// there is no 100% guarranty that checkout btn is ready
+//
+// this check should be removed in the future when hydration is improved
+function waitForNonEmptyCartToBeLoaded() {
+  cartPage.getCartTotals().getTotalPrice().should('be.visible');
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(250);
+}

--- a/apps/storefront-e2e/src/support/cy-actions/login.actions.ts
+++ b/apps/storefront-e2e/src/support/cy-actions/login.actions.ts
@@ -1,0 +1,44 @@
+import { LoginPage } from '../page-objects/login.page';
+import { SCCOSApi } from '../sccos-api/sccos.api';
+import { Customer } from '../types/user.type';
+
+export {};
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      login(): Chainable<void>;
+      loginApi(): Chainable<void>;
+    }
+  }
+}
+
+Cypress.Commands.add('login', () => {
+  cy.fixture<Customer>('test-customer').then((customer) => {
+    const loginPage = new LoginPage();
+
+    loginPage.visit();
+
+    cy.intercept('/customers/DE--**').as('profileRequest');
+    loginPage.loginForm.login(customer);
+    cy.wait('@profileRequest');
+
+    loginPage.header.getUserSummaryHeading().should('contain', customer.name);
+  });
+});
+
+Cypress.Commands.add('loginApi', () => {
+  cy.fixture<Customer>('test-customer').then((customer) => {
+    const api = new SCCOSApi();
+
+    api.token.post(customer).then((res) => {
+      cy.window().then((win) => {
+        win.localStorage.setItem(
+          'oryx.oauth-state',
+          '{"authorizedBy":"spryker"}'
+        );
+        win.localStorage.setItem('oryx.oauth-token', JSON.stringify(res.body));
+      });
+    });
+  });
+});


### PR DESCRIPTION
Simplifies storefront Cypress actions, cakes them more atomic and clear

closes: https://spryker.atlassian.net/browse/HRZ-3332