### PR TITLE
fix: move light mode color mode out of boilerplate

### DIFF
--- a/apps/fulfillment/src/app.ts
+++ b/apps/fulfillment/src/app.ts
@@ -2,7 +2,6 @@ import { appBuilder } from '@spryker-oryx/application';
 import { labsFeatures } from '@spryker-oryx/labs';
 import { fulfillmentFeatures } from '@spryker-oryx/presets/fulfillment';
 import { fulfillmentTheme } from '@spryker-oryx/themes';
-import { ColorMode } from '@spryker-oryx/utilities';
 
 const env = import.meta.env;
 
@@ -18,8 +17,5 @@ const features = [
 appBuilder()
   .withEnvironment(env)
   .withFeature(features)
-  .withOptions({
-    'oryx-app': { colorMode: ColorMode.Light },
-  })
   .withTheme(fulfillmentTheme)
   .create();

--- a/libs/template/presets/fulfillment/app.ts
+++ b/libs/template/presets/fulfillment/app.ts
@@ -4,7 +4,7 @@ import {
 } from '@spryker-oryx/application';
 import { BapiAuthComponentsFeature, BapiAuthFeature } from '@spryker-oryx/auth';
 import { contentFeature } from '@spryker-oryx/content';
-import { AppFeature, coreFeature } from '@spryker-oryx/core';
+import { AppFeature, coreFeature, FeatureOptions } from '@spryker-oryx/core';
 import { experienceFeature, Resources } from '@spryker-oryx/experience';
 import { formFeature } from '@spryker-oryx/form';
 import { I18nFeature, I18nFeatureOptions } from '@spryker-oryx/i18n';
@@ -24,7 +24,7 @@ import {
 import { RouterFeature } from '@spryker-oryx/router';
 import { siteFeature } from '@spryker-oryx/site';
 import { uiFeature } from '@spryker-oryx/ui';
-import { featureVersion } from '@spryker-oryx/utilities';
+import { ColorMode, featureVersion } from '@spryker-oryx/utilities';
 import { StaticExperienceFeature } from './experience';
 import {
   FulfillmentRootFeature,
@@ -61,6 +61,10 @@ export function fulfillmentFeatures(
             {
               provide: ThemeMetaInitializer,
               useClass: PWAThemeMetaInitializer,
+            },
+            {
+              provide: FeatureOptions,
+              useValue: { 'oryx-app': { colorMode: ColorMode.Light } },
             },
           ],
         }


### PR DESCRIPTION
We move the light mode configuration to the feature set of fulfillment app.

closes: [HRZ-90569](https://spryker.atlassian.net/browse/HRZ-90569)


[HRZ-90569]: https://spryker.atlassian.net/browse/HRZ-90569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ