### PR TITLE
fix: avoid user id when unknown

### DIFF
--- a/libs/domain/picking/user-profile/user-profile.component.spec.ts
+++ b/libs/domain/picking/user-profile/user-profile.component.spec.ts
@@ -1,5 +1,5 @@
 import { fixture } from '@open-wc/testing-helpers';
-import { AuthService } from '@spryker-oryx/auth';
+import { AuthService, IdentityService } from '@spryker-oryx/auth';
 import { App, AppRef, StorageService } from '@spryker-oryx/core';
 import { createInjector, destroyInjector } from '@spryker-oryx/di';
 import { NetworkStateService } from '@spryker-oryx/offline';
@@ -47,6 +47,10 @@ class MockNetworkStateService implements Partial<NetworkStateService> {
   online = vi.fn().mockReturnValue(of(true));
 }
 
+class MockIdentityService implements IdentityService {
+  get = vi.fn().mockReturnValue(of({}));
+}
+
 describe('PickingUserProfileComponent', () => {
   let element: PickingUserProfileComponent;
   let routerService: MockRouterService;
@@ -85,6 +89,10 @@ describe('PickingUserProfileComponent', () => {
         {
           provide: NetworkStateService,
           useClass: MockNetworkStateService,
+        },
+        {
+          provide: IdentityService,
+          useClass: MockIdentityService,
         },
       ],
     });

--- a/libs/domain/picking/user-profile/user-profile.component.ts
+++ b/libs/domain/picking/user-profile/user-profile.component.ts
@@ -1,4 +1,4 @@
-import { AuthService } from '@spryker-oryx/auth';
+import { AuthService, IdentityService } from '@spryker-oryx/auth';
 import { AppRef, StorageService } from '@spryker-oryx/core';
 import { INJECTOR, resolve } from '@spryker-oryx/di';
 import { SyncSchedulerService } from '@spryker-oryx/offline/sync';
@@ -30,6 +30,7 @@ export class PickingUserProfileComponent extends I18nMixin(LitElement) {
   protected routerService = resolve(RouterService);
   protected authService = resolve(AuthService);
   protected storageService = resolve(StorageService);
+  protected identityService = resolve(IdentityService);
 
   protected injector = resolve(INJECTOR);
   protected injectorDataPlugin =
@@ -56,6 +57,8 @@ export class PickingUserProfileComponent extends I18nMixin(LitElement) {
     )
   );
 
+  protected $identity = signal(this.identityService.get());
+
   protected override render(): TemplateResult {
     return html`
       <div class="info-block">
@@ -70,7 +73,10 @@ export class PickingUserProfileComponent extends I18nMixin(LitElement) {
         )}
         <dl>
           <dt class="info-label">${this.i18n('user.profile.employee-id')}</dt>
-          <dd class="info-value">admin@spryker.com</dd>
+          <dd class="info-value">
+            ${this.$identity().userId ??
+            this.i18n('user.profile.unknown-user-id')}
+          </dd>
         </dl>
       </div>
 


### PR DESCRIPTION
When there's no user id available in the identity, we add the text "Unknown user id". 

closes: [HRZ-90350](https://spryker.atlassian.net/browse/HRZ-90350)


[HRZ-90350]: https://spryker.atlassian.net/browse/HRZ-90350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ