### PR TITLE
fix: improve computed observable switch

### DIFF
--- a/libs/base/utilities/src/signals/signal.spec.ts
+++ b/libs/base/utilities/src/signals/signal.spec.ts
@@ -75,7 +75,7 @@ describe('computed', () => {
       period.set(50);
       vi.advanceTimersByTime(100 * maxValues);
 
-      expect(values).toEqual([undefined, 0, 1, 2, undefined, 0, 1, 2, 3, 4, 5]);
+      expect(values).toEqual([undefined, 0, 1, 2, 2, 0, 1, 2, 3, 4, 5]);
 
       ef.stop();
     });

--- a/libs/base/utilities/src/signals/signal.ts
+++ b/libs/base/utilities/src/signals/signal.ts
@@ -64,11 +64,16 @@ export function computed<T>(
     const value = instance.value;
     if (isObservable(value)) {
       if (value !== last) {
+        let previousValue = undefined;
+        if (isObservable(last)) {
+          previousValue = observableSignal!();
+        }
         last = value;
-        observableSignal = signalFrom(
-          value as Observable<T>,
-          options as ConnectableSignalOptions<T, undefined>
-        );
+        observableSignal = signalFrom(value as Observable<T>, {
+          ...(options as ConnectableSignalOptions<T, undefined>),
+          initialValue:
+            previousValue !== undefined ? previousValue : options?.initialValue,
+        });
       }
       return observableSignal!();
     }


### PR DESCRIPTION
Remove additional undefined emissions when new pending observable is emitted from computed.