### PR TITLE
fix(product): tax message based on gross or net price mode

### DIFF
--- a/libs/domain/product/price/src/price.component.ts
+++ b/libs/domain/product/price/src/price.component.ts
@@ -115,7 +115,7 @@ export class ProductPriceComponent extends ProductMixin(
     return html`<span part="tax">
       ${this.i18n(
         `product.price.${
-          this.$product()?.price?.originalPrice?.isNet
+          this.$product()?.price?.defaultPrice?.isNet
             ? 'tax-excluded'
             : 'tax-included'
         }`


### PR DESCRIPTION
Fix tax message for the product price, depending on the gross or net price mode.

closes: [HRZ-89820](https://spryker.atlassian.net/browse/HRZ-89820)


[HRZ-89820]: https://spryker.atlassian.net/browse/HRZ-89820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ