### PR TITLE
fix(picking): wrong number of picked items

### DIFF
--- a/libs/domain/picking/offline/services/adapter/picking-list-offline.adapter.spec.ts
+++ b/libs/domain/picking/offline/services/adapter/picking-list-offline.adapter.spec.ts
@@ -332,6 +332,7 @@ describe('PickingListOfflineAdapter', () => {
     it('should call store', () => {
       expect(mockTable.update).toHaveBeenCalledWith(mockPickingListData[0].id, {
         localStatus: PickingListStatus.PickingFinished,
+        items: mockPickingListData[0].items,
       });
       expect(mockTable.get).toHaveBeenCalledWith(mockPickingListData[0].id);
     });

--- a/libs/domain/picking/offline/services/adapter/picking-list-offline.adapter.ts
+++ b/libs/domain/picking/offline/services/adapter/picking-list-offline.adapter.ts
@@ -8,8 +8,8 @@ import {
   PickingListStatus,
 } from '@spryker-oryx/picking';
 import { intersectArrays } from '@spryker-oryx/utilities';
-import { Collection, liveQuery, Table } from 'dexie';
-import { combineLatestWith, map, Observable, switchMap } from 'rxjs';
+import { Collection, Table, liveQuery } from 'dexie';
+import { Observable, combineLatestWith, map, switchMap } from 'rxjs';
 import {
   MappedQualifier,
   PickingListEntity,
@@ -204,6 +204,7 @@ export class PickingListOfflineAdapter implements PickingListAdapter {
               pickingList.id,
               {
                 localStatus: PickingListStatus.PickingFinished,
+                items: pickingList.items,
               }
             );
 


### PR DESCRIPTION
Fixed updating indexed db data on picking finishing.

fixes: [HRZ-90094](https://spryker.atlassian.net/browse/HRZ-90094)


[HRZ-90094]: https://spryker.atlassian.net/browse/HRZ-90094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ