### PR TITLE
fix: transfomer ordering

### DIFF
--- a/libs/platform/core/src/services/transformer/default-transformer.service.spec.ts
+++ b/libs/platform/core/src/services/transformer/default-transformer.service.spec.ts
@@ -150,4 +150,20 @@ describe('DefaultTransformerService', () => {
     expect(mockATransformer).toHaveBeenCalledWith(mockData, service);
     expect(result).toBe(mockATransformerResult);
   });
+
+  it('should overwrite property with the value from the last transformer when multiple transformers modify the same property', () => {
+    const mockFirstTransformerResult = { a: '5', b: '1' };
+    const mockSecondTransformerResult = { a: '6', c: '2' };
+    mockATransformer.mockReturnValueOnce(mockFirstTransformerResult);
+    mockBTransformer.mockReturnValueOnce(mockSecondTransformerResult);
+
+    service
+      .transform(
+        mockData,
+        'mockBTransformer' as keyof InjectionTokensContractMap
+      )
+      .subscribe((result) => {
+        expect(result).toEqual({ a: '5', b: '1', c: '2' });
+      });
+  });
 });

--- a/libs/platform/core/src/services/transformer/default-transformer.service.ts
+++ b/libs/platform/core/src/services/transformer/default-transformer.service.ts
@@ -41,8 +41,8 @@ export class DefaultTransformerService implements TransformerService {
       }
 
       return {
-        ...(currentData as Record<string, unknown>),
         ...(fullData as Record<string, unknown>),
+        ...(currentData as Record<string, unknown>),
       };
     };
     const asyncData: Observable<unknown>[] = [];


### PR DESCRIPTION
Fixes case, where multiple tranformers contribute to the same field in the resulting object (last should win).

Closes [HRZ-90348](https://spryker.atlassian.net/browse/HRZ-90348)

[HRZ-90348]: https://spryker.atlassian.net/browse/HRZ-90348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ