### PR TITLE
feat: scroll facet values into view on toggle

### DIFF
--- a/libs/base/ui/structure/collapsible/src/collapsible.component.spec.ts
+++ b/libs/base/ui/structure/collapsible/src/collapsible.component.spec.ts
@@ -12,14 +12,56 @@ describe('CollapsibleComponent', () => {
     await useComponent(collapsibleComponent);
   });
 
-  describe('When the open property is provided', () => {
-    beforeEach(async () => {
-      element = await fixture(html`<oryx-collapsible open></oryx-collapsible>`);
+  describe('when the version >= 1.2', () => {
+    beforeEach(() => {
+      mockFeatureVersion('1.2');
     });
 
-    it('should have an open attribute on the details element', () => {
-      const details = element.renderRoot?.querySelector('details');
-      expect(details?.hasAttribute('open')).toBe(true);
+    describe('when the open property is provided', () => {
+      beforeEach(async () => {
+        element = await fixture(
+          html`<oryx-collapsible open></oryx-collapsible>`
+        );
+        element.scrollIntoView = vi.fn();
+      });
+
+      it('should have an open attribute on the details element', () => {
+        expect(element).toContainElement('details[open]');
+      });
+
+      it('should not scroll the element into the view port', () => {
+        expect(element.scrollIntoView).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when the open property is not provided', () => {
+      beforeEach(async () => {
+        element = await fixture(html`<oryx-collapsible></oryx-collapsible>`);
+        element.scrollIntoView = vi.fn();
+      });
+
+      it('should not have an open attribute on the details element', () => {
+        expect(element).not.toContainElement('details[open]');
+      });
+
+      describe('and when the element is clicked', () => {
+        beforeEach(async () => {
+          const details = element.renderRoot.querySelector('details');
+          if (details) {
+            details.click();
+            details.open = true;
+            details.dispatchEvent(new Event('toggle'));
+          }
+        });
+
+        it('should have an open attribute on the details element', () => {
+          expect(element).toContainElement('details[open]');
+        });
+
+        it('should scroll the element into the view port', () => {
+          expect(element.scrollIntoView).toHaveBeenCalled();
+        });
+      });
     });
   });
 

--- a/libs/base/ui/structure/collapsible/src/collapsible.component.ts
+++ b/libs/base/ui/structure/collapsible/src/collapsible.component.ts
@@ -55,12 +55,12 @@ export class CollapsibleComponent
 
   protected onToggle(): void {
     this.open = this.details?.open;
-    if (this.isManuallyOpened && this.open) {
-      if (featureVersion >= '1.2') {
+    if (featureVersion >= '1.2') {
+      if (this.isManuallyOpened && this.open) {
         this.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
       }
+      this.isManuallyOpened = false;
     }
-    this.isManuallyOpened = false;
   }
 
   protected onClick(): void {

--- a/libs/base/ui/structure/collapsible/src/collapsible.component.ts
+++ b/libs/base/ui/structure/collapsible/src/collapsible.component.ts
@@ -1,6 +1,6 @@
 import { ButtonSize, ButtonType } from '@spryker-oryx/ui/button';
 import { IconTypes } from '@spryker-oryx/ui/icon';
-import { I18nMixin } from '@spryker-oryx/utilities';
+import { I18nMixin, featureVersion } from '@spryker-oryx/utilities';
 import { LitElement, TemplateResult, html } from 'lit';
 import { property, query } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -23,12 +23,23 @@ export class CollapsibleComponent
 
   @query('details') protected details?: HTMLDetailsElement;
 
+  /**
+   * Indicates that the collapsible was opened by a user. We need this info since
+   * we need to scroll the collapsible into the view port whenever it is opened by
+   * the user. We do not like to do this when it's (initially) rendered `open`.
+   */
+  protected isManuallyOpened = false;
+
   protected override render(): TemplateResult {
     const nonTabbable =
       this.nonTabbable || this.appearance === CollapsibleAppearance.Inline;
 
     return html`
-      <details ?open=${this.open} @toggle=${this.onToggle}>
+      <details
+        ?open=${this.open}
+        @click=${this.onClick}
+        @toggle=${this.onToggle}
+      >
         <summary
           part="heading"
           tabindex=${ifDefined(nonTabbable ? -1 : undefined)}
@@ -44,6 +55,16 @@ export class CollapsibleComponent
 
   protected onToggle(): void {
     this.open = this.details?.open;
+    if (this.isManuallyOpened && this.open) {
+      if (featureVersion >= '1.2') {
+        this.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
+    }
+    this.isManuallyOpened = false;
+  }
+
+  protected onClick(): void {
+    this.isManuallyOpened = true;
   }
 
   protected renderToggleControl(): TemplateResult {

--- a/libs/base/ui/structure/collapsible/src/collapsible.component.ts
+++ b/libs/base/ui/structure/collapsible/src/collapsible.component.ts
@@ -23,11 +23,6 @@ export class CollapsibleComponent
 
   @query('details') protected details?: HTMLDetailsElement;
 
-  /**
-   * Indicates that the collapsible was opened by a user. We need this info since
-   * we need to scroll the collapsible into the view port whenever it is opened by
-   * the user. We do not like to do this when it's (initially) rendered `open`.
-   */
   protected isManuallyOpened = false;
 
   protected override render(): TemplateResult {

--- a/libs/base/ui/structure/collapsible/src/collapsible.component.ts
+++ b/libs/base/ui/structure/collapsible/src/collapsible.component.ts
@@ -23,6 +23,11 @@ export class CollapsibleComponent
 
   @query('details') protected details?: HTMLDetailsElement;
 
+  /**
+   * Indicates that the collapsible was opened by a user. We need this info since
+   * we need to scroll the collapsible into the view port whenever it is opened by
+   * the user. We do not like to do this when it's (initially) rendered `open`.
+   */
   protected isManuallyOpened = false;
 
   protected override render(): TemplateResult {

--- a/libs/base/ui/structure/collapsible/src/collapsible.model.ts
+++ b/libs/base/ui/structure/collapsible/src/collapsible.model.ts
@@ -21,6 +21,13 @@ export interface CollapsibleAttributes {
    * Prevent focus by keyboard navigation
    */
   nonTabbable?: boolean;
+
+  /**
+   * Indicates that the collapsible was opened by a user. We need this info since
+   * we need to scroll the collapsible into the view port whenever it is opened by
+   * the user. We do not like to do this when it's (initially) rendered `open`.
+   */
+  isManuallyOpened?: boolean;
 }
 
 export const enum CollapsibleAppearance {

--- a/libs/base/ui/structure/collapsible/src/collapsible.model.ts
+++ b/libs/base/ui/structure/collapsible/src/collapsible.model.ts
@@ -21,13 +21,6 @@ export interface CollapsibleAttributes {
    * Prevent focus by keyboard navigation
    */
   nonTabbable?: boolean;
-
-  /**
-   * Indicates that the collapsible was opened by a user. We need this info since
-   * we need to scroll the collapsible into the view port whenever it is opened by
-   * the user. We do not like to do this when it's (initially) rendered `open`.
-   */
-  isManuallyOpened?: boolean;
 }
 
 export const enum CollapsibleAppearance {

--- a/libs/domain/search/facet-value-navigation/facet-value-navigation.styles.ts
+++ b/libs/domain/search/facet-value-navigation/facet-value-navigation.styles.ts
@@ -1,3 +1,4 @@
+import { featureVersion } from '@spryker-oryx/utilities';
 import { css } from 'lit';
 
 export const facetValueNavigationStyles = css`
@@ -25,7 +26,13 @@ export const facetValueNavigationStyles = css`
 
   slot:not([name]) + oryx-button {
     width: fit-content;
-    padding-block-start: 10px;
+    ${featureVersion <= '1.2'
+      ? css`
+          padding-block-end: 10px;
+        `
+      : css`
+          padding-block-start: 10px;
+        `}
   }
 
   oryx-collapsible {

--- a/libs/domain/search/facet-value-navigation/facet-value-navigation.styles.ts
+++ b/libs/domain/search/facet-value-navigation/facet-value-navigation.styles.ts
@@ -25,7 +25,7 @@ export const facetValueNavigationStyles = css`
 
   slot:not([name]) + oryx-button {
     width: fit-content;
-    padding-block-end: 10px;
+    padding-block-start: 10px;
   }
 
   oryx-collapsible {


### PR DESCRIPTION
When the facet is collapsed, and the values are not visible, we scroll the facet values into the (nearest) view.

closes: [HRZ-90098](https://spryker.atlassian.net/browse/HRZ-90098)


[HRZ-90098]: https://spryker.atlassian.net/browse/HRZ-90098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ