### PR TITLE
fix(experience): top header layout is broken on medium screens

### DIFF
--- a/libs/platform/experience/layout/stories/static/util.ts
+++ b/libs/platform/experience/layout/stories/static/util.ts
@@ -162,7 +162,7 @@ export const generateNestedLayout = (
 
     <oryx-layout layout=${layout}>
       <div>1</div>
-      <oryx-layout layout="flex">
+      <oryx-layout .options=${{ rules: [{ layout: { type: 'flex' } }] }}>
         ${generateLayoutItems(3, 1, 'N', true)}
       </oryx-layout>
       ${generateLayoutItems(10, 5)}
@@ -174,7 +174,9 @@ export const generateNestedLayout = (
     </ul>
     <oryx-layout layout=${layout}>
       <div>1</div>
-      <oryx-layout layout="flex" .options=${{ rules: [{ colSpan: 2 }] }}>
+      <oryx-layout  .options=${{
+        rules: [{ layout: { type: 'flex' }, colSpan: 2 }],
+      }}>
         <div style="background:var(--oryx-color-secondary-9);">
           N1 - lengthy content
         </div>

--- a/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.model.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.model.ts
@@ -14,7 +14,8 @@ export interface FlexLayoutProperties {
   /**
    * If true, items will wrap to the next line.
    *
-   * @since 1.3, 1.2 had hardcoded wrap for all flex items.
+   * @since 1.3, previously wrap was enabled by default and there was
+   * no ability to disable it.
    */
   wrap?: boolean;
 }

--- a/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.model.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.model.ts
@@ -6,4 +6,15 @@ declare global {
   export interface Layouts {
     flex: undefined;
   }
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface LayoutProperty extends FlexLayoutProperties {}
+}
+
+export interface FlexLayoutProperties {
+  /**
+   * If true, items will wrap to the next line.
+   *
+   * @since 1.3, 1.2 had hardcoded wrap for all flex items.
+   */
+  wrap?: boolean;
 }

--- a/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.plugin.spec.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.plugin.spec.ts
@@ -1,4 +1,5 @@
 import { lastValueFrom } from 'rxjs';
+import { LayoutPluginPropertiesParams } from '../../layout.plugin';
 import { FlexLayoutPlugin } from './flex-layout.plugin';
 
 describe('FlexLayoutPlugin', () => {
@@ -28,6 +29,43 @@ describe('FlexLayoutPlugin', () => {
       const result = await (config.schema as () => unknown)();
 
       expect(result).toEqual(schema);
+    });
+  });
+
+  describe('getDefaultProperties', () => {
+    it('should return wrap = false', async () => {
+      const result = await lastValueFrom(plugin.getDefaultProperties());
+      expect(result.wrap).toEqual(false);
+    });
+  });
+
+  describe('getStyleProperties', () => {
+    describe('When the wrap option is set to true', () => {
+      let result: any;
+      beforeEach(async () => {
+        result = await lastValueFrom(
+          plugin.getStyleProperties({
+            options: { wrap: true },
+          } as LayoutPluginPropertiesParams)
+        );
+      });
+      it('should return flex-wrap', async () => {
+        expect(result['flex-wrap']).toEqual('wrap');
+      });
+    });
+
+    describe('When the wrap option is set to false', () => {
+      let result: any;
+      beforeEach(async () => {
+        result = await lastValueFrom(
+          plugin.getStyleProperties({
+            options: { wrap: false },
+          } as LayoutPluginPropertiesParams)
+        );
+      });
+      it('should return flex-wrap', async () => {
+        expect(result['flex-wrap']).toBeFalsy();
+      });
     });
   });
 });

--- a/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.plugin.spec.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.plugin.spec.ts
@@ -33,14 +33,14 @@ describe('FlexLayoutPlugin', () => {
   });
 
   describe('getDefaultProperties', () => {
-    it('should return wrap = false', async () => {
+    it('should return wrap = true', async () => {
       const result = await lastValueFrom(plugin.getDefaultProperties());
-      expect(result.wrap).toEqual(false);
+      expect(result.wrap).toEqual(true);
     });
   });
 
   describe('getStyleProperties', () => {
-    describe('When the wrap option is set to true', () => {
+    describe('when the wrap option is set to true', () => {
       let result: any;
       beforeEach(async () => {
         result = await lastValueFrom(
@@ -49,12 +49,13 @@ describe('FlexLayoutPlugin', () => {
           } as LayoutPluginPropertiesParams)
         );
       });
+
       it('should return flex-wrap', async () => {
         expect(result['flex-wrap']).toEqual('wrap');
       });
     });
 
-    describe('When the wrap option is set to false', () => {
+    describe('when the wrap option is set to false', () => {
       let result: any;
       beforeEach(async () => {
         result = await lastValueFrom(
@@ -63,6 +64,7 @@ describe('FlexLayoutPlugin', () => {
           } as LayoutPluginPropertiesParams)
         );
       });
+
       it('should return flex-wrap', async () => {
         expect(result['flex-wrap']).toBeFalsy();
       });

--- a/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.plugin.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.plugin.ts
@@ -1,13 +1,28 @@
 import { ssrAwaiter } from '@spryker-oryx/core/utilities';
+import { signal } from '@spryker-oryx/utilities';
 import { Observable, of } from 'rxjs';
-import { LayoutStyles } from '../../../layout.model';
+import { LayoutStyles, LayoutStylesOptions } from '../../../layout.model';
 import {
   LayoutPlugin,
   LayoutPluginConfig,
   LayoutPluginOptionsParams,
+  LayoutPluginPropertiesParams,
+  LayoutStyleProperties,
 } from '../../layout.plugin';
 
 export class FlexLayoutPlugin implements LayoutPlugin {
+  getStyleProperties(
+    data: LayoutPluginPropertiesParams
+  ): Observable<LayoutStyleProperties> {
+    const options = { ...this.$defaultOptions(), ...data.options };
+    const props: LayoutStyleProperties = {};
+    if (options.wrap) {
+      props['flex-wrap'] = 'wrap';
+    }
+
+    return of(props);
+  }
+
   getStyles(data: LayoutPluginOptionsParams): Observable<LayoutStyles> {
     const { options } = data;
 
@@ -26,6 +41,21 @@ export class FlexLayoutPlugin implements LayoutPlugin {
   getConfig(): Observable<LayoutPluginConfig> {
     return of({
       schema: () => import('./flex-layout.schema').then((m) => m.schema),
+    });
+  }
+
+  protected $defaultOptions = signal(this.getDefaultProperties());
+
+  /**
+   * The default properties are redefined by the layout options, which can
+   * be set in the experience data options or directly when using a layout
+   * component.
+   *
+   * @returns Default properties for the flex layout.
+   */
+  getDefaultProperties(): Observable<LayoutStylesOptions> {
+    return of({
+      wrap: false,
     });
   }
 }

--- a/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.plugin.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.plugin.ts
@@ -53,7 +53,7 @@ export class FlexLayoutPlugin implements LayoutPlugin {
    */
   getDefaultProperties(): Observable<LayoutStylesOptions> {
     return of({
-      wrap: false,
+      wrap: true,
     });
   }
 }

--- a/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.plugin.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.plugin.ts
@@ -11,16 +11,14 @@ import {
 } from '../../layout.plugin';
 
 export class FlexLayoutPlugin implements LayoutPlugin {
+  /**
+   * @override adds a `flex-wrap: wrap` when the layout option wrap is set to true.
+   */
   getStyleProperties(
     data: LayoutPluginPropertiesParams
   ): Observable<LayoutStyleProperties> {
     const options = { ...this.$defaultOptions(), ...data.options };
-    const props: LayoutStyleProperties = {};
-    if (options.wrap) {
-      props['flex-wrap'] = 'wrap';
-    }
-
-    return of(props);
+    return of(options.wrap ? { 'flex-wrap': 'wrap' } : {});
   }
 
   getStyles(data: LayoutPluginOptionsParams): Observable<LayoutStyles> {

--- a/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.styles.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.styles.ts
@@ -5,7 +5,6 @@ export const styles: LayoutStyles = {
   styles: css`
     :host {
       display: flex;
-      flex-wrap: wrap;
       align-items: var(--align, start);
       justify-content: var(--justify, start);
     }

--- a/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.styles.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/flex/flex-layout.styles.ts
@@ -1,3 +1,4 @@
+import { featureVersion } from '@spryker-oryx/utilities';
 import { css } from 'lit';
 import { LayoutStyles } from '../../../layout.model';
 
@@ -7,6 +8,11 @@ export const styles: LayoutStyles = {
       display: flex;
       align-items: var(--align, start);
       justify-content: var(--justify, start);
+      ${featureVersion >= `1.3`
+        ? css``
+        : css`
+            flex-wrap: wrap;
+          `}
     }
   `,
 };

--- a/libs/template/presets/storefront/experience/header.ts
+++ b/libs/template/presets/storefront/experience/header.ts
@@ -64,11 +64,10 @@ export const topHeader = (options?: {
         rules: [
           {
             layout:
-              featureVersion >= '1.2'
-                ? {
-                    type: 'flex',
-                    bleed: true,
-                  }
+              featureVersion >= '1.3'
+                ? { type: 'flex', bleed: true, wrap: false }
+                : featureVersion >= '1.2'
+                ? { type: 'flex', bleed: true }
                 : 'flex',
             background: 'hsl(0, 0%, 9.0%)',
             padding: '10px 0',


### PR DESCRIPTION
We've added an option to the flex layout to specify whether items should warp to the next line. On the top header, we do not want this, which is the default behaviour. 

closes: [HRZ-90414](https://spryker.atlassian.net/browse/HRZ-90414)

[HRZ-90414]: https://spryker.atlassian.net/browse/HRZ-90414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ