### PR TITLE
fix: carousel navigation is missing mutation observer

### DIFF
--- a/libs/platform/experience/carousel-navigation/carousel-navigation.component.ts
+++ b/libs/platform/experience/carousel-navigation/carousel-navigation.component.ts
@@ -432,14 +432,15 @@ export class CarouselNavigationComponent
    * @returns An array of HTMLElements representing the child elements of the host component.
    */
   protected resolveItems(): HTMLElement[] {
-    const items = [
-      ...(this.hostElement?.shadowRoot?.querySelectorAll(
-        ':not(:is(oryx-carousel-navigation,slot,style)'
-      ) ?? []),
-      ...this.hostElement.children,
-    ];
-
     const result: HTMLElement[] = [];
+
+    const items = [
+      ...Array.from(this.hostElement.shadowRoot?.children ?? []),
+      ...this.hostElement.children,
+    ].filter(
+      (e) =>
+        !['style', 'oryx-carousel-navigation'].includes(e.tagName.toLowerCase())
+    );
 
     for (const item of items) {
       // If the display is 'contents' we collect all the child elements to the result


### PR DESCRIPTION
We've added a mutation observer to ensure that the carousel is instantiated when the layout intersects, but does not yet have any items. Moreover, when items dynamically change over time, the navigation should be rebuild.

closes [HRZ-90434](https://spryker.atlassian.net/browse/HRZ-90434)

[HRZ-90434]: https://spryker.atlassian.net/browse/HRZ-90434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ