### PR TITLE
fix(fulfillment): override sapi locale adapter with default one

### DIFF
--- a/apps/fulfillment/src/app.ts
+++ b/apps/fulfillment/src/app.ts
@@ -2,7 +2,6 @@ import { appBuilder } from '@spryker-oryx/application';
 import { injectEnv, PageMetaResolver } from '@spryker-oryx/core';
 import { ContentBackendUrl, experienceFeature } from '@spryker-oryx/experience';
 import { formFeature } from '@spryker-oryx/form';
-import { DefaultLocaleAdapter, LocaleAdapter } from '@spryker-oryx/i18n';
 import { labsFeatures } from '@spryker-oryx/labs';
 import { siteFeature } from '@spryker-oryx/site';
 import { fulfillmentTheme } from '@spryker-oryx/themes';
@@ -32,14 +31,6 @@ appBuilder()
     ],
   })
   .withFeature(siteFeature)
-  .withFeature({
-    providers: [
-      {
-        provide: LocaleAdapter,
-        useClass: DefaultLocaleAdapter,
-      },
-    ],
-  })
   .withFeature(formFeature)
   .withFeature(
     offlineFulfillmentFeatures({

--- a/apps/fulfillment/src/app.ts
+++ b/apps/fulfillment/src/app.ts
@@ -2,10 +2,11 @@ import { appBuilder } from '@spryker-oryx/application';
 import { injectEnv, PageMetaResolver } from '@spryker-oryx/core';
 import { ContentBackendUrl, experienceFeature } from '@spryker-oryx/experience';
 import { formFeature } from '@spryker-oryx/form';
+import { DefaultLocaleAdapter, LocaleAdapter } from '@spryker-oryx/i18n';
 import { labsFeatures } from '@spryker-oryx/labs';
-import { offlineFulfillmentFeatures } from '../../../libs/template/presets/fulfillment';
 import { siteFeature } from '@spryker-oryx/site';
 import { fulfillmentTheme } from '@spryker-oryx/themes';
+import { offlineFulfillmentFeatures } from '../../../libs/template/presets/fulfillment';
 import { fallbackEnv } from './fallback-env';
 
 const env = import.meta.env;
@@ -31,6 +32,14 @@ appBuilder()
     ],
   })
   .withFeature(siteFeature)
+  .withFeature({
+    providers: [
+      {
+        provide: LocaleAdapter,
+        useClass: DefaultLocaleAdapter,
+      },
+    ],
+  })
   .withFeature(formFeature)
   .withFeature(
     offlineFulfillmentFeatures({

--- a/libs/domain/picking/offline/feature.ts
+++ b/libs/domain/picking/offline/feature.ts
@@ -8,6 +8,7 @@ import {
   StorageType,
 } from '@spryker-oryx/core';
 import { Provider } from '@spryker-oryx/di';
+import { DefaultLocaleAdapter, LocaleAdapter } from '@spryker-oryx/i18n';
 import { provideIndexedDbEntities } from '@spryker-oryx/indexed-db';
 import { provideSyncActionsHandler } from '@spryker-oryx/offline';
 import {
@@ -80,6 +81,10 @@ export class OfflinePickingFeature implements AppFeature {
       {
         provide: StorageService,
         useFactory: () => new DefaultStorageService(StorageType.Idb),
+      },
+      {
+        provide: LocaleAdapter,
+        useClass: DefaultLocaleAdapter,
       },
     ];
   }


### PR DESCRIPTION
Site providers provide extended version of locale adapter that is requesting a list of supported locales from stores. For fulfillment app it is not necessary, due to it uses static set of locales and currencies

closes: [HRZ-89955](https://spryker.atlassian.net/browse/HRZ-89955)


[HRZ-89955]: https://spryker.atlassian.net/browse/HRZ-89955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ