### PR TITLE
fix(picking): use item id instead of order item id in finish picking request

### DIFF
--- a/libs/domain/picking/src/services/adapter/picking-list-default.adapter.ts
+++ b/libs/domain/picking/src/services/adapter/picking-list-default.adapter.ts
@@ -71,7 +71,7 @@ export class PickingListDefaultAdapter implements PickingListAdapter {
   finishPicking(pickingList: PickingList): Observable<PickingList> {
     const body = {
       data: pickingList.items.map((item) => ({
-        id: item.orderItem.uuid,
+        id: item.id,
         type: 'picking-list-items',
         status: item.status,
         attributes: {


### PR DESCRIPTION
Used different id in finish picking request because of BE API changes.

closes: https://spryker.atlassian.net/browse/HRZ-89932