### PR TITLE
feat: configurable forced color mode

### DIFF
--- a/apps/fulfillment/src/app.ts
+++ b/apps/fulfillment/src/app.ts
@@ -1,6 +1,7 @@
 import { appBuilder } from '@spryker-oryx/application';
 import { offlineFulfillmentFeatures } from '@spryker-oryx/presets/fulfillment';
 import { fulfillmentTheme } from '@spryker-oryx/themes';
+import { ColorMode } from '@spryker-oryx/utilities';
 
 const env = import.meta.env;
 
@@ -8,12 +9,11 @@ appBuilder()
   .withEnvironment(env)
   .withFeature(
     offlineFulfillmentFeatures({
-      picking: {
-        appVersion: env.ORYX_FULFILLMENT_APP_VERSION,
-      },
+      picking: { appVersion: env.ORYX_FULFILLMENT_APP_VERSION },
     })
   )
+  .withOptions({
+    'oryx-app': { colorMode: ColorMode.Light },
+  })
   .withTheme(fulfillmentTheme)
-  .create()
-  .then(() => console.debug('Fulfillment App started!'))
-  .catch(console.error);
+  .create();

--- a/libs/template/application/oryx-app/oryx-app.component.spec.ts
+++ b/libs/template/application/oryx-app/oryx-app.component.spec.ts
@@ -1,13 +1,15 @@
+import { fixture } from '@open-wc/testing-helpers';
 import { mockCartProviders } from '@spryker-oryx/cart/mocks';
 import { ContextService, DefaultContextService } from '@spryker-oryx/core';
 import { createInjector, destroyInjector, getInjector } from '@spryker-oryx/di';
 import { RouteParams, RouterService } from '@spryker-oryx/router';
 import { LitRouter, RouteConfig } from '@spryker-oryx/router/lit';
 import { siteProviders } from '@spryker-oryx/site';
-import { useComponent } from '@spryker-oryx/utilities';
+import { ColorMode, useComponent } from '@spryker-oryx/utilities';
 import { html } from 'lit';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { SpyInstance } from 'vitest';
+import { OryxAppComponent } from './oryx-app.component';
 import { oryxAppComponent } from './oryx-app.def';
 
 class MockRouterService implements Partial<RouterService> {
@@ -33,6 +35,7 @@ class MockRouterService implements Partial<RouterService> {
 }
 
 describe('OryxAppComponent', () => {
+  let element: OryxAppComponent;
   let routerService: MockRouterService;
   let litRouterOutletSpy: SpyInstance;
 
@@ -79,5 +82,43 @@ describe('OryxAppComponent', () => {
 
     expect(oryxApp).toBeInstanceOf(HTMLElement);
     expect(oryxApp?.shadowRoot?.innerHTML).toContain('mock-lit-router-outlet');
+  });
+
+  describe(`when no colorMode option is set`, () => {
+    beforeEach(async () => {
+      element = await fixture(html`<oryx-app></oryx-app>`);
+    });
+
+    it('should not have the mode-light attribute', () => {
+      expect(element.hasAttribute('mode-light')).toBe(false);
+    });
+
+    it('should not have the mode-dark attribute', () => {
+      expect(element.hasAttribute('mode-dark')).toBe(false);
+    });
+  });
+
+  describe(`when the colorMode option is set to ColorMode.Light`, () => {
+    beforeEach(async () => {
+      element = await fixture(
+        html`<oryx-app .options=${{ colorMode: ColorMode.Light }}></oryx-app>`
+      );
+    });
+
+    it('should add the mode-light attribute', async () => {
+      expect(element.hasAttribute('mode-light')).toBe(true);
+    });
+  });
+
+  describe(`when the colorMode option is set to ColorMode.Dark`, () => {
+    beforeEach(async () => {
+      element = await fixture(
+        html`<oryx-app .options=${{ colorMode: ColorMode.Dark }}></oryx-app>`
+      );
+    });
+
+    it('should add the mode-dark attribute', async () => {
+      expect(element.hasAttribute('mode-dark')).toBe(true);
+    });
   });
 });

--- a/libs/template/application/oryx-app/oryx-app.component.ts
+++ b/libs/template/application/oryx-app/oryx-app.component.ts
@@ -1,10 +1,19 @@
+import { ContentMixin } from '@spryker-oryx/experience';
 import { LitRouter } from '@spryker-oryx/router/lit';
-import { featureVersion, hydrate } from '@spryker-oryx/utilities';
+import {
+  ColorMode,
+  elementEffect,
+  featureVersion,
+  hydrate,
+  ssrShim,
+} from '@spryker-oryx/utilities';
 import { LitElement, TemplateResult, html } from 'lit';
+import { OryxAppOptions } from './oryx-app.model';
 import { styles } from './oryx-app.styles';
 
+@ssrShim('style')
 @hydrate()
-export class OryxAppComponent extends LitElement {
+export class OryxAppComponent extends ContentMixin<OryxAppOptions>(LitElement) {
   static styles = styles;
 
   protected router = new LitRouter(this, []);
@@ -22,4 +31,16 @@ export class OryxAppComponent extends LitElement {
       <oryx-composition uid="footer"></oryx-composition>
     `;
   }
+
+  /**
+   * Color mode effect, sets the color mode based on the colorMode configuration.
+   * If the colorMode is not set, the color mode depends on the user's system preferences
+   * or the application's color mode set by the color selector.
+   */
+  @elementEffect() setColorMode = () => {
+    const { colorMode } = this.$options();
+
+    this.toggleAttribute('mode-light', colorMode === ColorMode.Light);
+    this.toggleAttribute('mode-dark', colorMode === ColorMode.Dark);
+  };
 }

--- a/libs/template/application/oryx-app/oryx-app.def.ts
+++ b/libs/template/application/oryx-app/oryx-app.def.ts
@@ -1,4 +1,11 @@
 import { componentDef } from '@spryker-oryx/utilities';
+import { OryxAppOptions } from './oryx-app.model';
+
+declare global {
+  interface FeatureOptions {
+    'oryx-app'?: OryxAppOptions;
+  }
+}
 
 export const oryxAppComponent = componentDef({
   name: 'oryx-app',

--- a/libs/template/application/oryx-app/oryx-app.model.ts
+++ b/libs/template/application/oryx-app/oryx-app.model.ts
@@ -1,0 +1,9 @@
+import { ColorMode } from '@spryker-oryx/utilities';
+
+export interface OryxAppOptions {
+  /**
+   * Color mode of the application, forces the color mode to be light or dark
+   * rather than using the user's system preferences.
+   */
+  colorMode: ColorMode.Dark | ColorMode.Light;
+}


### PR DESCRIPTION
Oryx supports both dark and light mode colors, leveraging the device color mode or by an application color mode selector. However, some applications are not ready to go in dark mode. This is also the case for the Fulfillment App. 
To still leverage the rich color palette, we introduce an option on the Oryx App (root) component to control forcing the light vs dark mode. 

This feature can be enabled by providing a configuration on the application: 

```ts
appBuilder()
  ...
  .withOptions({
    'oryx-app': { colorMode: ColorMode.Light },
  })
  .create();
```

closes: [HRZ-90485](https://spryker.atlassian.net/browse/HRZ-90485)


[HRZ-90485]: https://spryker.atlassian.net/browse/HRZ-90485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ