### PR TITLE
fix(search): facets and browser history

### DIFF
--- a/libs/domain/search/facet/facet.component.ts
+++ b/libs/domain/search/facet/facet.component.ts
@@ -69,7 +69,8 @@ export class SearchFacetComponent extends I18nMixin(LitElement) {
     return html`<ul>
       ${repeat(
         values,
-        (facetValue) => String(facetValue.value),
+        (facetValue) =>
+          `${facetValue.value}${facetValue.selected ? '-selected' : ''}`,
         (facetValue) => html`<li>
           ${this.renderValueControl(facetValue)}
           ${this.renderValues(facetValue.children)}


### PR DESCRIPTION
Improved unique key creation for lists of facets that is started taking into account selected state 

closes: [HRZ-89854](https://spryker.atlassian.net/browse/HRZ-89854)


[HRZ-89854]: https://spryker.atlassian.net/browse/HRZ-89854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ