### PR TITLE
fix(picking): return null in PickingListDefaultAdapter if concrete product image set is missing

### DIFF
--- a/libs/domain/picking/src/services/adapter/picking-list-default.adapter.ts
+++ b/libs/domain/picking/src/services/adapter/picking-list-default.adapter.ts
@@ -152,10 +152,10 @@ export class PickingListDefaultAdapter implements PickingListAdapter {
       sku: product.sku,
       productName: product.name,
       image:
-        product.concreteProductImageSets[0].imageSets[0].images[0]
+        product.concreteProductImageSets?.[0].imageSets[0].images[0]
           .externalUrlSmall,
       imageLarge:
-        product.concreteProductImageSets[0].imageSets[0].images[0]
+        product.concreteProductImageSets?.[0].imageSets[0].images[0]
           .externalUrlLarge,
     }));
 


### PR DESCRIPTION
closes: [HRZ-86542](https://spryker.atlassian.net/browse/HRZ-86542)


[HRZ-86542]: https://spryker.atlassian.net/browse/HRZ-86542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ