### PR TITLE
test: increase search request wait timeout

### DIFF
--- a/apps/storefront-e2e/src/support/mixins/page-with-product-list.mixin.ts
+++ b/apps/storefront-e2e/src/support/mixins/page-with-product-list.mixin.ts
@@ -28,7 +28,7 @@ export function WithProductList<TPage extends Constructor<E2EPage>>(
       cy.wait('@catalogSearch');
       // wait till product cards are re-renreded after search
       // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(500);
+      cy.wait(1000);
     }
 
     waitForLoaded(): void {


### PR DESCRIPTION
The last failure is caused by the product list DOM not being updated in 500ms after the API response is received (2 times in a row). The only thing we can do here is to increase the timeout, so it should be more stable, but, in theory, still might fail.

I don't know why it takes so long to re-render the page, may be worth investigating what is going on under the hood there.

---
closes: https://spryker.atlassian.net/browse/HRZ-90356