### PR TITLE
fix: fixed animation for vertical dropdown

### DIFF
--- a/libs/base/ui/overlays/dropdown/src/styles/base.styles.ts
+++ b/libs/base/ui/overlays/dropdown/src/styles/base.styles.ts
@@ -38,6 +38,13 @@ export const dropdownBaseStyles = css`
       var(--_oryx-dropdown-end-offset, auto);
     transform-origin: var(--_dropdown-origin-x, left)
       var(--_dropdown-origin-y, top);
+
+    ${featureVersion >= `1.3`
+      ? css``
+      : css`
+          transform: scaleX(var(--oryx-popover-visible, 0))
+            scaleY(var(--oryx-popover-visible, 0));
+        `}
   }
 
   ${featureVersion >= `1.3`
@@ -46,17 +53,8 @@ export const dropdownBaseStyles = css`
           transform: scaleX(var(--oryx-popover-visible, 0))
             scaleY(var(--oryx-popover-visible, 0));
         }
-
-        :host([vertical-align]) oryx-popover {
-          transform: scaleY(var(--oryx-popover-visible, 0));
-        }
       `
-    : css`
-        oryx-popover {
-          transform: scaleX(var(--oryx-popover-visible, 0))
-            scaleY(var(--oryx-popover-visible, 0));
-        }
-      `}
+    : css``}
 
   slot[name='trigger'] {
     cursor: pointer;
@@ -118,6 +116,12 @@ export const dropdownBaseStyles = css`
       var(--_available-popover-height, ${unsafecss(POPOVER_HEIGHT)}px),
       var(--oryx-popover-maxheight, ${unsafecss(POPOVER_HEIGHT)}px)
     );
+
+    ${featureVersion >= `1.3`
+      ? css``
+      : css`
+          transform: scaleY(var(--oryx-popover-visible, 0));
+        `}
   }
 
   :host([vertical-align][position=${unsafecss(Position.END)}]) oryx-popover,

--- a/libs/base/ui/overlays/dropdown/src/styles/base.styles.ts
+++ b/libs/base/ui/overlays/dropdown/src/styles/base.styles.ts
@@ -1,3 +1,4 @@
+import { featureVersion } from '@spryker-oryx/utilities';
 import { css, unsafeCSS as unsafecss } from 'lit';
 import { POPOVER_HEIGHT } from '../../../popover';
 import { Position } from '../dropdown.model';
@@ -37,9 +38,25 @@ export const dropdownBaseStyles = css`
       var(--_oryx-dropdown-end-offset, auto);
     transform-origin: var(--_dropdown-origin-x, left)
       var(--_dropdown-origin-y, top);
-    transform: scaleX(var(--oryx-popover-visible, 0))
-      scaleY(var(--oryx-popover-visible, 0));
   }
+
+  ${featureVersion >= `1.3`
+    ? css`
+        :host(:not([vertical-align])) oryx-popover {
+          transform: scaleX(var(--oryx-popover-visible, 0))
+            scaleY(var(--oryx-popover-visible, 0));
+        }
+
+        :host([vertical-align]) oryx-popover {
+          transform: scaleY(var(--oryx-popover-visible, 0));
+        }
+      `
+    : css`
+        oryx-popover {
+          transform: scaleX(var(--oryx-popover-visible, 0))
+            scaleY(var(--oryx-popover-visible, 0));
+        }
+      `}
 
   slot[name='trigger'] {
     cursor: pointer;


### PR DESCRIPTION
The dropdown animation for vertical dropdown (aka select) should only apply the scaleY transform effect.

closes: [HRZ-90553](https://spryker.atlassian.net/browse/HRZ-90553)

[HRZ-90553]: https://spryker.atlassian.net/browse/HRZ-90553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ