### PR TITLE
fix: use standard query language for brands

### DIFF
--- a/libs/domain/product/brand/brand.component.spec.ts
+++ b/libs/domain/product/brand/brand.component.spec.ts
@@ -69,7 +69,7 @@ describe('ProductBrandComponent', () => {
       const image = element.shadowRoot?.querySelector(
         'oryx-image'
       ) as ImageComponent;
-      expect(image.resource).toBe('brand1');
+      expect(image.resource).toBe('Brand1');
     });
   });
 

--- a/libs/domain/product/brand/brand.component.ts
+++ b/libs/domain/product/brand/brand.component.ts
@@ -10,7 +10,7 @@ export class ProductBrandComponent extends ProductMixin(
   ContentMixin<ProductBrandOptions>(LitElement)
 ) {
   protected $brand = computed(() => {
-    return this.$product()?.attributes?.['brand']?.toLowerCase();
+    return this.$product()?.attributes?.['brand'];
   });
 
   protected override render(): TemplateResult | void {

--- a/libs/template/presets/storefront/experience/pages/home-page.ts
+++ b/libs/template/presets/storefront/experience/pages/home-page.ts
@@ -3,7 +3,9 @@ import { ExperienceComponent, StyleRuleSet } from '@spryker-oryx/experience';
 const brand = (name: string, rules?: StyleRuleSet[]) => ({
   type: 'oryx-content-image',
   name,
-  content: { data: { graphic: name, label: name, link: `/search?q=${name}` } },
+  content: {
+    data: { graphic: name, label: name, link: `/search?brand=${name}` },
+  },
   options: { rules },
 });
 
@@ -124,15 +126,15 @@ export const homePage: ExperienceComponent = {
         ],
       },
       components: [
-        brand('samsung'),
-        brand('sony'),
-        brand('lenovo'),
-        brand('hp'),
-        brand('tomtom'),
-        brand('dell'),
-        brand('fujitsu', [{ padding: '0 0 2px' }]),
-        brand('asus'),
-        brand('acer'),
+        brand('Samsung'),
+        brand('Sony'),
+        brand('Lenovo'),
+        brand('HP'),
+        brand('TomTom'),
+        brand('DELL'),
+        brand('Fujitsu', [{ padding: '0 0 2px' }]),
+        brand('Asus'),
+        brand('Acer'),
       ],
     },
   ],

--- a/libs/template/resources/src/graphics/brands/index.ts
+++ b/libs/template/resources/src/graphics/brands/index.ts
@@ -4,16 +4,16 @@ import { paymentMethodsLogos } from './payment';
 import { socialLogos } from './social';
 
 export const brandGraphics: ResourceGraphic = {
-  apple: { source: () => import('./apple').then((m) => m.resource) },
-  dell: { source: () => import('./dell').then((m) => m.resource) },
-  samsung: { source: () => import('./samsung').then((m) => m.resource) },
-  sony: { source: () => import('./sony').then((m) => m.resource) },
-  tomtom: { source: () => import('./tomtom').then((m) => m.resource) },
-  lenovo: { source: () => import('./lenovo').then((m) => m.resource) },
-  hp: { source: () => import('./hp').then((m) => m.resource) },
-  asus: { source: () => import('./asus').then((m) => m.resource) },
-  acer: { source: () => import('./acer').then((m) => m.resource) },
-  fujitsu: { source: () => import('./fujitsu').then((m) => m.resource) },
+  Apple: { source: () => import('./apple').then((m) => m.resource) },
+  DELL: { source: () => import('./dell').then((m) => m.resource) },
+  Samsung: { source: () => import('./samsung').then((m) => m.resource) },
+  Sony: { source: () => import('./sony').then((m) => m.resource) },
+  TomTom: { source: () => import('./tomtom').then((m) => m.resource) },
+  Lenovo: { source: () => import('./lenovo').then((m) => m.resource) },
+  HP: { source: () => import('./hp').then((m) => m.resource) },
+  Asus: { source: () => import('./asus').then((m) => m.resource) },
+  Acer: { source: () => import('./acer').then((m) => m.resource) },
+  Fujitsu: { source: () => import('./fujitsu').then((m) => m.resource) },
   appleStore: { source: () => import('./apple-store').then((m) => m.resource) },
   playStore: { source: () => import('./play-store').then((m) => m.resource) },
 


### PR DESCRIPTION
We've been lower casing the brand names so far, and use an incorrect query (`q=sony`) instead of the dedicated query (`brand=Sony`).