### PR TITLE
fix(cart): render unit price from the cart entry data

### DIFF
--- a/apps/storefront-e2e/src/support/page-fragments/cart-entry.fragment.ts
+++ b/apps/storefront-e2e/src/support/page-fragments/cart-entry.fragment.ts
@@ -14,15 +14,9 @@ export class CartEntryFragment {
   getDefaultImage = () =>
     this.getWrapper().find('oryx-product-media').find('oryx-icon');
   getSKU = () => this.getWrapper().find('oryx-product-id').shadow();
-  getSalesPrice = () =>
-    this.getWrapper()
-      .find('oryx-product-price')
-      .shadow()
-      .find('oryx-site-price[part="sales"]');
-
-  getOriginalPrice = () =>
-    this.getWrapper().find('oryx-product-price').find('[part="original"]');
-  getSubtotal = () => this.getWrapper().find('.pricing > oryx-site-price');
+  getSalesPrice = () => this.getWrapper().find('oryx-site-price.sales');
+  getOriginalPrice = () => this.getWrapper().find('oryx-site-price.original');
+  getSubtotal = () => this.getWrapper().find('oryx-site-price.subtotal');
   getRemoveBtn = () => this.getWrapper().find('[aria-label="Remove"]');
   getQuantityInput = () =>
     new QuantityInputFragment(

--- a/libs/domain/cart/entries/src/entries.component.ts
+++ b/libs/domain/cart/entries/src/entries.component.ts
@@ -42,6 +42,7 @@ export class CartEntriesComponent extends CartComponentMixin(
               .currency=${this.$cart()?.currency}
               .quantity=${entry.quantity}
               .price=${entry.calculations?.sumPriceToPayAggregation}
+              .itemPrice=${entry.calculations?.unitPriceToPayAggregation}
               .unitPrice=${entry.calculations?.unitPrice}
               .discountedUnitPrice=${entry.calculations
                 ?.unitPriceToPayAggregation}

--- a/libs/domain/cart/entries/src/entries.component.ts
+++ b/libs/domain/cart/entries/src/entries.component.ts
@@ -42,7 +42,9 @@ export class CartEntriesComponent extends CartComponentMixin(
               .currency=${this.$cart()?.currency}
               .quantity=${entry.quantity}
               .price=${entry.calculations?.sumPriceToPayAggregation}
-              .itemPrice=${entry.calculations?.unitPriceToPayAggregation}
+              .unitPrice=${entry.calculations?.unitPrice}
+              .discountedUnitPrice=${entry.calculations
+                ?.unitPriceToPayAggregation}
               .key=${entry.groupKey}
               .options=${this.$options()}
               ?readonly=${this.$options().readonly}

--- a/libs/domain/cart/entry/src/entry.component.spec.ts
+++ b/libs/domain/cart/entry/src/entry.component.spec.ts
@@ -5,7 +5,7 @@ import { ProductService } from '@spryker-oryx/product';
 import { MockProductService } from '@spryker-oryx/product/mocks';
 import { LinkService, PricingService, siteProviders } from '@spryker-oryx/site';
 import { IconTypes } from '@spryker-oryx/ui/icon';
-import { useComponent } from '@spryker-oryx/utilities';
+import { featureVersion, useComponent } from '@spryker-oryx/utilities';
 import { html } from 'lit';
 import { BehaviorSubject, of } from 'rxjs';
 import { QuantityInputComponent } from '../../quantity-input/src';
@@ -225,61 +225,101 @@ describe('CartEntryComponent', () => {
       });
 
       describe('enableItemPrice', () => {
-        describe('when enableItemPrice is not provided', () => {
-          beforeEach(async () => {
-            element = await fixture(html` <oryx-cart-entry
-              quantity="1"
-              unitPrice="100"
-              discountedUnitPrice="200"
-            ></oryx-cart-entry>`);
+        if (featureVersion < '1.2') {
+          describe('when enableItemPrice is not provided', () => {
+            beforeEach(async () => {
+              element = await fixture(html` <oryx-cart-entry
+                quantity="1"
+              ></oryx-cart-entry>`);
+            });
+
+            it('should render enableItemPrice by default', () => {
+              expect(element).toContainElement('oryx-product-price');
+            });
           });
 
-          it('should render the original unit price by default', () => {
-            expect(element).toContainElement('oryx-site-price.original');
+          describe('when enableItemPrice is false', () => {
+            beforeEach(async () => {
+              element = await fixture(html` <oryx-cart-entry
+                quantity="1"
+                .options=${{ enableItemPrice: false }}
+              ></oryx-cart-entry>`);
+            });
+            it('should not render enableItemPrice', () => {
+              expect(element).not.toContainElement('oryx-product-price');
+            });
           });
 
-          it('should render the discounted unit price by default', () => {
-            expect(element).toContainElement('oryx-site-price.sales');
+          describe('when enableItemPrice is true', () => {
+            beforeEach(async () => {
+              element = await fixture(html` <oryx-cart-entry
+                quantity="1"
+                .options=${{ enableItemPrice: true }}
+              ></oryx-cart-entry>`);
+            });
+            it('should render enableItemPrice', () => {
+              expect(element).toContainElement('oryx-product-price');
+            });
           });
-        });
+        }
 
-        describe('when enableItemPrice is false', () => {
-          beforeEach(async () => {
-            element = await fixture(html` <oryx-cart-entry
-              quantity="1"
-              unitPrice="100"
-              discountedUnitPrice="200"
-              .options=${{ enableItemPrice: false }}
-            ></oryx-cart-entry>`);
-          });
+        if (featureVersion >= '1.2') {
+          describe('when enableItemPrice is not provided', () => {
+            beforeEach(async () => {
+              element = await fixture(html` <oryx-cart-entry
+                quantity="1"
+                unitPrice="100"
+                discountedUnitPrice="200"
+              ></oryx-cart-entry>`);
+            });
 
-          it('should not render the original unit price by default', () => {
-            expect(element).not.toContainElement('oryx-site-price.original');
-          });
+            it('should render the original unit price by default', () => {
+              expect(element).toContainElement('oryx-site-price.original');
+            });
 
-          it('should not render the discounted unit price by default', () => {
-            expect(element).not.toContainElement('oryx-site-price.sales');
-          });
-        });
-
-        describe('when enableItemPrice is true', () => {
-          beforeEach(async () => {
-            element = await fixture(html` <oryx-cart-entry
-              quantity="1"
-              unitPrice="100"
-              discountedUnitPrice="200"
-              .options=${{ enableItemPrice: true }}
-            ></oryx-cart-entry>`);
+            it('should render the discounted unit price by default', () => {
+              expect(element).toContainElement('oryx-site-price.sales');
+            });
           });
 
-          it('should render the original unit price by default', () => {
-            expect(element).toContainElement('oryx-site-price.original');
+          describe('when enableItemPrice is false', () => {
+            beforeEach(async () => {
+              element = await fixture(html` <oryx-cart-entry
+                quantity="1"
+                unitPrice="100"
+                discountedUnitPrice="200"
+                .options=${{ enableItemPrice: false }}
+              ></oryx-cart-entry>`);
+            });
+
+            it('should not render the original unit price by default', () => {
+              expect(element).not.toContainElement('oryx-site-price.original');
+            });
+
+            it('should not render the discounted unit price by default', () => {
+              expect(element).not.toContainElement('oryx-site-price.sales');
+            });
           });
 
-          it('should render the discounted unit price by default', () => {
-            expect(element).toContainElement('oryx-site-price.sales');
+          describe('when enableItemPrice is true', () => {
+            beforeEach(async () => {
+              element = await fixture(html` <oryx-cart-entry
+                quantity="1"
+                unitPrice="100"
+                discountedUnitPrice="200"
+                .options=${{ enableItemPrice: true }}
+              ></oryx-cart-entry>`);
+            });
+
+            it('should render the original unit price by default', () => {
+              expect(element).toContainElement('oryx-site-price.original');
+            });
+
+            it('should render the discounted unit price by default', () => {
+              expect(element).toContainElement('oryx-site-price.sales');
+            });
           });
-        });
+        }
       });
 
       describe('removeByQuantity', () => {
@@ -383,42 +423,44 @@ describe('CartEntryComponent', () => {
       });
     });
 
-    describe('discounted unit price', () => {
-      describe('when the unit price is the same as the discounted unit price', () => {
+    if (featureVersion >= '1.2') {
+      describe('discounted unit price', () => {
+        describe('when the unit price is the same as the discounted unit price', () => {
+          beforeEach(async () => {
+            element = await fixture(html` <oryx-cart-entry
+              quantity="1"
+              unitPrice="100"
+              discountedUnitPrice="100"
+            ></oryx-cart-entry>`);
+          });
+
+          it('should not render the original price', () => {
+            expect(element).not.toContainElement('oryx-site-price.original');
+          });
+
+          it('should render the sales price', () => {
+            expect(element).toContainElement('oryx-site-price.sales');
+          });
+        });
+      });
+
+      describe('when the unit price is not the same as the discounted unit price', () => {
         beforeEach(async () => {
           element = await fixture(html` <oryx-cart-entry
             quantity="1"
             unitPrice="100"
-            discountedUnitPrice="100"
+            discountedUnitPrice="200"
           ></oryx-cart-entry>`);
         });
 
-        it('should not render the original price', () => {
-          expect(element).not.toContainElement('oryx-site-price.original');
+        it('should render the original price', () => {
+          expect(element).toContainElement('oryx-site-price.original');
         });
 
         it('should render the sales price', () => {
           expect(element).toContainElement('oryx-site-price.sales');
         });
       });
-    });
-
-    describe('when the unit price is not the same as the discounted unit price', () => {
-      beforeEach(async () => {
-        element = await fixture(html` <oryx-cart-entry
-          quantity="1"
-          unitPrice="100"
-          discountedUnitPrice="200"
-        ></oryx-cart-entry>`);
-      });
-
-      it('should render the original price', () => {
-        expect(element).toContainElement('oryx-site-price.original');
-      });
-
-      it('should render the sales price', () => {
-        expect(element).toContainElement('oryx-site-price.sales');
-      });
-    });
+    }
   });
 });

--- a/libs/domain/cart/entry/src/entry.component.spec.ts
+++ b/libs/domain/cart/entry/src/entry.component.spec.ts
@@ -232,8 +232,12 @@ describe('CartEntryComponent', () => {
             ></oryx-cart-entry>`);
           });
 
-          it('should render enableItemPrice by default', () => {
-            expect(element).toContainElement('oryx-product-price');
+          it('should render the original unit price by default', () => {
+            expect(element).toContainElement('oryx-site-price.original');
+          });
+
+          it('should render the discounted unit price by default', () => {
+            expect(element).toContainElement('oryx-site-price.sales');
           });
         });
 
@@ -244,8 +248,13 @@ describe('CartEntryComponent', () => {
               .options=${{ enableItemPrice: false }}
             ></oryx-cart-entry>`);
           });
-          it('should not render enableItemPrice', () => {
-            expect(element).not.toContainElement('oryx-product-price');
+
+          it('should not render the original unit price by default', () => {
+            expect(element).not.toContainElement('oryx-site-price.original');
+          });
+
+          it('should not render the discounted unit price by default', () => {
+            expect(element).not.toContainElement('oryx-site-price.sales');
           });
         });
 
@@ -256,8 +265,13 @@ describe('CartEntryComponent', () => {
               .options=${{ enableItemPrice: true }}
             ></oryx-cart-entry>`);
           });
-          it('should render enableItemPrice', () => {
-            expect(element).toContainElement('oryx-product-price');
+
+          it('should render the original unit price by default', () => {
+            expect(element).toContainElement('oryx-site-price.original');
+          });
+
+          it('should render the discounted unit price by default', () => {
+            expect(element).toContainElement('oryx-site-price.sales');
           });
         });
       });

--- a/libs/domain/cart/entry/src/entry.component.spec.ts
+++ b/libs/domain/cart/entry/src/entry.component.spec.ts
@@ -229,6 +229,8 @@ describe('CartEntryComponent', () => {
           beforeEach(async () => {
             element = await fixture(html` <oryx-cart-entry
               quantity="1"
+              unitPrice="100"
+              discountedUnitPrice="200"
             ></oryx-cart-entry>`);
           });
 
@@ -245,6 +247,8 @@ describe('CartEntryComponent', () => {
           beforeEach(async () => {
             element = await fixture(html` <oryx-cart-entry
               quantity="1"
+              unitPrice="100"
+              discountedUnitPrice="200"
               .options=${{ enableItemPrice: false }}
             ></oryx-cart-entry>`);
           });
@@ -262,6 +266,8 @@ describe('CartEntryComponent', () => {
           beforeEach(async () => {
             element = await fixture(html` <oryx-cart-entry
               quantity="1"
+              unitPrice="100"
+              discountedUnitPrice="200"
               .options=${{ enableItemPrice: true }}
             ></oryx-cart-entry>`);
           });
@@ -374,6 +380,44 @@ describe('CartEntryComponent', () => {
             '.actions oryx-button:not([disabled])'
           );
         });
+      });
+    });
+
+    describe('discounted unit price', () => {
+      describe('when the unit price is the same as the discounted unit price', () => {
+        beforeEach(async () => {
+          element = await fixture(html` <oryx-cart-entry
+            quantity="1"
+            unitPrice="100"
+            discountedUnitPrice="100"
+          ></oryx-cart-entry>`);
+        });
+
+        it('should not render the original price', () => {
+          expect(element).not.toContainElement('oryx-site-price.original');
+        });
+
+        it('should render the sales price', () => {
+          expect(element).toContainElement('oryx-site-price.sales');
+        });
+      });
+    });
+
+    describe('when the unit price is not the same as the discounted unit price', () => {
+      beforeEach(async () => {
+        element = await fixture(html` <oryx-cart-entry
+          quantity="1"
+          unitPrice="100"
+          discountedUnitPrice="200"
+        ></oryx-cart-entry>`);
+      });
+
+      it('should render the original price', () => {
+        expect(element).toContainElement('oryx-site-price.original');
+      });
+
+      it('should render the sales price', () => {
+        expect(element).toContainElement('oryx-site-price.sales');
       });
     });
   });

--- a/libs/domain/cart/entry/src/entry.component.ts
+++ b/libs/domain/cart/entry/src/entry.component.ts
@@ -6,7 +6,6 @@ import {
   ProductMediaContainerSize,
   ProductMixin,
 } from '@spryker-oryx/product';
-import { ProductPriceOptions } from '@spryker-oryx/product/price';
 import { RouteType } from '@spryker-oryx/router';
 import {
   LinkService,
@@ -63,6 +62,8 @@ export class CartEntryComponent
   @property() key?: string;
   @property({ type: Number }) price?: number;
   @property({ type: Number }) itemPrice?: number;
+  @property({ type: Number }) unitPrice?: number;
+  @property({ type: Number }) discountedUnitPrice?: number;
   @property({ type: Boolean }) readonly?: boolean;
   @property() currency?: string;
 
@@ -173,13 +174,20 @@ export class CartEntryComponent
         ${when(
           this.$options()?.enableItemPrice,
           () =>
-            html`<div class="item-price">
+            html`<div class="unit-price">
               <span>${this.i18n('cart.entry.item-price')}</span>
-              <oryx-product-price
-                .options=${{ enableTaxMessage: false } as ProductPriceOptions}
-                .sales=${this.itemPrice}
+
+              <oryx-site-price
+                .value=${this.unitPrice}
                 .currency=${this.currency}
-              ></oryx-product-price>
+                original
+              ></oryx-site-price>
+
+              <oryx-site-price
+                .value=${this.discountedUnitPrice}
+                .currency=${this.currency}
+                discounted
+              ></oryx-site-price>
             </div>`
         )}
       </section>

--- a/libs/domain/cart/entry/src/entry.component.ts
+++ b/libs/domain/cart/entry/src/entry.component.ts
@@ -61,7 +61,6 @@ export class CartEntryComponent
   @signalProperty({ type: Number }) quantity?: number;
   @property() key?: string;
   @property({ type: Number }) price?: number;
-  @property({ type: Number }) itemPrice?: number;
   @property({ type: Number }) unitPrice?: number;
   @property({ type: Number }) discountedUnitPrice?: number;
   @property({ type: Boolean }) readonly?: boolean;
@@ -170,6 +169,7 @@ export class CartEntryComponent
         <oryx-site-price
           .value=${this.price}
           .currency=${this.currency}
+          class="subtotal"
         ></oryx-site-price>
         ${when(
           this.$options()?.enableItemPrice,
@@ -181,12 +181,14 @@ export class CartEntryComponent
                 .value=${this.unitPrice}
                 .currency=${this.currency}
                 original
+                class="original"
               ></oryx-site-price>
 
               <oryx-site-price
                 .value=${this.discountedUnitPrice}
                 .currency=${this.currency}
                 discounted
+                class="sales"
               ></oryx-site-price>
             </div>`
         )}

--- a/libs/domain/cart/entry/src/entry.component.ts
+++ b/libs/domain/cart/entry/src/entry.component.ts
@@ -163,6 +163,8 @@ export class CartEntryComponent
           ?disabled=${this.$isBusy()}
         ></oryx-cart-quantity-input>`;
 
+    const isDiscounted = this.unitPrice !== this.discountedUnitPrice;
+
     return html`
       <section class="pricing">
         ${qtyTemplate}
@@ -177,17 +179,22 @@ export class CartEntryComponent
             html`<div class="unit-price">
               <span>${this.i18n('cart.entry.item-price')}</span>
 
-              <oryx-site-price
-                .value=${this.unitPrice}
-                .currency=${this.currency}
-                original
-                class="original"
-              ></oryx-site-price>
+              ${when(
+                isDiscounted,
+                () => html`
+                  <oryx-site-price
+                    .value=${this.unitPrice}
+                    .currency=${this.currency}
+                    original
+                    class="original"
+                  ></oryx-site-price>
+                `
+              )}
 
               <oryx-site-price
                 .value=${this.discountedUnitPrice}
                 .currency=${this.currency}
-                discounted
+                ?discounted=${isDiscounted}
                 class="sales"
               ></oryx-site-price>
             </div>`

--- a/libs/domain/cart/entry/src/entry.model.ts
+++ b/libs/domain/cart/entry/src/entry.model.ts
@@ -17,8 +17,21 @@ export interface CartEntryAttributes {
   quantity?: number;
 
   /**
-   * The entry price represents the price per item of the entry. This might be a
-   * discounted price because of volume pricing.
+   * Regular unit price of the product, before volume discounts (see `discountedUnitPrice`).
+   *
+   * The given number represents the non formatted price.
+   */
+  unitPrice?: number;
+
+  /**
+   * Unit price after applying volume discount.
+   *
+   * The given number represents the non formatted price.
+   */
+  discountedUnitPrice?: number;
+
+  /**
+   * Subtotal price for the entry (quantity * discountedUnitPrice)
    *
    * The given number represents the non formatted price.
    */
@@ -29,6 +42,8 @@ export interface CartEntryAttributes {
    * a discounted price. Additional discounts can be given by volume pricing, see `price`.
    *
    * The given number represents the non formatted price.
+   *
+   * @deprecated use `unitPrice` instead
    */
   itemPrice?: number;
 

--- a/libs/domain/cart/entry/src/entry.model.ts
+++ b/libs/domain/cart/entry/src/entry.model.ts
@@ -20,6 +20,8 @@ export interface CartEntryAttributes {
    * Regular unit price of the product, before volume discounts (see `discountedUnitPrice`).
    *
    * The given number represents the non formatted price.
+   *
+   * @since 1.2.0
    */
   unitPrice?: number;
 
@@ -27,6 +29,8 @@ export interface CartEntryAttributes {
    * Unit price after applying volume discount.
    *
    * The given number represents the non formatted price.
+   *
+   * @since 1.2.0
    */
   discountedUnitPrice?: number;
 
@@ -43,7 +47,7 @@ export interface CartEntryAttributes {
    *
    * The given number represents the non formatted price.
    *
-   * @deprecated use `unitPrice` instead
+   * @deprecated use `unitPrice` instead. Will be removed in 2.0.0.
    */
   itemPrice?: number;
 

--- a/libs/domain/cart/entry/src/stories/Static/states.stories.ts
+++ b/libs/domain/cart/entry/src/stories/Static/states.stories.ts
@@ -1,6 +1,6 @@
 import { storybookDefaultViewports } from '@/tools/storybook';
 import { Meta, Story } from '@storybook/web-components';
-import { html, TemplateResult } from 'lit';
+import { TemplateResult, html } from 'lit';
 import { storybookPrefix } from '../../../../.constants';
 import {
   CartEntryAttributes,
@@ -15,6 +15,8 @@ const createEntry = (
     .sku=${props.sku ?? '1'}
     .quantity=${props.quantity ?? '1'}
     .price=${props.price ?? (props.quantity ?? 1) * 1879}
+    .unitPrice=${props.price ?? (props.quantity ?? 1) * 2879}
+    .discountedUnitPrice=${props.price ?? (props.quantity ?? 1) * 1879}
     .options=${props}
     ?readonly=${props.readonly}
   ></oryx-cart-entry>`;

--- a/libs/domain/cart/entry/src/stories/entry-demo.stories.ts
+++ b/libs/domain/cart/entry/src/stories/entry-demo.stories.ts
@@ -1,6 +1,6 @@
 import { MockProductService } from '@spryker-oryx/product/mocks';
 import { Meta, Story } from '@storybook/web-components';
-import { html, TemplateResult } from 'lit';
+import { TemplateResult, html } from 'lit';
 import { storybookPrefix } from '../../../.constants';
 import { CartEntryAttributes, CartEntryOptions } from '../entry.model';
 
@@ -17,6 +17,8 @@ export default {
     confirmBeforeRemove: false,
     notifyOnRemove: false,
     price: 3000,
+    unitPrice: 3100,
+    discountedUnitPrice: 3000,
   } as CartEntryAttributes & CartEntryOptions,
   argTypes: {
     sku: {
@@ -25,6 +27,8 @@ export default {
       table: { category: 'demo' },
     },
     price: { table: { category: 'demo' } },
+    unitPrice: { table: { category: 'demo' } },
+    discountedUnitPrice: { table: { category: 'demo' } },
     quantity: { table: { category: 'demo' } },
   },
   parameters: {
@@ -42,6 +46,8 @@ const Template: Story<CartEntryAttributes & CartEntryOptions> = (
       .sku=${props.sku}
       .quantity=${props.quantity}
       .price=${props.price}
+      .unitPrice=${props.unitPrice}
+      .discountedUnitPrice=${props.discountedUnitPrice}
       .readonly=${props.readonly}
       .options=${props}
     ></oryx-cart-entry>

--- a/libs/domain/cart/entry/src/styles/entry.styles.ts
+++ b/libs/domain/cart/entry/src/styles/entry.styles.ts
@@ -23,14 +23,14 @@ const pricing = css`
     height: auto;
   }
 
-  oryx-site-price {
+  .pricing > oryx-site-price {
     font-size: var(--oryx-typography-h6-size);
     font-weight: var(--oryx-typography-h6-weight);
     line-height: var(--oryx-typography-h6-line);
     align-self: end;
   }
 
-  .item-price {
+  .unit-price {
     font-size: var(--oryx-typography-small-size);
     font-weight: var(--oryx-typography-small-weight);
     line-height: var(--oryx-typography-small-line);

--- a/libs/domain/cart/entry/src/styles/entry.styles.ts
+++ b/libs/domain/cart/entry/src/styles/entry.styles.ts
@@ -9,21 +9,12 @@ const pricing = css`
     padding-inline-end: 20px;
   }
 
-  oryx-product-price,
-  oryx-product-price::part(original) {
-    color: inherit;
-  }
-
-  oryx-product-price {
-    display: contents;
-  }
-
   .image {
     grid-row: span 2;
     height: auto;
   }
 
-  .pricing > oryx-site-price {
+  oryx-site-price.subtotal {
     font-size: var(--oryx-typography-h6-size);
     font-weight: var(--oryx-typography-h6-weight);
     line-height: var(--oryx-typography-h6-line);
@@ -39,24 +30,6 @@ const pricing = css`
     align-items: center;
     grid-auto-flow: column;
     gap: 4px;
-  }
-
-  oryx-product-price,
-  oryx-product-price::part(sales),
-  oryx-product-price::part(original),
-  oryx-product-price::part(tax) {
-    font-size: inherit;
-    font-weight: inherit;
-    line-height: inherit;
-    grid-column: initial;
-  }
-
-  oryx-product-price::part(original) {
-    grid-column: 2;
-  }
-
-  .item-price oryx-product-price {
-    gap: inherit;
   }
 `;
 

--- a/libs/domain/cart/entry/src/styles/entry.styles.ts
+++ b/libs/domain/cart/entry/src/styles/entry.styles.ts
@@ -1,38 +1,104 @@
+import { HeadingTag, headingUtil } from '@spryker-oryx/ui/heading';
+import { featureVersion } from '@spryker-oryx/utilities';
 import { css } from 'lit';
 
-const pricing = css`
-  section.pricing {
-    display: grid;
-    grid-row: 1 / span 2;
-    grid-column: 3;
-    justify-items: end;
-    padding-inline-end: 20px;
-  }
+const pricing =
+  featureVersion > '1.2'
+    ? css`
+        section.pricing {
+          display: grid;
+          grid-row: 1 / span 2;
+          grid-column: 3;
+          justify-items: end;
+          padding-inline-end: 20px;
+        }
 
-  .image {
-    grid-row: span 2;
-    height: auto;
-  }
+        .image {
+          grid-row: span 2;
+          height: auto;
+        }
 
-  oryx-site-price.subtotal {
-    font-size: var(--oryx-typography-h6-size);
-    font-weight: var(--oryx-typography-h6-weight);
-    line-height: var(--oryx-typography-h6-line);
-    align-self: end;
-  }
+        oryx-site-price.subtotal {
+          ${headingUtil(HeadingTag.H6)}
 
-  .unit-price {
-    font-size: var(--oryx-typography-small-size);
-    font-weight: var(--oryx-typography-small-weight);
-    line-height: var(--oryx-typography-small-line);
-    color: var(--oryx-color-neutral-9);
-    display: grid;
-    align-items: center;
-    grid-auto-flow: column;
-    gap: 4px;
-  }
-`;
+          align-self: end;
+        }
 
+        .unit-price {
+          ${headingUtil(HeadingTag.Small)}
+
+          color: var(--oryx-color-neutral-9);
+          display: grid;
+          align-items: center;
+          grid-auto-flow: column;
+          gap: 4px;
+        }
+      `
+    : css`
+        section.pricing {
+          display: grid;
+          grid-row: 1 / span 2;
+          grid-column: 3;
+          justify-items: end;
+          padding-inline-end: 20px;
+        }
+
+        oryx-product-price,
+        oryx-product-price::part(original) {
+          color: inherit;
+        }
+
+        oryx-product-price {
+          display: contents;
+        }
+
+        .image {
+          grid-row: span 2;
+          height: auto;
+        }
+
+        oryx-site-price {
+          font-size: var(--oryx-typography-h6-size);
+          font-weight: var(--oryx-typography-h6-weight);
+          line-height: var(--oryx-typography-h6-line);
+          align-self: end;
+        }
+
+        .item-price {
+          font-size: var(--oryx-typography-small-size);
+          font-weight: var(--oryx-typography-small-weight);
+          line-height: var(--oryx-typography-small-line);
+          color: var(--oryx-color-neutral-9);
+          display: grid;
+          align-items: center;
+          grid-auto-flow: column;
+          gap: 4px;
+        }
+
+        oryx-product-price,
+        oryx-product-price::part(sales),
+        oryx-product-price::part(original),
+        oryx-product-price::part(tax) {
+          font-size: inherit;
+          font-weight: inherit;
+          line-height: inherit;
+          grid-column: initial;
+        }
+
+        oryx-product-price::part(original) {
+          grid-column: 2;
+        }
+
+        .item-price oryx-product-price {
+          gap: inherit;
+        }
+      `;
+
+/**
+ * We change a couple of small styles in 2.0.0 since the underlying components have changed. The main difference is that
+ * we now use the `oryx-site-price` component instead of the `oryx-product-price` component. The price component is now
+ * now equipped to handle discounted and from prices, with the associated styling (highlight color or strikethrough).
+ */
 export const cartEntryStyles = css`
   :host {
     --image-fit: contain;

--- a/libs/domain/product/price/src/price.component.spec.ts
+++ b/libs/domain/product/price/src/price.component.spec.ts
@@ -22,6 +22,12 @@ const mockEurNet = {
   isNet: true,
 };
 
+const mockOriginalEurNet = {
+  currency: 'EUR',
+  value: 1195,
+  isNet: true,
+};
+
 const mockEurGross = {
   currency: 'EUR',
   value: 1095,
@@ -105,68 +111,26 @@ describe('ProductPriceComponent', () => {
         expect(element).not.toContainElement('oryx-site-price');
       });
     });
-
-    describe('and a sales price is provided', () => {
-      beforeEach(async () => {
-        vi.spyOn(mockProductService, 'get').mockImplementation(() => of());
-        element = await fixture(
-          html`<oryx-product-price
-            sku="123"
-            .sales=${1234}
-          ></oryx-product-price>`
-        );
-      });
-
-      it(`should render a sales price`, () => {
-        expect(
-          element.renderRoot.querySelector('oryx-site-price[part="sales"]')
-        ).toHaveProperty('value', 1234);
-      });
-    });
   });
 
   describe('when only a default price is provided', () => {
-    describe('and there is no currency property provided', () => {
-      beforeEach(async () => {
-        vi.spyOn(mockProductService, 'get').mockImplementation(() =>
-          of({ price: { defaultPrice: mockEurNet } })
-        );
-        element = await fixture(
-          html`<oryx-product-price sku="123"></oryx-product-price>`
-        );
-      });
-
-      it(`should render the sales price`, () => {
-        expect(
-          element.renderRoot.querySelector('oryx-site-price[part="sales"]')
-        ).toHaveProperty('value', 1095);
-      });
-
-      it(`should render the tax`, () => {
-        expect(element).toContainElement('span[part="tax"]');
-      });
+    beforeEach(async () => {
+      vi.spyOn(mockProductService, 'get').mockImplementation(() =>
+        of({ price: { defaultPrice: mockEurNet } })
+      );
+      element = await fixture(
+        html`<oryx-product-price sku="123"></oryx-product-price>`
+      );
     });
 
-    describe('and the currency property is different from the price currency', () => {
-      beforeEach(async () => {
-        vi.spyOn(mockProductService, 'get').mockImplementation(() =>
-          of({ price: { defaultPrice: mockEurNet } })
-        );
-        element = await fixture(
-          html`<oryx-product-price
-            sku="123"
-            currency="USD"
-          ></oryx-product-price>`
-        );
-      });
+    it(`should render the sales price`, () => {
+      expect(
+        element.renderRoot.querySelector('oryx-site-price[part="sales"]')
+      ).toHaveProperty('value', 1095);
+    });
 
-      it(`should not render the sales price`, () => {
-        expect(element).not.toContainElement('oryx-site-price[part="sales"]');
-      });
-
-      it(`should not render the tax`, () => {
-        expect(element).not.toContainElement('span[part="tax"]');
-      });
+    it(`should render the tax`, () => {
+      expect(element).toContainElement('span[part="tax"]');
     });
   });
 
@@ -189,34 +153,17 @@ describe('ProductPriceComponent', () => {
         expect(element).toContainElement('[part="tax"]');
       });
     });
-
-    describe('and the currency property is different from the price currency', () => {
-      beforeEach(async () => {
-        vi.spyOn(mockProductService, 'get').mockImplementation(() =>
-          of({ price: { originalPrice: mockEurNet } })
-        );
-        element = await fixture(
-          html`<oryx-product-price
-            sku="123"
-            currency="USD"
-          ></oryx-product-price>`
-        );
-      });
-
-      it(`should not render the original price`, () => {
-        expect(element).not.toContainElement('oryx-site-price[part="sales"]');
-      });
-
-      it(`should not render the tax`, () => {
-        expect(element).not.toContainElement('[part="tax"]');
-      });
-    });
   });
 
-  describe('when a default and original price is provided', () => {
+  describe('when a different default and original price is provided', () => {
     beforeEach(async () => {
       vi.spyOn(mockProductService, 'get').mockImplementation(() =>
-        of({ price: { originalPrice: mockEurNet, defaultPrice: mockEurNet } })
+        of({
+          price: {
+            originalPrice: mockOriginalEurNet,
+            defaultPrice: mockEurNet,
+          },
+        })
       );
       element = await fixture(
         html`<oryx-product-price sku="123"></oryx-product-price>`

--- a/libs/domain/product/price/src/price.model.ts
+++ b/libs/domain/product/price/src/price.model.ts
@@ -16,7 +16,7 @@ export interface ProductPriceOptions {
 }
 
 /**
- * @deprecated Not in use. Will be removed in the next major release.
+ * @deprecated not used anywhere. Will be removed in 2.0.0.
  */
 export interface Prices {
   original?: string | null;

--- a/libs/domain/product/price/src/price.model.ts
+++ b/libs/domain/product/price/src/price.model.ts
@@ -15,6 +15,9 @@ export interface ProductPriceOptions {
   enableSalesLabel?: boolean;
 }
 
+/**
+ * @deprecated Not in use. Will be removed in the next major release.
+ */
 export interface Prices {
   original?: string | null;
   sales?: string | null;

--- a/libs/domain/product/price/src/price.styles.ts
+++ b/libs/domain/product/price/src/price.styles.ts
@@ -18,15 +18,10 @@ export const ProductPriceStyles = css`
     line-height: var(--oryx-typography-h2-line);
   }
 
-  [has-discount] {
-    color: var(--oryx-color-highlight-9);
-  }
-
   [part='original'] {
     font-size: var(--oryx-typography-h4-size);
     font-weight: var(--oryx-typography-h4-weight);
     line-height: var(--oryx-typography-h4-line);
-    text-decoration: line-through;
   }
 
   [part='tax'] {

--- a/libs/domain/product/price/src/price.styles.ts
+++ b/libs/domain/product/price/src/price.styles.ts
@@ -1,5 +1,41 @@
+import { HeadingTag, headingUtil } from '@spryker-oryx/ui/heading';
 import { css } from 'lit';
 
+export const productPriceStyles = css`
+  :host {
+    display: grid;
+    grid-auto-flow: row;
+    grid-template-columns: auto auto auto;
+    grid-template-rows: auto auto;
+    justify-content: start;
+    align-items: baseline;
+    gap: 6px;
+  }
+
+  [part='sales'] {
+    ${headingUtil(HeadingTag.H2)}
+
+    grid-column: 1 / span 2;
+  }
+
+  [part='original'] {
+    ${headingUtil(HeadingTag.H4)}
+  }
+
+  [part='tax'] {
+    ${headingUtil(HeadingTag.Caption)}
+
+    color: var(--oryx-color-neutral-9);
+  }
+
+  [part='labels'] {
+    grid-column: 2 / span 2;
+    padding: 0;
+  }
+`;
+/**
+ * @deprecated since 1.2.0. Use `productPriceStyles` (camelCase) instead.
+ */
 export const ProductPriceStyles = css`
   :host {
     display: grid;
@@ -18,10 +54,15 @@ export const ProductPriceStyles = css`
     line-height: var(--oryx-typography-h2-line);
   }
 
+  [has-discount] {
+    color: var(--oryx-color-highlight-9);
+  }
+
   [part='original'] {
     font-size: var(--oryx-typography-h4-size);
     font-weight: var(--oryx-typography-h4-weight);
     line-height: var(--oryx-typography-h4-line);
+    text-decoration: line-through;
   }
 
   [part='tax'] {
@@ -37,6 +78,9 @@ export const ProductPriceStyles = css`
   }
 `;
 
+/**
+ * @deprecated since 1.2.0. Cleanup, it was not used anywhere.
+ */
 export const oldProductPriceStyles = css`
   :host {
     display: flex;

--- a/libs/domain/site/price/price.component.spec.ts
+++ b/libs/domain/site/price/price.component.spec.ts
@@ -77,7 +77,7 @@ describe('SitePriceComponent', () => {
       });
 
       it('should render €12.34', () => {
-        expect(element.shadowRoot?.textContent?.trim()).toBe('€12.34');
+        expect(element.shadowRoot?.textContent?.trim()).toContain('€12.34');
       });
     });
 
@@ -92,7 +92,7 @@ describe('SitePriceComponent', () => {
       });
 
       it('should render $12.34', () => {
-        expect(element.shadowRoot?.textContent?.trim()).toBe('$12.34');
+        expect(element.shadowRoot?.textContent?.trim()).toContain('$12.34');
       });
     });
   });
@@ -111,7 +111,7 @@ describe('SitePriceComponent', () => {
       });
 
       it('should render 12,34 £', () => {
-        expect(element.shadowRoot?.textContent?.trim()).toBe('12,34 £');
+        expect(element.shadowRoot?.textContent?.trim()).toContain('12,34 £');
       });
     });
 
@@ -126,7 +126,7 @@ describe('SitePriceComponent', () => {
       });
 
       it('should render $12.34', () => {
-        expect(element.shadowRoot?.textContent?.trim()).toBe('12,34 $');
+        expect(element.shadowRoot?.textContent?.trim()).toContain('12,34 $');
       });
     });
   });

--- a/libs/domain/site/price/price.component.ts
+++ b/libs/domain/site/price/price.component.ts
@@ -7,7 +7,9 @@ import {
   signalProperty,
 } from '@spryker-oryx/utilities';
 import { LitElement, TemplateResult, html } from 'lit';
+import { property } from 'lit/decorators.js';
 import { SitePriceComponentAttributes } from './price.model';
+import { priceStyles } from './price.styles';
 
 @hydrate()
 @signalAware()
@@ -15,10 +17,14 @@ export class SitePriceComponent
   extends LitElement
   implements SitePriceComponentAttributes
 {
+  static styles = priceStyles;
+
   protected pricingService = resolve(PricingService);
 
   @signalProperty() value?: number;
   @signalProperty() currency?: string;
+  @property({ type: Boolean, reflect: true }) discounted?: boolean;
+  @property({ type: Boolean, reflect: true }) original?: boolean;
 
   protected $price = computed(() =>
     this.pricingService.format(this.value, this.currency)

--- a/libs/domain/site/price/price.model.ts
+++ b/libs/domain/site/price/price.model.ts
@@ -15,4 +15,21 @@ export interface SitePriceComponentAttributes {
    * currencies used worldwide.
    */
   currency?: string;
+
+  /**
+   * The discounted property represents whether the price is discounted.
+   * If set to true, the price will be rendered with the highlight color.
+   *
+   * @since 1.1.0
+   */
+  discounted?: boolean;
+
+  /**
+   * The original property represents whether the price should be
+   * strikethrough. If set to true, the price will be rendered with a
+   * line-through css style.
+   *
+   * @since 1.1.0
+   */
+  original?: boolean;
 }

--- a/libs/domain/site/price/price.model.ts
+++ b/libs/domain/site/price/price.model.ts
@@ -20,7 +20,7 @@ export interface SitePriceComponentAttributes {
    * The discounted property represents whether the price is discounted.
    * If set to true, the price will be rendered with the highlight color.
    *
-   * @since 1.1.0
+   * @since 1.2.0
    */
   discounted?: boolean;
 
@@ -29,7 +29,7 @@ export interface SitePriceComponentAttributes {
    * strikethrough. If set to true, the price will be rendered with a
    * line-through css style.
    *
-   * @since 1.1.0
+   * @since 1.2.0
    */
   original?: boolean;
 }

--- a/libs/domain/site/price/price.styles.ts
+++ b/libs/domain/site/price/price.styles.ts
@@ -1,11 +1,18 @@
+import { featureVersion } from '@spryker-oryx/utilities';
 import { css } from 'lit';
 
-export const priceStyles = css`
-  :host([discounted]) {
-    color: var(--oryx-color-highlight-9);
-  }
+/**
+ * @since 1.2.0
+ */
+export const priceStyles =
+  featureVersion > '1.2'
+    ? css`
+        :host([discounted]) {
+          color: var(--oryx-color-highlight-9);
+        }
 
-  :host([original]) {
-    text-decoration: line-through;
-  }
-`;
+        :host([original]) {
+          text-decoration: line-through;
+        }
+      `
+    : css``;

--- a/libs/domain/site/price/price.styles.ts
+++ b/libs/domain/site/price/price.styles.ts
@@ -1,0 +1,11 @@
+import { css } from 'lit';
+
+export const priceStyles = css`
+  :host([discounted]) {
+    color: var(--oryx-color-highlight-9);
+  }
+
+  :host([original]) {
+    text-decoration: line-through;
+  }
+`;


### PR DESCRIPTION
The cart entry renders the product price. Until now, the product price was based on the product data. There are few cases where this is not accurate. For example, if the product price changes, while the cart had not been updated yet. Or when the current currency or price mode is changed. 

In order to always show the accurate _unit price_, we render the price that is calculated by cart (`entry.calculations.unitPrice`).  

A number of changes has been introduced since `1.2.0`. They will become breaking changes in version `2.0.0` and have started to become deprecated with `1.2.0`. You can already use those changes in a `1.2.0` release or higher, by using the [version feature flag](https://docs.spryker.com/docs/scos/dev/front-end-development/202307.0/oryx/getting-started/oryx-versioning.html#deprecation-practices). 

The cart entry component no longer uses the `ProductPriceComponent`, and prices are all driven by the cart calculation data. Consequently, the `CartEntriesComponent` and `CartEntryAttributes` have gone through a few breaking changes:
- `CartEntriesComponent` provides the `entry.calculations.unitPrice` to the `unitPrice` property
- `CartEntriesComponent` provides the `entry.calculations.unitPriceToPayAggregation` to the `discountedUnitPrice` property
- the `CartEntryComponent` renders the `unitPrice`  and `discountedUnitPrice` with the `SitePriceComponent`, rather than using the `ProductPriceComponent`
- A couple of CSS changes has been done because of this. 

closes: [HRZ-89844](https://spryker.atlassian.net/browse/HRZ-89844)

[HRZ-89844]: https://spryker.atlassian.net/browse/HRZ-89844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ