### PR TITLE
chore(release): bump labs version

### DIFF
--- a/libs/template/labs/package.json
+++ b/libs/template/labs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spryker-oryx/labs",
-  "version": "0.131.0-oryx.1.1.0-patch.0",
+  "version": "0.131.0-oryx.1.1.0-patch.1",
   "type": "module",
   "author": "Spryker Systems GmbH",
   "license": "See license in LICENSE",


### PR DESCRIPTION
Release: labs-0.131.0-oryx.1.1.0-patch.1

closes: [HRZ-89891](https://spryker.atlassian.net/browse/HRZ-89891)

[HRZ-89891]: https://spryker.atlassian.net/browse/HRZ-89891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ