### PR TITLE
fix(presets): additional white space at the end of product list on the home page

### DIFF
--- a/libs/template/presets/storefront/experience/pages/home-page.ts
+++ b/libs/template/presets/storefront/experience/pages/home-page.ts
@@ -90,7 +90,7 @@ export const homePage: ExperienceComponent = {
             padding: '30px 0 5px',
             align: 'stretch',
           },
-          { query: { breakpoint: 'sm' }, padding: '20px' },
+          { query: { breakpoint: 'sm' }, padding: '20px 0' },
         ],
         category: '10',
         sort: 'rating',


### PR DESCRIPTION
Additional padding removed. This also eliminated the need for `scroll-padding`.

closes: [HRZ-90361](https://spryker.atlassian.net/browse/HRZ-90361)

[HRZ-90361]: https://spryker.atlassian.net/browse/HRZ-90361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ