### PR TITLE
fix(picking): receiving picking lists with previously unknown products

### DIFF
--- a/libs/domain/picking/offline/services/picking-sync-action-handler.service.spec.ts
+++ b/libs/domain/picking/offline/services/picking-sync-action-handler.service.spec.ts
@@ -12,7 +12,15 @@ import {
 } from './picking-sync-action-handler.service';
 
 class MockIndexedDbService implements Partial<IndexedDbService> {
-  getStore = vi.fn().mockImplementation(() => of(mockTable));
+  getStore = vi
+    .fn()
+    .mockImplementation((entityType) =>
+      of(
+        entityType === PickingListEntity
+          ? mockPickingListsTable
+          : mockProductsTable
+      )
+    );
 }
 
 class MockPickingListOnlineAdapter
@@ -37,7 +45,8 @@ class MockTable implements Partial<Table> {
   });
 }
 
-const mockTable = new MockTable();
+const mockPickingListsTable = new MockTable();
+const mockProductsTable = new MockTable();
 
 const mockSync = {
   action: PickingSyncAction.FinishPicking,
@@ -134,13 +143,16 @@ describe('PickingSyncActionHandlerService', () => {
       expect(callback).toHaveBeenCalled();
       expect(adapter.finishPicking).toHaveBeenCalledWith(mockSync.payload);
       expect(indexeddb.getStore).toHaveBeenCalledWith(PickingListEntity);
-      expect(mockTable.update).toHaveBeenCalledWith(mockSync.payload.id, []);
+      expect(mockPickingListsTable.update).toHaveBeenCalledWith(
+        mockSync.payload.id,
+        []
+      );
     });
 
     describe('and store is not updated', () => {
       const callback = vi.fn();
       beforeEach(() => {
-        mockTable.update.mockReturnValue(0);
+        mockPickingListsTable.update.mockReturnValue(0);
 
         service.handleSync(mockSync).subscribe({ error: callback });
       });
@@ -156,7 +168,38 @@ describe('PickingSyncActionHandlerService', () => {
   });
 
   describe('when Push action is handled', () => {
-    const mockPickingLists = [{ id: 'id1' }, { id: 'id2' }];
+    const mockPickingLists = [
+      {
+        id: 'id1',
+        items: [
+          {
+            product: {
+              id: 'product-id-1',
+            },
+          },
+          {
+            product: {
+              id: 'product-id-2',
+            },
+          },
+        ],
+      },
+      {
+        id: 'id2',
+        items: [
+          {
+            product: {
+              id: 'product-id-2',
+            },
+          },
+          {
+            product: {
+              id: 'product-id-3',
+            },
+          },
+        ],
+      },
+    ];
 
     const pickingListsIdsToRemove = ['id3'];
     const mockPickingListsIdsToCreate = mockPickingLists.map((pl) => pl.id);
@@ -175,8 +218,10 @@ describe('PickingSyncActionHandlerService', () => {
 
     beforeEach(() => {
       adapter.get.mockReturnValue(of(mockPickingLists));
-      mockTable.bulkPut.mockReturnValue(mockPickingListsIdsToCreate);
-      mockTable.where = vi.fn().mockReturnValue({
+      mockPickingListsTable.bulkPut.mockReturnValue(
+        mockPickingListsIdsToCreate
+      );
+      mockPickingListsTable.where = vi.fn().mockReturnValue({
         anyOf: vi.fn().mockReturnValue({
           count: vi.fn().mockResolvedValue(pickingListsIdsToRemove.length),
         }),
@@ -191,14 +236,21 @@ describe('PickingSyncActionHandlerService', () => {
         ids: mockSyncPush.payload.ids,
       });
       expect(indexeddb.getStore).toHaveBeenCalledWith(PickingListEntity);
-      expect(mockTable.bulkDelete).toHaveBeenCalledWith(
+      expect(mockPickingListsTable.bulkDelete).toHaveBeenCalledWith(
         pickingListsIdsToRemove
       );
-      expect(mockTable.bulkPut).toHaveBeenCalledWith(mockPickingLists, {
-        allKeys: true,
-      });
+      expect(mockPickingListsTable.bulkPut).toHaveBeenCalledWith(
+        mockPickingLists,
+        {
+          allKeys: true,
+        }
+      );
+      expect(mockProductsTable.bulkPut).toHaveBeenLastCalledWith([
+        { id: 'product-id-1' },
+        { id: 'product-id-2' },
+        { id: 'product-id-3' },
+      ]);
     });
-
     it('should update syncing status', () => {
       expect(syncCallback).toHaveBeenNthCalledWith(1, true);
       expect(syncCallback).toHaveBeenLastCalledWith(false);

--- a/libs/domain/picking/offline/services/picking-sync-action-handler.service.ts
+++ b/libs/domain/picking/offline/services/picking-sync-action-handler.service.ts
@@ -116,7 +116,7 @@ export class PickingSyncActionHandlerService
             return true;
           });
 
-        await productsStore.bulkAdd(products);
+        await productsStore.bulkPut(products);
         await pickingListsStore.bulkPut(pickingLists, {
           allKeys: true,
         });

--- a/libs/domain/picking/offline/services/picking-sync-action-handler.service.ts
+++ b/libs/domain/picking/offline/services/picking-sync-action-handler.service.ts
@@ -9,7 +9,7 @@ import {
   tap,
   throwError,
 } from 'rxjs';
-import { PickingListEntity } from '../entities';
+import { PickingListEntity, PickingProductEntity } from '../entities';
 import { PickingListOnlineAdapter } from './adapter';
 
 declare global {
@@ -95,14 +95,29 @@ export class PickingSyncActionHandlerService
 
     this.syncing$.next(true);
     return this.onlineAdapter.get({ ids: sync.payload.ids }).pipe(
-      combineLatestWith(this.indexedDbService.getStore(PickingListEntity)),
-      switchMap(async ([pickingLists, store]) => {
+      combineLatestWith(
+        this.indexedDbService.getStore(PickingListEntity),
+        this.indexedDbService.getStore(PickingProductEntity)
+      ),
+      switchMap(async ([pickingLists, pickingListsStore, productsStore]) => {
         const pickingListsIdsToRemove = sync.payload.ids.filter((id) => {
           return !pickingLists.find((pl) => pl.id === id);
         });
 
-        await store.bulkDelete(pickingListsIdsToRemove);
-        await store.bulkPut(pickingLists, {
+        await pickingListsStore.bulkDelete(pickingListsIdsToRemove);
+
+        const productIds = new Set<string>();
+        const products = pickingLists
+          .map((pickingList) => pickingList.items.map((item) => item.product))
+          .flat()
+          .filter((product) => {
+            if (productIds.has(product.id)) return false;
+            productIds.add(product.id);
+            return true;
+          });
+
+        await productsStore.bulkAdd(products);
+        await pickingListsStore.bulkPut(pickingLists, {
           allKeys: true,
         });
       }),


### PR DESCRIPTION
Fixed receiving picking lists with products that aren't yet placed in indexDB.

closes: https://spryker.atlassian.net/browse/HRZ-90219 and https://spryker.atlassian.net/browse/HRZ-90194
