### PR TITLE
feat(core): query postTransform and cacheKey

### DIFF
--- a/libs/platform/core/src/services/query/models/query.ts
+++ b/libs/platform/core/src/services/query/models/query.ts
@@ -3,6 +3,11 @@ import { QueryEventHandler } from './query-event';
 
 export type QueryTrigger = string | Observable<any>;
 
+export type QueryTransformer<ValueType, Qualifier> = (
+  data: ValueType,
+  qualifier: Qualifier
+) => ValueType /*| Observable<ValueType>*/ | void;
+
 export interface QueryOptions<
   ValueType,
   Qualifier extends object | undefined = undefined
@@ -15,6 +20,19 @@ export interface QueryOptions<
 
   onLoad?: QueryEventHandler<ValueType, Qualifier>[];
   onError?: QueryEventHandler<ValueType, Qualifier>[];
+
+  /**
+   * Determines the cache key based on the provided qualifier.
+   * This is useful to cache different data under the same key if they represent the same entity.
+   * If not provided, the default behavior would be using the qualifier itself.
+   */
+  cacheKey?: (qualifier: Qualifier) => string | Partial<Qualifier>;
+
+  /**
+   * Transforms the data returned by the loader based on the qualifier or the model itself.
+   * Useful for applying context-specific modifications to the model before it's consumed.
+   */
+  postTransforms?: QueryTransformer<ValueType, Qualifier>[];
 
   /**
    * Query is not cached between subscriptions


### PR DESCRIPTION
Improves query customization by intoducing `cacheKey` and `postTransform` options. 

Closes [HRZ-90221](https://spryker.atlassian.net/browse/HRZ-90221)


[HRZ-90221]: https://spryker.atlassian.net/browse/HRZ-90221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ