### PR TITLE
fix(user): don't update UI on validity triggered by change event in `UserAddressFormComponent`

### DIFF
--- a/libs/domain/user/address-form/address-form.component.spec.ts
+++ b/libs/domain/user/address-form/address-form.component.spec.ts
@@ -208,6 +208,33 @@ describe('UserAddressFormComponent', () => {
     });
   });
 
+  describe('when form changes', () => {
+    const callback = vi.fn();
+    beforeEach(async () => {
+      element = await fixture(
+        html`<oryx-user-address-form></oryx-user-address-form>`
+      );
+
+      element.addEventListener('change', callback);
+
+      element.shadowRoot
+        ?.querySelector('select')
+        ?.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    it('should dispatch change event', () => {
+      expect(callback).toHaveBeenCalledWith(
+        new CustomEvent('change', {
+          detail: {
+            valid: true,
+          },
+          bubbles: true,
+          composed: true,
+        })
+      );
+    });
+  });
+
   describe('when selected country changes', () => {
     beforeEach(async () => {
       element = await fixture(

--- a/libs/domain/user/address-form/address-form.component.ts
+++ b/libs/domain/user/address-form/address-form.component.ts
@@ -171,28 +171,24 @@ export class UserAddressFormComponent
     this.countryService.set(this.country);
   }
 
-  protected preventInvalidDisplay = (e: Event): void => {
-    e.stopImmediatePropagation();
-  };
-
   protected onChange(): void {
     if (this.form) {
       const address: Address = Object.fromEntries(
         new FormData(this.form).entries()
       );
       address.id = this.values?.id;
-      this.form.addEventListener('invalid', this.preventInvalidDisplay, true);
       this.dispatchEvent(
         new CustomEvent<AddressEventDetail>('change', {
-          detail: { address, valid: this.form.checkValidity() },
+          detail: {
+            address,
+            // We don't want to trigger valdity in the UI, just store details in storage.
+            valid: [...this.form.elements].every(
+              (e) => (e as HTMLInputElement).validity.valid
+            ),
+          },
           bubbles: true,
           composed: true,
         })
-      );
-      this.form.removeEventListener(
-        'invalid',
-        this.preventInvalidDisplay,
-        true
       );
     }
   }

--- a/libs/domain/user/address-form/address-form.component.ts
+++ b/libs/domain/user/address-form/address-form.component.ts
@@ -171,18 +171,28 @@ export class UserAddressFormComponent
     this.countryService.set(this.country);
   }
 
+  protected preventInvalidDisplay = (e: Event): void => {
+    e.stopImmediatePropagation();
+  };
+
   protected onChange(): void {
     if (this.form) {
       const address: Address = Object.fromEntries(
         new FormData(this.form).entries()
       );
       address.id = this.values?.id;
+      this.form.addEventListener('invalid', this.preventInvalidDisplay, true);
       this.dispatchEvent(
         new CustomEvent<AddressEventDetail>('change', {
           detail: { address, valid: this.form.checkValidity() },
           bubbles: true,
           composed: true,
         })
+      );
+      this.form.removeEventListener(
+        'invalid',
+        this.preventInvalidDisplay,
+        true
       );
     }
   }


### PR DESCRIPTION
closes: [HRZ-3293](https://spryker.atlassian.net/browse/HRZ-3293)

[HRZ-3293]: https://spryker.atlassian.net/browse/HRZ-3293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ