### PR TITLE
fix: featureVersion is not applied in client for development ssr mode

### DIFF
--- a/libs/base/utilities/src/misc/version.ts
+++ b/libs/base/utilities/src/misc/version.ts
@@ -6,4 +6,4 @@ const defaultVersion = '1.0';
 export const featureVersion =
   typeof __ORYX_FEATURE_VERSION__ !== 'undefined'
     ? __ORYX_FEATURE_VERSION__ || defaultVersion
-    : defaultVersion;
+    : import.meta.env.ORYX_FEATURE_VERSION || defaultVersion;

--- a/libs/base/utilities/src/misc/version.ts
+++ b/libs/base/utilities/src/misc/version.ts
@@ -3,7 +3,11 @@ declare const __ORYX_FEATURE_VERSION__: string;
 // this one should be adjusted per major version
 const defaultVersion = '1.0';
 
+interface ImportMeta {
+  readonly env?: Record<string, string | undefined>;
+}
+
 export const featureVersion =
   typeof __ORYX_FEATURE_VERSION__ !== 'undefined'
     ? __ORYX_FEATURE_VERSION__ || defaultVersion
-    : import.meta.env.ORYX_FEATURE_VERSION || defaultVersion;
+    : (import.meta as ImportMeta)?.env?.ORYX_FEATURE_VERSION || defaultVersion;


### PR DESCRIPTION
FeatureVersion flag is picked from the environment, if it was not part of define replacement. 

Closes [HRZ-90431](https://spryker.atlassian.net/browse/HRZ-90431)


[HRZ-90431]: https://spryker.atlassian.net/browse/HRZ-90431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ