### PR TITLE
feat(content): resolve product, category and content links

### DIFF
--- a/libs/domain/content/link/link.component.ts
+++ b/libs/domain/content/link/link.component.ts
@@ -30,7 +30,7 @@ export class ContentLinkComponent extends ContentMixin<
 
   protected $text = computed(() => {
     const { type, id } = this.$options();
-    const { text } = this.$content();
+    const { text } = this.$content() ?? {};
 
     if (text) return text;
 

--- a/libs/domain/content/link/link.component.ts
+++ b/libs/domain/content/link/link.component.ts
@@ -1,14 +1,10 @@
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin } from '@spryker-oryx/experience';
-import { ProductCategoryService, ProductService } from '@spryker-oryx/product';
-import { RouteType } from '@spryker-oryx/router';
 import { LinkService } from '@spryker-oryx/site';
 import { computed, hydrate } from '@spryker-oryx/utilities';
 import { LitElement, TemplateResult, html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { when } from 'lit/directives/when.js';
-import { map } from 'rxjs';
-import { ContentService } from '../src/services';
 import { ContentLinkContent, ContentLinkOptions } from './link.model';
 
 @hydrate()
@@ -17,9 +13,9 @@ export class ContentLinkComponent extends ContentMixin<
   ContentLinkContent
 >(LitElement) {
   protected semanticLinkService = resolve(LinkService);
-  protected categoryService = resolve(ProductCategoryService);
-  protected productService = resolve(ProductService);
-  protected contentService = resolve(ContentService);
+  // protected categoryService = resolve(ProductCategoryService);
+  // protected productService = resolve(ProductService);
+  // protected contentService = resolve(ContentService);
 
   protected $link = computed(() => {
     const { url, type, id, params } = this.$options();
@@ -47,23 +43,23 @@ export class ContentLinkComponent extends ContentMixin<
     const { type, id } = this.$options();
     const { text } = this.$content() ?? {};
 
-    if (text) return text;
+    return text;
 
-    if (type === RouteType.Category && id) {
-      return this.categoryService
-        .get(id)
-        .pipe(map((category) => category?.name));
-    }
+    // if (type === RouteType.Category && id) {
+    //   return this.categoryService
+    //     .get(id)
+    //     .pipe(map((category) => category?.name));
+    // }
 
-    if (type === RouteType.Product && id) {
-      return this.productService
-        .get({ sku: id })
-        .pipe(map((product) => product?.name));
-    }
+    // if (type === RouteType.Product && id) {
+    //   return this.productService
+    //     .get({ sku: id })
+    //     .pipe(map((product) => product?.name));
+    // }
 
-    return this.contentService
-      .get({ type, id })
-      .pipe(map((content) => content?.name));
+    // return this.contentService
+    //   .get({ type, id })
+    //   .pipe(map((content) => content?.name));
   });
 
   protected renderLink(custom?: boolean): TemplateResult {

--- a/libs/domain/content/link/link.component.ts
+++ b/libs/domain/content/link/link.component.ts
@@ -8,6 +8,7 @@ import { LitElement, TemplateResult, html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { when } from 'lit/directives/when.js';
 import { map } from 'rxjs';
+import { ContentService } from '../src/services';
 import { ContentLinkContent, ContentLinkOptions } from './link.model';
 
 @hydrate()
@@ -18,6 +19,7 @@ export class ContentLinkComponent extends ContentMixin<
   protected semanticLinkService = resolve(LinkService);
   protected categoryService = resolve(ProductCategoryService);
   protected productService = resolve(ProductService);
+  protected contentService = resolve(ContentService);
 
   protected $link = computed(() => {
     const { url, type, id, params } = this.$options();
@@ -44,7 +46,9 @@ export class ContentLinkComponent extends ContentMixin<
         .pipe(map((product) => product?.name));
     }
 
-    return null;
+    return this.contentService
+      .get({ type, id })
+      .pipe(map((content) => content?.name));
   });
 
   protected override render(): TemplateResult | void {

--- a/libs/domain/content/link/link.component.ts
+++ b/libs/domain/content/link/link.component.ts
@@ -1,3 +1,4 @@
+import { ContentService } from '@spryker-oryx/content';
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin } from '@spryker-oryx/experience';
 import { ProductCategoryService, ProductService } from '@spryker-oryx/product';
@@ -18,7 +19,7 @@ export class ContentLinkComponent extends ContentMixin<
   protected semanticLinkService = resolve(LinkService);
   protected categoryService = resolve(ProductCategoryService);
   protected productService = resolve(ProductService);
-  // protected contentService = resolve(ContentService);
+  protected contentService = resolve(ContentService);
 
   protected $link = computed(() => {
     const { url, type, id, params } = this.$options();
@@ -60,11 +61,9 @@ export class ContentLinkComponent extends ContentMixin<
         .pipe(map((product) => product?.name));
     }
 
-    return null;
-
-    // return this.contentService
-    //   .get({ type, id })
-    //   .pipe(map((content) => content?.name));
+    return this.contentService
+      .get({ type, id })
+      .pipe(map((content) => content?.name));
   });
 
   protected renderLink(custom?: boolean): TemplateResult {

--- a/libs/domain/content/link/link.component.ts
+++ b/libs/domain/content/link/link.component.ts
@@ -1,10 +1,13 @@
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin } from '@spryker-oryx/experience';
+import { ProductCategoryService, ProductService } from '@spryker-oryx/product';
+import { RouteType } from '@spryker-oryx/router';
 import { LinkService } from '@spryker-oryx/site';
 import { computed, hydrate } from '@spryker-oryx/utilities';
 import { LitElement, TemplateResult, html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { when } from 'lit/directives/when.js';
+import { map } from 'rxjs';
 import { ContentLinkContent, ContentLinkOptions } from './link.model';
 
 @hydrate()
@@ -13,8 +16,8 @@ export class ContentLinkComponent extends ContentMixin<
   ContentLinkContent
 >(LitElement) {
   protected semanticLinkService = resolve(LinkService);
-  // protected categoryService = resolve(ProductCategoryService);
-  // protected productService = resolve(ProductService);
+  protected categoryService = resolve(ProductCategoryService);
+  protected productService = resolve(ProductService);
   // protected contentService = resolve(ContentService);
 
   protected $link = computed(() => {
@@ -43,19 +46,21 @@ export class ContentLinkComponent extends ContentMixin<
     const { type, id } = this.$options();
     const { text } = this.$content() ?? {};
 
-    return text;
+    if (text) return text;
 
-    // if (type === RouteType.Category && id) {
-    //   return this.categoryService
-    //     .get(id)
-    //     .pipe(map((category) => category?.name));
-    // }
+    if (type === RouteType.Category && id) {
+      return this.categoryService
+        .get(id)
+        .pipe(map((category) => category?.name));
+    }
 
-    // if (type === RouteType.Product && id) {
-    //   return this.productService
-    //     .get({ sku: id })
-    //     .pipe(map((product) => product?.name));
-    // }
+    if (type === RouteType.Product && id) {
+      return this.productService
+        .get({ sku: id })
+        .pipe(map((product) => product?.name));
+    }
+
+    return null;
 
     // return this.contentService
     //   .get({ type, id })

--- a/libs/domain/content/link/link.component.ts
+++ b/libs/domain/content/link/link.component.ts
@@ -28,6 +28,21 @@ export class ContentLinkComponent extends ContentMixin<
     return null;
   });
 
+  protected override render(): TemplateResult | void {
+    const { button, icon, singleLine, color } = this.$options();
+
+    if (button) {
+      return html`<oryx-button>${this.renderLink(true)}</oryx-button>`;
+    }
+
+    return html`<oryx-link
+      .color=${color}
+      ?singleLine=${singleLine}
+      .icon=${icon}
+      >${this.renderLink()}
+    </oryx-link>`;
+  }
+
   protected $text = computed(() => {
     const { type, id } = this.$options();
     const { text } = this.$content() ?? {};
@@ -50,21 +65,6 @@ export class ContentLinkComponent extends ContentMixin<
       .get({ type, id })
       .pipe(map((content) => content?.name));
   });
-
-  protected override render(): TemplateResult | void {
-    const { button, icon, singleLine, color } = this.$options();
-
-    if (button) {
-      return html`<oryx-button>${this.renderLink(true)}</oryx-button>`;
-    }
-
-    return html`<oryx-link
-      .color=${color}
-      ?singleLine=${singleLine}
-      .icon=${icon}
-      >${this.renderLink()}
-    </oryx-link>`;
-  }
 
   protected renderLink(custom?: boolean): TemplateResult {
     if (!this.$link()) return html`${this.$text()}`;

--- a/libs/domain/content/link/link.schema.ts
+++ b/libs/domain/content/link/link.schema.ts
@@ -5,16 +5,18 @@ import { ColorType } from '@spryker-oryx/ui/link';
 import { iconInjectable } from '@spryker-oryx/utilities';
 import { ContentLinkComponent } from './link.component';
 
+export const ContentSuggestionField = 'oryx.ContentSuggestion';
+
 export const linkComponentSchema: ContentComponentSchema<
   ContentLinkComponent,
-  { suggestion: unknown }
+  { [ContentSuggestionField]: unknown }
 > = {
   name: 'Link',
   group: 'Content',
   icon: IconTypes.Link,
   options: {
-    suggestion: {
-      type: 'suggestion',
+    [ContentSuggestionField]: {
+      type: ContentSuggestionField,
       width: 100,
     },
     url: { type: FormFieldType.Text },

--- a/libs/domain/content/link/link.schema.ts
+++ b/libs/domain/content/link/link.schema.ts
@@ -1,75 +1,86 @@
 import { ContentComponentSchema } from '@spryker-oryx/experience';
 import { FormFieldType } from '@spryker-oryx/form';
+import { RouteType } from '@spryker-oryx/router';
 import { IconTypes } from '@spryker-oryx/ui/icon';
 import { ColorType } from '@spryker-oryx/ui/link';
 import { iconInjectable } from '@spryker-oryx/utilities';
 import { ContentLinkComponent } from './link.component';
 
-export const linkComponentSchema: ContentComponentSchema<ContentLinkComponent> =
-  {
-    name: 'Link',
-    group: 'Content',
-    icon: IconTypes.Link,
-    options: {
-      url: { type: FormFieldType.Text },
-      type: {
-        type: FormFieldType.Select,
-        options: [
-          {
-            value: 'page',
-            text: 'Page',
-          },
-          {
-            value: 'product',
-            text: 'Product',
-          },
-          {
-            value: 'category',
-            text: 'Category',
-          },
-        ],
-      },
-      target: {
-        type: FormFieldType.Select,
-        options: [
-          {
-            value: '_blank',
-            text: '_blank',
-          },
-          {
-            value: '_self',
-            text: '_self',
-          },
-          {
-            value: '_parent',
-            text: '_parent',
-          },
-          {
-            value: '_top',
-            text: '_top',
-          },
-        ],
-      },
-      id: {
-        label: 'Product/Category/Page ID',
-        type: FormFieldType.Text,
-      },
-      color: {
-        type: FormFieldType.Select,
-        options: [{ value: ColorType.Primary }, { value: ColorType.Neutral }],
-      },
-      icon: {
-        type: FormFieldType.Select,
-        options:
-          iconInjectable
-            .get()
-            ?.getIcons()
-            .sort()
-            .map((i) => ({ value: i, text: i })) ?? [],
-      },
-      noopener: { type: FormFieldType.Boolean },
-      nofollow: { type: FormFieldType.Boolean },
-      singleLine: { type: FormFieldType.Boolean },
+export const linkComponentSchema: ContentComponentSchema<
+  ContentLinkComponent,
+  { suggestion: unknown }
+> = {
+  name: 'Link',
+  group: 'Content',
+  icon: IconTypes.Link,
+  options: {
+    suggestion: {
+      type: 'suggestion',
+      width: 100,
     },
-    content: { text: { type: FormFieldType.Text } },
-  };
+    url: { type: FormFieldType.Text },
+    type: {
+      type: FormFieldType.Select,
+      options: [
+        {
+          value: RouteType.Page,
+          text: 'Page',
+        },
+        {
+          value: RouteType.Product,
+          text: 'Product',
+        },
+        {
+          value: RouteType.Category,
+          text: 'Category',
+        },
+        {
+          value: RouteType.ProductList,
+          text: 'Search',
+        },
+      ],
+    },
+    target: {
+      type: FormFieldType.Select,
+      options: [
+        {
+          value: '_blank',
+          text: '_blank',
+        },
+        {
+          value: '_self',
+          text: '_self',
+        },
+        {
+          value: '_parent',
+          text: '_parent',
+        },
+        {
+          value: '_top',
+          text: '_top',
+        },
+      ],
+    },
+    id: {
+      label: 'Product/Category/Page ID',
+      type: FormFieldType.Text,
+    },
+    color: {
+      type: FormFieldType.Select,
+      options: [{ value: ColorType.Primary }, { value: ColorType.Neutral }],
+    },
+    icon: {
+      type: FormFieldType.Select,
+      options:
+        iconInjectable
+          .get()
+          ?.getIcons()
+          .sort()
+          .map((i) => ({ value: i, text: i })) ?? [],
+    },
+    noopener: { type: FormFieldType.Boolean },
+    nofollow: { type: FormFieldType.Boolean },
+    singleLine: { type: FormFieldType.Boolean },
+  },
+  content: { text: { type: FormFieldType.Text } },
+};

--- a/libs/domain/content/link/link.schema.ts
+++ b/libs/domain/content/link/link.schema.ts
@@ -5,7 +5,7 @@ import { ColorType } from '@spryker-oryx/ui/link';
 import { iconInjectable } from '@spryker-oryx/utilities';
 import { ContentLinkComponent } from './link.component';
 
-export const ContentSuggestionField = 'oryx.ContentSuggestion';
+export const ContentSuggestionField = 'ContentSuggestion';
 
 export const linkComponentSchema: ContentComponentSchema<
   ContentLinkComponent,

--- a/libs/domain/content/link/link.schema.ts
+++ b/libs/domain/content/link/link.schema.ts
@@ -1,6 +1,5 @@
 import { ContentComponentSchema } from '@spryker-oryx/experience';
 import { FormFieldType } from '@spryker-oryx/form';
-import { RouteType } from '@spryker-oryx/router';
 import { IconTypes } from '@spryker-oryx/ui/icon';
 import { ColorType } from '@spryker-oryx/ui/link';
 import { iconInjectable } from '@spryker-oryx/utilities';
@@ -19,27 +18,6 @@ export const linkComponentSchema: ContentComponentSchema<
       width: 100,
     },
     url: { type: FormFieldType.Text },
-    type: {
-      type: FormFieldType.Select,
-      options: [
-        {
-          value: RouteType.Page,
-          text: 'Page',
-        },
-        {
-          value: RouteType.Product,
-          text: 'Product',
-        },
-        {
-          value: RouteType.Category,
-          text: 'Category',
-        },
-        {
-          value: RouteType.ProductList,
-          text: 'Search',
-        },
-      ],
-    },
     target: {
       type: FormFieldType.Select,
       options: [
@@ -60,10 +38,6 @@ export const linkComponentSchema: ContentComponentSchema<
           text: '_top',
         },
       ],
-    },
-    id: {
-      label: 'Product/Category/Page ID',
-      type: FormFieldType.Text,
     },
     color: {
       type: FormFieldType.Select,

--- a/libs/domain/content/package.json
+++ b/libs/domain/content/package.json
@@ -18,6 +18,7 @@
     "@spryker-oryx/di": "1.0.2",
     "@spryker-oryx/experience": "1.0.2",
     "@spryker-oryx/router": "1.0.2",
+    "@spryker-oryx/product": "1.0.2",
     "@spryker-oryx/site": "1.0.2",
     "@spryker-oryx/utilities": "1.0.2"
   },

--- a/libs/domain/content/src/services/default-content.service.ts
+++ b/libs/domain/content/src/services/default-content.service.ts
@@ -10,7 +10,7 @@ export class DefaultContentService implements ContentService {
   protected contents: Record<string, string[]> = {};
 
   constructor(
-    protected adapters = inject(ContentAdapter),
+    protected adapters = inject(ContentAdapter, [] as ContentAdapter[]),
     protected config = inject(ContentConfig, [] as ContentConfig[]),
     protected injector = inject(INJECTOR)
   ) {

--- a/libs/domain/product/card/src/card.component.spec.ts
+++ b/libs/domain/product/card/src/card.component.spec.ts
@@ -1,5 +1,4 @@
 import { fixture } from '@open-wc/testing-helpers';
-import { contentLinkComponent } from '@spryker-oryx/content';
 import * as core from '@spryker-oryx/core';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
 import { mockProductProviders } from '@spryker-oryx/product/mocks';
@@ -34,7 +33,7 @@ describe('ProductCardComponent', () => {
   let element: ProductCardComponent;
 
   beforeAll(async () => {
-    await useComponent([productCardComponent, contentLinkComponent]);
+    await useComponent([productCardComponent]);
   });
 
   beforeEach(async () => {

--- a/libs/domain/product/package.json
+++ b/libs/domain/product/package.json
@@ -20,7 +20,6 @@
     }
   },
   "dependencies": {
-    "@spryker-oryx/content": "1.0.2",
     "@spryker-oryx/core": "1.0.2",
     "@spryker-oryx/di": "1.0.2",
     "@spryker-oryx/experience": "1.0.2",

--- a/libs/domain/search/src/services/adapter/default-suggestion.adapter.ts
+++ b/libs/domain/search/src/services/adapter/default-suggestion.adapter.ts
@@ -53,7 +53,7 @@ export class DefaultSuggestionAdapter implements SuggestionAdapter {
           ? ApiProductModel.Includes.CategoryNodes
           : '';
       const includes = [product, categories].filter(Boolean).join(',');
-      console.log(includes);
+
       return this.http
         .get<ApiSuggestionModel.Response>(
           `${this.SCOS_BASE_URL}/${this.queryEndpoint}?q=${query}&include=${includes}`

--- a/libs/domain/search/src/services/adapter/default-suggestion.adapter.ts
+++ b/libs/domain/search/src/services/adapter/default-suggestion.adapter.ts
@@ -37,10 +37,11 @@ export class DefaultSuggestionAdapter implements SuggestionAdapter {
         ].includes(entity as SuggestionField)
       )
     ) {
-      const product =
+      const include =
         entities?.includes(SuggestionField.Products) || !entities?.length
           ? [
               ApiProductModel.Includes.AbstractProducts,
+              ApiProductModel.Includes.CategoryNodes,
               ApiProductModel.Includes.ConcreteProducts,
               ApiProductModel.Includes.ConcreteProductImageSets,
               ApiProductModel.Includes.ConcreteProductPrices,
@@ -48,15 +49,10 @@ export class DefaultSuggestionAdapter implements SuggestionAdapter {
               ApiProductModel.Includes.Labels,
             ].join(',')
           : '';
-      const categories =
-        entities?.includes(SuggestionField.Categories) || !entities?.length
-          ? ApiProductModel.Includes.CategoryNodes
-          : '';
-      const includes = [product, categories].filter(Boolean).join(',');
 
       return this.http
         .get<ApiSuggestionModel.Response>(
-          `${this.SCOS_BASE_URL}/${this.queryEndpoint}?q=${query}&include=${includes}`
+          `${this.SCOS_BASE_URL}/${this.queryEndpoint}?q=${query}&include=${include}`
         )
         .pipe(this.transformer.do(SuggestionNormalizer));
     }

--- a/libs/domain/search/src/services/revealers/index.ts
+++ b/libs/domain/search/src/services/revealers/index.ts
@@ -1,1 +1,2 @@
 export * from './products-experience-data.revealer';
+export * from './suggestion-experience-data.revealer';

--- a/libs/domain/search/src/services/revealers/products-experience-data.revealer.ts
+++ b/libs/domain/search/src/services/revealers/products-experience-data.revealer.ts
@@ -10,6 +10,9 @@ import { Suggestion } from '../../models';
 import { SuggestionField } from '../adapter';
 import { SuggestionService } from '../suggestion';
 
+/**
+ * @deprecated since 1.1 use SuggestionExperienceDataRevealer instead.
+ */
 export class ProductsExperienceDataRevealer implements ExperienceDataRevealer {
   constructor(protected suggestionService = inject(SuggestionService, null)) {}
 

--- a/libs/domain/search/src/services/revealers/suggestion-experience-data.revealer.spec.ts
+++ b/libs/domain/search/src/services/revealers/suggestion-experience-data.revealer.spec.ts
@@ -1,0 +1,80 @@
+import { nextFrame } from '@open-wc/testing-helpers';
+import { createInjector, destroyInjector, getInjector } from '@spryker-oryx/di';
+import { MessageType, postMessage } from '@spryker-oryx/experience';
+import { RouteType } from '@spryker-oryx/router';
+import { of } from 'rxjs';
+import { SuggestionField } from '../adapter';
+import { SuggestionService } from '../suggestion';
+import { SuggestionExperienceDataRevealer } from './suggestion-experience-data.revealer';
+
+const mockSuggestionService = {
+  get: vi.fn().mockReturnValue(of(null)),
+};
+
+describe('SuggestionExperienceDataRevealer', () => {
+  beforeEach(() => {
+    createInjector({
+      providers: [
+        {
+          provide: SuggestionService,
+          useValue: mockSuggestionService,
+        },
+        {
+          provide: 'service',
+          useClass: SuggestionExperienceDataRevealer,
+        },
+      ],
+    });
+    vi.spyOn(window.parent, 'postMessage');
+  });
+
+  afterEach(() => {
+    destroyInjector();
+    vi.clearAllMocks();
+  });
+
+  describe('reveal', () => {
+    it('should send `MessageType.SuggestionQuery` post message', async () => {
+      const mockQuery = 'mockQuery';
+      const mockSuggestions = {
+        products: [
+          {
+            a: 'a',
+            sku: 'skuA',
+            name: 'nameA',
+            type: RouteType.Product,
+          },
+          {
+            b: 'b',
+            sku: 'skuB',
+            name: 'nameB',
+            type: RouteType.Product,
+          },
+        ],
+        suggestion: ['a', 'b'],
+      };
+      mockSuggestionService.get.mockReturnValue(of(mockSuggestions));
+      getInjector().inject('service').reveal().subscribe();
+      const mockData = {
+        query: mockQuery,
+        entities: [SuggestionField.Products],
+      };
+      postMessage(
+        {
+          type: MessageType.SuggestionQuery,
+          data: mockData,
+        },
+        window
+      );
+      await nextFrame();
+      expect(mockSuggestionService.get).toHaveBeenCalledWith(mockData);
+      expect(window.parent.postMessage).toHaveBeenCalledWith(
+        {
+          type: MessageType.Suggestions,
+          data: mockSuggestions,
+        },
+        '*'
+      );
+    });
+  });
+});

--- a/libs/domain/search/src/services/revealers/suggestion-experience-data.revealer.ts
+++ b/libs/domain/search/src/services/revealers/suggestion-experience-data.revealer.ts
@@ -16,7 +16,7 @@ export class SuggestionExperienceDataRevealer
 {
   constructor(protected suggestionService = inject(SuggestionService, null)) {}
 
-  protected products$ = catchMessage(MessageType.SuggestionQuery).pipe(
+  protected suggestions$ = catchMessage(MessageType.SuggestionQuery).pipe(
     switchMap((data) => this.suggestionService?.get(data) ?? of(undefined)),
     tap((suggestions?: Suggestion) => {
       if (suggestions) {
@@ -34,6 +34,6 @@ export class SuggestionExperienceDataRevealer
   );
 
   reveal(): Observable<unknown> {
-    return this.products$;
+    return this.suggestions$;
   }
 }

--- a/libs/domain/search/src/services/revealers/suggestion-experience-data.revealer.ts
+++ b/libs/domain/search/src/services/revealers/suggestion-experience-data.revealer.ts
@@ -1,0 +1,39 @@
+import { inject } from '@spryker-oryx/di';
+import {
+  catchMessage,
+  ExperienceDataRevealer,
+  ExperienceSuggestionRecords,
+  MessageType,
+  postMessage,
+} from '@spryker-oryx/experience';
+import { RouteType } from '@spryker-oryx/router';
+import { Observable, of, switchMap, tap } from 'rxjs';
+import { Suggestion } from '../../models';
+import { SuggestionService } from '../suggestion';
+
+export class SuggestionExperienceDataRevealer
+  implements ExperienceDataRevealer
+{
+  constructor(protected suggestionService = inject(SuggestionService, null)) {}
+
+  protected products$ = catchMessage(MessageType.SuggestionQuery).pipe(
+    switchMap((data) => this.suggestionService?.get(data) ?? of(undefined)),
+    tap((suggestions?: Suggestion) => {
+      if (suggestions) {
+        suggestions.products = suggestions?.products?.map((product) => ({
+          ...product,
+          type: RouteType.Product,
+        }));
+      }
+
+      return postMessage({
+        type: MessageType.Suggestions,
+        data: suggestions as ExperienceSuggestionRecords,
+      });
+    })
+  );
+
+  reveal(): Observable<unknown> {
+    return this.products$;
+  }
+}

--- a/libs/domain/search/src/services/search.providers.ts
+++ b/libs/domain/search/src/services/search.providers.ts
@@ -17,7 +17,10 @@ import {
   CategoryPageTitleMetaResolver,
   SearchPageTitleMetaResolver,
 } from './resolvers';
-import { ProductsExperienceDataRevealer } from './revealers';
+import {
+  ProductsExperienceDataRevealer,
+  SuggestionExperienceDataRevealer,
+} from './revealers';
 import { categoryRoutes } from './routes';
 import { SortingService } from './sorting.service';
 import {
@@ -76,5 +79,9 @@ export const searchPreviewProviders: Provider[] = [
   {
     provide: ExperienceDataRevealer,
     useClass: ProductsExperienceDataRevealer,
+  },
+  {
+    provide: ExperienceDataRevealer,
+    useClass: SuggestionExperienceDataRevealer,
   },
 ];

--- a/libs/domain/search/src/services/suggestion/renderer/default-suggestion-renderer.service.ts
+++ b/libs/domain/search/src/services/suggestion/renderer/default-suggestion-renderer.service.ts
@@ -41,7 +41,6 @@ export class DefaultSuggestionRendererService
     suggestions: Suggestion,
     options: SuggestionRendererOptions & Record<'query', string>
   ): TemplateResult {
-    // console.log(suggestions, 'suggestionssuggestions');
     const data = Object.keys(options)
       .map((entity) => {
         const records = suggestions?.[entity as keyof Suggestion];

--- a/libs/domain/search/src/services/suggestion/renderer/default-suggestion-renderer.service.ts
+++ b/libs/domain/search/src/services/suggestion/renderer/default-suggestion-renderer.service.ts
@@ -41,6 +41,7 @@ export class DefaultSuggestionRendererService
     suggestions: Suggestion,
     options: SuggestionRendererOptions & Record<'query', string>
   ): TemplateResult {
+    // console.log(suggestions, 'suggestionssuggestions');
     const data = Object.keys(options)
       .map((entity) => {
         const records = suggestions?.[entity as keyof Suggestion];

--- a/libs/platform/experience/src/models/component-schema.model.ts
+++ b/libs/platform/experience/src/models/component-schema.model.ts
@@ -20,7 +20,10 @@ export type ComponentSchema<Options, Content> = {
 };
 
 export type ContentComponentSchema<
-  T = ContentMixinInterface<unknown, unknown>
-> = T extends ContentMixinInterface<infer Options, infer Content> | LitElement
-  ? ComponentSchema<Options, Content>
+  Component = ContentMixinInterface<unknown, unknown>,
+  CustomOptions = unknown
+> = Component extends
+  | ContentMixinInterface<infer Options, infer Content>
+  | LitElement
+  ? ComponentSchema<Options & CustomOptions, Content>
   : never;

--- a/libs/platform/experience/src/services/data-client/data-client.model.ts
+++ b/libs/platform/experience/src/services/data-client/data-client.model.ts
@@ -10,6 +10,9 @@ export const enum MessageType {
    * @deprecated Since version 1.1. Use Suggestions instead.
    */
   Products = 'oryx.products',
+  /**
+   * @deprecated Since version 1.1. Use SuggestionQuery instead.
+   */
   Query = 'oryx.query',
   Static = 'oryx.static',
   ComponentType = 'oryx.component-type',

--- a/libs/platform/experience/src/services/data-client/data-client.model.ts
+++ b/libs/platform/experience/src/services/data-client/data-client.model.ts
@@ -6,6 +6,9 @@ import { ExperienceComponent } from '../experience-data';
 export const enum MessageType {
   Graphics = 'oryx.graphics',
   Options = 'oryx.options',
+  /**
+   * @deprecated Since version 1.1. Use Suggestions instead.
+   */
   Products = 'oryx.products',
   Query = 'oryx.query',
   Static = 'oryx.static',
@@ -14,12 +17,34 @@ export const enum MessageType {
   ColorMode = 'oryx.color-mode',
   AppReady = 'oryx.app-ready',
   Icons = 'oryx.icons',
+  SuggestionQuery = 'oryx.suggestion-query',
+  Suggestions = 'oryx.suggestions',
 }
 
+/**
+ * @deprecated Since version 1.1. Use ExperienceSuggestionsData instead.
+ */
 export interface ExperienceProductData {
   sku?: string;
   name?: string;
 }
+
+export interface ExperienceSuggestionQuery {
+  query: string;
+  entities?: string[];
+}
+
+export interface ExperienceSuggestionsData {
+  sku?: string;
+  name: string;
+  id?: string;
+  type: string;
+  params?: Record<string, string>;
+}
+
+export type ExperienceSuggestionRecords =
+  | Record<string, ExperienceSuggestionsData[]>
+  | undefined;
 
 export type ExperienceMessageData<T> = {
   type: T;
@@ -29,8 +54,12 @@ export type ExperienceMessageData<T> = {
     ? FeatureOptions[keyof FeatureOptions]
     : T extends MessageType.Products
     ? ExperienceProductData[]
+    : T extends MessageType.Suggestions
+    ? ExperienceSuggestionRecords
     : T extends MessageType.Query | MessageType.ComponentType
     ? string
+    : T extends MessageType.SuggestionQuery
+    ? ExperienceSuggestionQuery
     : T extends MessageType.ComponentSchemas
     ? ContentComponentSchema[] | undefined
     : T extends MessageType.Static

--- a/libs/platform/form/src/renderers/default-form.renderer.ts
+++ b/libs/platform/form/src/renderers/default-form.renderer.ts
@@ -144,6 +144,7 @@ export class DefaultFormRenderer implements FormRenderer {
       >
         <input
           .name=${field.id}
+          .value=${value ?? ''}
           value=${value ?? ''}
           placeholder=${ifDefined(field.placeholder)}
           minlength=${ifDefined(field.min)}


### PR DESCRIPTION
Improve the content link component to resolve links to product, category or content pages. 
Reveal suggestions so that integrations can reuse the data while building content. 

closes: [HRZ-89824](https://spryker.atlassian.net/browse/HRZ-89824)

[HRZ-89824]: https://spryker.atlassian.net/browse/HRZ-89824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ