### PR TITLE
feat: hide order totals component for guest users

### DIFF
--- a/libs/template/presets/storefront/experience/pages/order-confirmation-page.ts
+++ b/libs/template/presets/storefront/experience/pages/order-confirmation-page.ts
@@ -20,6 +20,9 @@ export const orderConfirmationPage: ExperienceComponent = {
         },
         {
           type: 'oryx-order-totals',
+          options: {
+            rules: [{ hideByRule: 'USER.!AUTHENTICATED' }],
+          },
           components: [
             { type: 'oryx-cart-totals-subtotal' },
             { type: 'oryx-cart-totals-discount' },


### PR DESCRIPTION
Added rule to hide order totals component for guest users

closes: https://spryker.atlassian.net/browse/HRZ-89560
