### PR TITLE
refactor(picking): use shadow style for header

### DIFF
--- a/libs/base/ui/navigation/tabs/src/tabs.styles.ts
+++ b/libs/base/ui/navigation/tabs/src/tabs.styles.ts
@@ -27,7 +27,7 @@ export const baseStyles = css`
   }
 
   :host([shadow]) slot:not([name]) {
-    box-shadow: 0 4px 8px var(--oryx-elevation-color-2);
+    box-shadow: 0 4px 8px var(--oryx-shadow-color);
   }
 
   input[type='range'] {

--- a/libs/base/ui/navigation/tabs/src/tabs.styles.ts
+++ b/libs/base/ui/navigation/tabs/src/tabs.styles.ts
@@ -5,8 +5,8 @@ import { TabsAppearance } from './tabs.model';
 const secondary = unsafeCSS(TabsAppearance.Secondary);
 const shadowCSSVar =
   featureVersion >= '1.3'
-    ? unsafeCSS('--oryx-shadow-color')
-    : unsafeCSS('--oryx-elevation-color-2');
+    ? unsafeCSS('var(--oryx-shadow-raised) var(--oryx-shadow-color)')
+    : unsafeCSS('0 4px 8px var(--oryx-elevation-color-2)');
 
 export const baseStyles = css`
   slot:not([name]) {
@@ -31,7 +31,7 @@ export const baseStyles = css`
   }
 
   :host([shadow]) slot:not([name]) {
-    box-shadow: 0 4px 8px var(${shadowCSSVar});
+    box-shadow: ${shadowCSSVar};
   }
 
   input[type='range'] {

--- a/libs/base/ui/navigation/tabs/src/tabs.styles.ts
+++ b/libs/base/ui/navigation/tabs/src/tabs.styles.ts
@@ -3,6 +3,10 @@ import { css, unsafeCSS } from 'lit';
 import { TabsAppearance } from './tabs.model';
 
 const secondary = unsafeCSS(TabsAppearance.Secondary);
+const shadowCSSVar =
+  featureVersion >= '1.3'
+    ? unsafeCSS('--oryx-shadow-color')
+    : unsafeCSS('--oryx-elevation-color-2');
 
 export const baseStyles = css`
   slot:not([name]) {
@@ -27,11 +31,7 @@ export const baseStyles = css`
   }
 
   :host([shadow]) slot:not([name]) {
-    ${unsafeCSS(
-      featureVersion >= '1.3'
-        ? `box-shadow: 0 4px 8px var(--oryx-shadow-color);`
-        : 'box-shadow: 0 4px 8px var(--oryx-elevation-color-2);'
-    )}
+    box-shadow: 0 4px 8px var(${shadowCSSVar});
   }
 
   input[type='range'] {

--- a/libs/base/ui/navigation/tabs/src/tabs.styles.ts
+++ b/libs/base/ui/navigation/tabs/src/tabs.styles.ts
@@ -1,4 +1,4 @@
-import { screenCss } from '@spryker-oryx/utilities';
+import { featureVersion, screenCss } from '@spryker-oryx/utilities';
 import { css, unsafeCSS } from 'lit';
 import { TabsAppearance } from './tabs.model';
 
@@ -27,7 +27,11 @@ export const baseStyles = css`
   }
 
   :host([shadow]) slot:not([name]) {
-    box-shadow: 0 4px 8px var(--oryx-shadow-color);
+    ${unsafeCSS(
+      featureVersion >= '1.3'
+        ? `box-shadow: 0 4px 8px var(--oryx-shadow-color);`
+        : 'box-shadow: 0 4px 8px var(--oryx-elevation-color-2);'
+    )}
   }
 
   input[type='range'] {

--- a/libs/template/presets/fulfillment/experience/templates/header.ts
+++ b/libs/template/presets/fulfillment/experience/templates/header.ts
@@ -1,4 +1,4 @@
-import { ExperienceComponent } from '@spryker-oryx/experience';
+import { ExperienceComponent, ShadowElevation } from '@spryker-oryx/experience';
 import { IconTypes } from '@spryker-oryx/ui/icon';
 
 export const HeaderTemplate: ExperienceComponent = {
@@ -14,11 +14,7 @@ export const HeaderTemplate: ExperienceComponent = {
         triggerType: 'icon',
         rules: [{ style: '--oryx-icon-color: var(--oryx-color-primary-9)' }],
       },
-      components: [
-        {
-          type: 'oryx-picking-user-profile',
-        },
-      ],
+      components: [{ type: 'oryx-picking-user-profile' }],
     },
   ],
   options: {
@@ -30,14 +26,14 @@ export const HeaderTemplate: ExperienceComponent = {
           zIndex: 1,
           bleed: true,
         },
+        shadow: ShadowElevation.Hovering,
         height: '66px',
         background: 'var(--oryx-color-neutral-1)',
         padding: '0 24px',
         gap: '12px',
         align: 'center',
         justify: 'end',
-        style:
-          'box-shadow: var(--oryx-elevation-2) var(--oryx-elevation-color-2); box-sizing: border-box;',
+        style: 'box-sizing: border-box;',
       },
     ],
   },

--- a/libs/template/themes/design-tokens/src/backoffice/other.tokens.ts
+++ b/libs/template/themes/design-tokens/src/backoffice/other.tokens.ts
@@ -12,17 +12,6 @@ export const tokens: ThemeToken = {
       focus: '0 0 3px var(--oryx-color-focus)',
     },
   },
-  /** @deprecated use oryx-shadow instead */
-  elevation: {
-    /** @deprecated use oryx-shadow-flat instead */
-    0: '0 1px 3px',
-    /** @deprecated use oryx-shadow-raised instead */
-    1: '0 4px 8px',
-    /** @deprecated use oryx-shadow-hovering instead */
-    2: '1px 3px 18px',
-    /** @deprecated use oryx-shadow-floating instead */
-    3: '-2px 2px 20px',
-  },
   'transition-time': '0.3s',
   transition: {
     time: {

--- a/libs/template/themes/design-tokens/src/common-tokens.ts
+++ b/libs/template/themes/design-tokens/src/common-tokens.ts
@@ -1,6 +1,21 @@
 import { ThemeToken } from '@spryker-oryx/experience';
 
 export const commonTokens: ThemeToken = {
+  /** @deprecated use oryx-shadow instead */
+  elevation: {
+    /**
+     * @deprecated use oryx-shadow-color instead
+     */
+    'color-2': 'rgb(0 0 0 / 10%)',
+    /** @deprecated use oryx-shadow-flat instead */
+    0: '0 1px 3px',
+    /** @deprecated use oryx-shadow-raised instead */
+    1: '0 4px 8px',
+    /** @deprecated use oryx-shadow-hovering instead */
+    2: '1px 3px 18px',
+    /** @deprecated use oryx-shadow-floating instead */
+    3: '-2px 2px 20px',
+  },
   shadow: {
     /** @since 1.3, replaced oryx-elevation-0 */
     flat: '0 1px 3px',

--- a/libs/template/themes/design-tokens/src/mobile-backoffice/index.ts
+++ b/libs/template/themes/design-tokens/src/mobile-backoffice/index.ts
@@ -6,7 +6,7 @@ import {
   typographyTokens,
 } from '../backoffice/typography.tokens';
 import { color } from '../color.tokens';
-import { commonTokensSmall } from '../common-tokens';
+import { commonTokens, commonTokensSmall } from '../common-tokens';
 import { layoutMdTokens, layoutSmTokens, layoutTokens } from './layout.tokens';
 import { tokens } from './other.tokens';
 
@@ -14,6 +14,7 @@ export const mobileBackofficeTokens: DesignToken[] = [
   ...buttonTokens,
   {
     color,
+    ...commonTokens,
     ...tokens,
     typography: Object.assign(
       {},
@@ -23,35 +24,20 @@ export const mobileBackofficeTokens: DesignToken[] = [
     ...layoutTokens,
   },
   {
-    media: {
-      screen: Size.Lg,
-    },
+    media: { screen: Size.Lg },
     ...layoutTokens,
   },
   {
-    media: {
-      screen: Size.Md,
-    },
+    media: { screen: Size.Md },
     ...layoutMdTokens,
-    container: {
-      width: '414px',
-      bleed: '8px',
-    },
-    modal: {
-      bleed: '8px',
-    },
+    container: { width: '414px', bleed: '8px' },
+    modal: { bleed: '8px' },
   },
   {
-    media: {
-      screen: Size.Sm,
-    },
+    media: { screen: Size.Sm },
     ...layoutSmTokens,
     ...commonTokensSmall,
-    container: {
-      bleed: '0',
-    },
-    modal: {
-      bleed: '16px',
-    },
+    container: { bleed: '0' },
+    modal: { bleed: '16px' },
   },
 ];

--- a/libs/template/themes/design-tokens/src/mobile-backoffice/other.tokens.ts
+++ b/libs/template/themes/design-tokens/src/mobile-backoffice/other.tokens.ts
@@ -12,14 +12,6 @@ export const tokens: ThemeToken = {
       focus: '0 0 3px var(--oryx-color-focus)',
     },
   },
-  elevation: {
-    color: 'rgb(23 11 11 / 15%)',
-    'color-2': 'rgb(0 0 0 / 10%)',
-    0: '0 1px 3px',
-    1: '0 4px 12px',
-    2: '0 4px 8px',
-    3: '-2px 2px 20px',
-  },
   'transition-time': '0.3s',
   transition: {
     time: {


### PR DESCRIPTION
Since we moved the header to experience data, we can leverage the shadow style property.