### PR TITLE
refactor: category links refactor

### DIFF
--- a/libs/base/ui/action/link/src/styles/storefront.styles.ts
+++ b/libs/base/ui/action/link/src/styles/storefront.styles.ts
@@ -31,6 +31,9 @@ export const storefrontLinkStyles = css`
     color: currentColor;
     width: var(--oryx-link-width);
     padding: var(--oryx-link-padding);
+  }
+
+  :host([icon]) ::slotted(a) {
     margin-inline-start: calc((var(--oryx-icon-size, 24px) + 8px) * -1);
     padding-inline-start: calc(var(--oryx-icon-size, 24px) + 8px);
   }

--- a/libs/domain/content/link/index.ts
+++ b/libs/domain/content/link/index.ts
@@ -1,3 +1,4 @@
 export * from './link.component';
 export * from './link.model';
 export * from './link.schema';
+export * from './link.styles';

--- a/libs/domain/content/link/link.component.ts
+++ b/libs/domain/content/link/link.component.ts
@@ -7,6 +7,7 @@ import { LinkService } from '@spryker-oryx/site';
 import {
   computed,
   elementEffect,
+  featureVersion,
   hydrate,
   signalAware,
   ssrShim,
@@ -16,6 +17,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { when } from 'lit/directives/when.js';
 import { map, of } from 'rxjs';
 import { ContentLinkContent, ContentLinkOptions } from './link.model';
+import { contentLinkStyles } from './link.styles';
 
 @ssrShim('style')
 @hydrate()
@@ -24,6 +26,8 @@ export class ContentLinkComponent extends ContentMixin<
   ContentLinkOptions,
   ContentLinkContent
 >(LitElement) {
+  static styles = featureVersion >= '1.3' ? contentLinkStyles : undefined;
+
   protected semanticLinkService = resolve(LinkService);
   protected categoryService = resolve(ProductCategoryService);
   protected productService = resolve(ProductService);

--- a/libs/domain/content/link/link.styles.ts
+++ b/libs/domain/content/link/link.styles.ts
@@ -1,0 +1,23 @@
+import { css } from 'lit';
+
+export const contentLinkStyles = css`
+  :host {
+    padding: var(--oryx-content-link-padding);
+  }
+
+  :host(:hover) {
+    background-color: var(--oryx-link-hover-background);
+    box-shadow: var(--oryx-link-hover-shadow);
+  }
+
+  :host(:active),
+  :host(:focus-within) {
+    background-color: var(--oryx-link-active-background);
+    box-shadow: var(--oryx-link-active-shadow);
+  }
+
+  :host([current]) {
+    color: var(--oryx-link-current-color);
+    box-shadow: var(--oryx-link-current-shadow);
+  }
+`;

--- a/libs/domain/search/box/box.component.spec.ts
+++ b/libs/domain/search/box/box.component.spec.ts
@@ -93,7 +93,9 @@ describe('SearchBoxComponent', () => {
         },
       ],
     });
-    linkService = testInjector.inject(LinkService) as MockSemanticLinkService;
+    linkService = testInjector.inject(
+      LinkService
+    ) as unknown as MockSemanticLinkService;
     routerService = testInjector.inject(
       RouterService
     ) as unknown as MockRouterService;

--- a/libs/platform/experience/src/services/layout/plugins/types/navigation/navigation-layout.plugin.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/navigation/navigation-layout.plugin.ts
@@ -1,5 +1,4 @@
 import { ssrAwaiter } from '@spryker-oryx/core/utilities';
-import { css } from 'lit';
 import { Observable, of } from 'rxjs';
 import { LayoutStyles } from '../../../layout.model';
 import {
@@ -18,12 +17,7 @@ export class NavigationLayoutPlugin implements LayoutPlugin {
           ? m.verticalStyles
           : m.horizontalStyles;
 
-        const navigationType =
-          options.navigationType === 'flyout' ? m.flyoutStyles : css``;
-
-        return {
-          styles: `${m.styles.styles}${direction}${navigationType}`,
-        };
+        return { styles: `${m.styles.styles}${direction}` };
       })
     );
   }

--- a/libs/platform/experience/src/services/layout/plugins/types/navigation/navigation-layout.styles.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/navigation/navigation-layout.styles.ts
@@ -24,61 +24,23 @@ export const styles: LayoutStyles = {
 export const horizontalStyles = css`
   :host {
     --oryx-link-padding: 16px 0;
+    --oryx-link-hover-shadow: 0 -4px 0 0 var(--oryx-color-primary-9) inset;
+    --oryx-link-active-shadow: var(--oryx-link-hover-shadow);
+    --oryx-link-current-shadow: var(--oryx-link-hover-shadow);
 
     align-items: var(--align, start);
     justify-content: var(--justify, start);
-  }
-
-  ::slotted(oryx-content-link:is([current], :hover, :focus-within)),
-  oryx-content-link:is([current], :hover, :focus-within) {
-    box-shadow: 0 -4px 0 0 var(--oryx-color-primary-9) inset;
   }
 `;
 
 export const verticalStyles = css`
   :host {
+    --oryx-content-link-padding: 0 0 0 12px;
     --oryx-link-padding: 8px 12px 8px 0;
+    --oryx-link-hover-background: var(--oryx-color-neutral-3);
+    --oryx-link-active-background: var(--oryx-color-primary-5);
+    --oryx-link-current-shadow: 4px 0 0 0 var(--oryx-color-primary-9) inset;
 
     flex-direction: column;
-  }
-
-  oryx-content-link,
-  ::slotted(oryx-content-link) {
-    padding-inline-start: 12px;
-  }
-
-  oryx-content-link[current],
-  ::slotted(oryx-content-link[current]) {
-    box-shadow: 4px 0 0 0 var(--oryx-color-primary-9) inset;
-  }
-
-  oryx-content-link:hover,
-  ::slotted(oryx-content-link:hover) {
-    background-color: var(--oryx-color-neutral-3);
-  }
-
-  oryx-content-link:active,
-  ::slotted(oryx-content-link:active) {
-    background-color: var(--oryx-color-primary-5);
-  }
-`;
-
-export const flyoutStyles = css`
-  :host {
-    margin-inline: initial; /* reverted from base layout */
-    width: initial; /* reverted from base layout */
-  }
-
-  :host(:not(:hover)) oryx-composition {
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  oryx-composition {
-    position: absolute;
-    transition: all 0.3s ease-in-out 0.1s;
-    width: min(100%, calc(var(--_container-width)));
-    inset-inline-start: var(--_bleed);
-    z-index: 100;
   }
 `;


### PR DESCRIPTION
we've changed the styles so that navigation styles can peers through the shadow DOM and affect the CSS of content links whether they're direct children or nested in other components (e.g. a category-list).