### PR TITLE
chore: hide spin buttons

### DIFF
--- a/libs/domain/search/facet-range/facet-range.styles.ts
+++ b/libs/domain/search/facet-range/facet-range.styles.ts
@@ -6,6 +6,15 @@ export const searchRangeFacetStyles = css`
     padding: 4px 1px;
   }
 
+  input {
+    appearance: textfield;
+  }
+
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    appearance: none;
+  }
+
   oryx-search-facet-value-navigation > section {
     display: grid;
     grid-template-columns: 1fr min-content 1fr;


### PR DESCRIPTION
We've noted a small UI glitch on the price facet component, showing spin buttons on the numeric input controls.

closes: [HRZ-90357](https://spryker.atlassian.net/browse/HRZ-90357)

[HRZ-90357]: https://spryker.atlassian.net/browse/HRZ-90357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ