### PR TITLE
fix(ui): icons are rendered outside the clickable area of a link

### DIFF
--- a/libs/base/ui/action/link/src/styles/storefront.styles.ts
+++ b/libs/base/ui/action/link/src/styles/storefront.styles.ts
@@ -4,10 +4,11 @@ export const storefrontLinkStyles = css`
   :host {
     position: relative;
     display: inline-flex;
+    width: var(--oryx-link-width);
   }
 
   :host([icon]) {
-    --oryx-icon-size: 16px;
+    --oryx-icon-size: var(--oryx-link-icon-size, 16px);
 
     align-items: baseline;
     gap: 8px;
@@ -20,17 +21,25 @@ export const storefrontLinkStyles = css`
   }
 
   oryx-icon {
+    pointer-events: none;
     position: relative;
-    inset-block-start: 3px;
+    inset-block-start: calc(var(--oryx-icon-size, 24px) / 4);
   }
 
   ::slotted(a) {
     text-decoration: none;
     color: currentColor;
+    width: var(--oryx-link-width);
+    padding: var(--oryx-link-padding);
+    margin-inline-start: calc((var(--oryx-icon-size, 24px) + 8px) * -1);
+    padding-inline-start: calc(var(--oryx-icon-size, 24px) + 8px);
   }
 
   :host(:hover) ::slotted(a) {
-    text-decoration: solid underline currentColor 1px;
+    text-decoration: var(
+      --oryx-link-decoration,
+      solid underline currentColor 1px
+    );
     text-underline-offset: 5px;
   }
 
@@ -52,6 +61,6 @@ export const storefrontLinkStyles = css`
   :host([color='primary']),
   :host([color='primary']:hover:not(:active)),
   :host(:active) {
-    color: var(--oryx-color-primary-10);
+    color: var(--oryx-link-color, var(--oryx-color-primary-10));
   }
 `;

--- a/libs/base/ui/action/link/src/styles/storefront.styles.ts
+++ b/libs/base/ui/action/link/src/styles/storefront.styles.ts
@@ -4,7 +4,6 @@ export const storefrontLinkStyles = css`
   :host {
     position: relative;
     display: inline-flex;
-    width: var(--oryx-link-width);
   }
 
   :host([icon]) {
@@ -29,17 +28,12 @@ export const storefrontLinkStyles = css`
   ::slotted(a) {
     text-decoration: none;
     color: currentColor;
-    width: var(--oryx-link-width);
-    padding: var(--oryx-link-padding);
     margin-inline-start: calc((var(--oryx-icon-size, 24px) + 8px) * -1);
     padding-inline-start: calc(var(--oryx-icon-size, 24px) + 8px);
   }
 
   :host(:hover) ::slotted(a) {
-    text-decoration: var(
-      --oryx-link-decoration,
-      solid underline currentColor 1px
-    );
+    text-decoration: solid underline currentColor 1px;
     text-underline-offset: 5px;
   }
 
@@ -61,6 +55,6 @@ export const storefrontLinkStyles = css`
   :host([color='primary']),
   :host([color='primary']:hover:not(:active)),
   :host(:active) {
-    color: var(--oryx-link-color, var(--oryx-color-primary-10));
+    color: var(--oryx-color-primary-10);
   }
 `;

--- a/libs/base/ui/action/link/src/styles/storefront.styles.ts
+++ b/libs/base/ui/action/link/src/styles/storefront.styles.ts
@@ -7,7 +7,7 @@ export const storefrontLinkStyles = css`
   }
 
   :host([icon]) {
-    --oryx-icon-size: var(--oryx-link-icon-size, 16px);
+    --oryx-icon-size: 16px;
 
     align-items: baseline;
     gap: 8px;


### PR DESCRIPTION
When an icon is used in a link, the icon is moved visually inside the clickable real estate of the `<oryx-link>` component, so that users can click on all the real estate to open a link.

closes: [HRZ-90413](https://spryker.atlassian.net/browse/HRZ-90413)

[HRZ-90413]: https://spryker.atlassian.net/browse/HRZ-90413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ