### PR TITLE
fix(cart): ensure handling of string-based cart entry quantities

### DIFF
--- a/libs/domain/cart/add/src/add.component.ts
+++ b/libs/domain/cart/add/src/add.component.ts
@@ -96,14 +96,29 @@ export class CartAddComponent extends ProductMixin(
     if (availability?.isNeverOutOfStock) return Infinity;
     if (availability?.quantity)
       return (
-        availability?.quantity -
+        availability.quantity -
         this.$entries()
           .filter((entry) => entry.sku === sku)
-          .map((entry) => entry.quantity)
-          .reduce((a: number, b) => a + b, 0)
+          .map((entry) => Number(entry.quantity))
+          .reduce((a: number, b) => a + Number(b), 0)
       );
     return 0;
   });
+
+  // protected $max = computed(() => {
+  //   const { availability, sku } = this.$product() ?? {};
+
+  //   if (availability?.isNeverOutOfStock) return Infinity;
+  //   if (availability?.quantity) {
+  //     const totalQuantity = this.$entries()
+  //       .filter((entry) => entry.sku === sku)
+  //       .map((entry) => entry.quantity as number) // Type assertion here
+  //       .reduce((a: number, b) => a + Number(b), 0);
+
+  //     return availability.quantity - totalQuantity;
+  //   }
+  //   return 0;
+  // });
 
   protected onUpdate(e: CustomEvent<QuantityEventDetail>): void {
     this.isInvalid = !!e.detail.isInvalid;

--- a/libs/domain/cart/add/src/add.component.ts
+++ b/libs/domain/cart/add/src/add.component.ts
@@ -99,26 +99,10 @@ export class CartAddComponent extends ProductMixin(
         availability.quantity -
         this.$entries()
           .filter((entry) => entry.sku === sku)
-          .map((entry) => Number(entry.quantity))
-          .reduce((a: number, b) => a + Number(b), 0)
+          .reduce((a, { quantity }) => a + Number(quantity), 0)
       );
     return 0;
   });
-
-  // protected $max = computed(() => {
-  //   const { availability, sku } = this.$product() ?? {};
-
-  //   if (availability?.isNeverOutOfStock) return Infinity;
-  //   if (availability?.quantity) {
-  //     const totalQuantity = this.$entries()
-  //       .filter((entry) => entry.sku === sku)
-  //       .map((entry) => entry.quantity as number) // Type assertion here
-  //       .reduce((a: number, b) => a + Number(b), 0);
-
-  //     return availability.quantity - totalQuantity;
-  //   }
-  //   return 0;
-  // });
 
   protected onUpdate(e: CustomEvent<QuantityEventDetail>): void {
     this.isInvalid = !!e.detail.isInvalid;

--- a/libs/domain/cart/src/controllers/cart.controller.ts
+++ b/libs/domain/cart/src/controllers/cart.controller.ts
@@ -101,7 +101,10 @@ export class CartController {
    */
   protected cumulateQuantity(cart: Cart | undefined): number | null {
     return (
-      cart?.products?.reduce((acc, { quantity }) => acc + quantity, 0) ?? null
+      cart?.products?.reduce(
+        (acc, { quantity }) => acc + Number(quantity),
+        0
+      ) ?? null
     );
   }
 

--- a/libs/domain/cart/src/mocks/src/mock-cart.adapter.ts
+++ b/libs/domain/cart/src/mocks/src/mock-cart.adapter.ts
@@ -10,7 +10,7 @@ import {
   UpdateCartEntryQualifier,
 } from '@spryker-oryx/cart';
 import { MockProductService } from '@spryker-oryx/product/mocks';
-import { delay, mapTo, Observable, of, take, tap, timer } from 'rxjs';
+import { Observable, delay, mapTo, of, take, tap, timer } from 'rxjs';
 import {
   mockCartEntry,
   mockCartLarge,
@@ -206,7 +206,7 @@ export class MockCartAdapter implements Partial<CartAdapter> {
     for (let i = 0; i < products.length; i++) {
       total =
         total +
-        products[i].quantity *
+        Number(products[i].quantity) *
           (products[i]?.calculations?.unitPrice ||
             Math.floor(Math.random() * 10 + 1));
     }

--- a/libs/domain/cart/src/models/cart.api.model.ts
+++ b/libs/domain/cart/src/models/cart.api.model.ts
@@ -35,7 +35,7 @@ export module ApiCartModel {
 
   export interface Entry {
     sku: string;
-    quantity: number;
+    quantity: number | string;
     groupKey: string;
     abstractSku: string;
     amount?: unknown;

--- a/libs/domain/cart/src/models/cart.model.ts
+++ b/libs/domain/cart/src/models/cart.model.ts
@@ -27,7 +27,7 @@ export interface Cart extends CartId {
 
 export interface CartEntry {
   sku: string;
-  quantity: number;
+  quantity: number | string;
   /**
    * The groupKey is used to identify and group together items that are
    * the same product but with different options.

--- a/libs/domain/cart/src/services/resolver/cart.resolver.spec.ts
+++ b/libs/domain/cart/src/services/resolver/cart.resolver.spec.ts
@@ -22,6 +22,14 @@ const bigCart = {
   ],
 };
 
+const bigB2bCart = {
+  products: [
+    { quantity: '50' } as CartEntry,
+    { quantity: 50 } as CartEntry,
+    { quantity: 50 } as CartEntry,
+  ],
+};
+
 class MockCartService implements Partial<CartService> {
   getCart = vi.fn().mockReturnValue(of(null));
 }
@@ -78,6 +86,11 @@ describe('CartResolver', () => {
       'when cart`s summary quantity is bigger then 99',
       '99+',
       bigCart
+    );
+    expectedResult(
+      'when cart`s summary quantity is bigger then 99',
+      '99+',
+      bigB2bCart
     );
   });
 

--- a/libs/domain/cart/src/services/resolver/cart.resolver.spec.ts
+++ b/libs/domain/cart/src/services/resolver/cart.resolver.spec.ts
@@ -22,7 +22,7 @@ const bigCart = {
   ],
 };
 
-const bigB2bCart = {
+const variousValuesTypeCart = {
   products: [
     { quantity: '50' } as CartEntry,
     { quantity: 50 } as CartEntry,
@@ -90,7 +90,7 @@ describe('CartResolver', () => {
     expectedResult(
       'when cart`s summary quantity is bigger then 99',
       '99+',
-      bigB2bCart
+      variousValuesTypeCart
     );
   });
 

--- a/libs/domain/cart/src/services/resolver/cart.resolver.ts
+++ b/libs/domain/cart/src/services/resolver/cart.resolver.ts
@@ -26,14 +26,13 @@ export class CartResolver extends BaseResolver<CartResolvers> {
         .pipe(
           map((cart) => {
             const quantity = cart?.products?.reduce(
-              (acc, { quantity }) => acc + quantity,
+              (acc, { quantity }) => acc + Number(quantity),
               0
             );
 
             if (!quantity) {
               return null;
             }
-
             //TODO: Make max quantity to show configurable
             return quantity > 99 ? '99+' : String(quantity);
           })


### PR DESCRIPTION
While connecting to a b2b backend in preparation of customer call, it turns out that the cart entry quantity is of type string. So far, we’ve been seeing the number type for quantity. 

We’re not entirely sure if quantity is always going to be numeric, hence we do not force the conversion of the response in the adapter layer. For now, we’ll assume it’s a quantity in the component layer, but over time we can change this when we have more clarity on the usage of string vs number.

closes: [HRZ-90046](https://spryker.atlassian.net/browse/HRZ-90046)

[HRZ-90046]: https://spryker.atlassian.net/browse/HRZ-90046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ