### PR TITLE
fix(core): drop unnecessary console error for simple string tokens

### DIFF
--- a/libs/platform/core/src/services/token-resolver/default-token-resolver.service.ts
+++ b/libs/platform/core/src/services/token-resolver/default-token-resolver.service.ts
@@ -19,10 +19,11 @@ export class DefaultTokenService implements TokenResolver {
     if (this.isConditionalToken(token)) {
       return this.resolveConditionalToken(token);
     }
+    
     if (!this.isToken(token)) {
-      this.warnInvalidToken(token);
       return of(token);
     }
+
     return this.resolveSimpleToken(token);
   }
 

--- a/libs/platform/core/src/services/token-resolver/default-token-resolver.service.ts
+++ b/libs/platform/core/src/services/token-resolver/default-token-resolver.service.ts
@@ -19,7 +19,7 @@ export class DefaultTokenService implements TokenResolver {
     if (this.isConditionalToken(token)) {
       return this.resolveConditionalToken(token);
     }
-    
+
     if (!this.isToken(token)) {
       return of(token);
     }


### PR DESCRIPTION
Token resolver service is trying to resolve a simple string token, and if string does not match token's pattern, it just returns a string as a resolved value. For such cases is not necessary to create some notifications

closes: [HRZ-89954](https://spryker.atlassian.net/browse/HRZ-89954)


[HRZ-89954]: https://spryker.atlassian.net/browse/HRZ-89954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ