### PR TITLE
fix(experience): store experience data correctly on component reload by route

### DIFF
--- a/libs/platform/experience/src/services/experience/default-experience.service.ts
+++ b/libs/platform/experience/src/services/experience/default-experience.service.ts
@@ -2,8 +2,9 @@ import { HttpService } from '@spryker-oryx/core';
 import { inject } from '@spryker-oryx/di';
 import {
   Observable,
-  of,
   ReplaySubject,
+  map,
+  of,
   switchMap,
   take,
   tap,
@@ -154,7 +155,9 @@ export class DefaultExperienceService implements ExperienceService {
 
     const adapter = this.experienceAdapter
       ? this.experienceAdapter.get({ route })
-      : this.http.get<Component>(componentsUrl);
+      : this.http
+          .get<Component[]>(componentsUrl)
+          .pipe(map((result) => result[0]));
 
     adapter
       .pipe(


### PR DESCRIPTION
closes: [HRZ-89845](https://spryker.atlassian.net/browse/HRZ-89845)

[HRZ-89845]: https://spryker.atlassian.net/browse/HRZ-89845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ