### PR TITLE
fix(core): add `as` attribute for preload links

### DIFF
--- a/libs/platform/core/src/services/page-meta/default-page-meta.service.spec.ts
+++ b/libs/platform/core/src/services/page-meta/default-page-meta.service.spec.ts
@@ -97,6 +97,7 @@ describe('DefaultPageMetaService', () => {
       const preloadLink = document.head.querySelector('link[rel="preload"]');
       expect(originalLink?.getAttribute('href')).toBe('href-stylesheet');
       expect(preloadLink?.getAttribute('href')).toBe('href-stylesheet');
+      expect(preloadLink?.getAttribute('as')).toBe('style');
     });
 
     it('should not add preload link if disablePreload is true', () => {

--- a/libs/platform/core/src/services/page-meta/default-page-meta.service.ts
+++ b/libs/platform/core/src/services/page-meta/default-page-meta.service.ts
@@ -78,6 +78,7 @@ export class DefaultPageMetaService implements PageMetaService {
         attrs: {
           rel: 'preload',
           href: definition.attrs.href,
+          as: 'style',
         },
       };
     }


### PR DESCRIPTION
The `PageMetaService` adds `link` elements dynamically to the head of the page and requires an `as="style"` attribute for preload links.

closes: [HRZ-90096](https://spryker.atlassian.net/browse/HRZ-90096)

[HRZ-90096]: https://spryker.atlassian.net/browse/HRZ-90096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ