### PR TITLE
refactor(ui): improve heading utility to support flexible margins margin

### DIFF
--- a/libs/base/ui/form/input-list/src/input-list.styles.ts
+++ b/libs/base/ui/form/input-list/src/input-list.styles.ts
@@ -41,7 +41,7 @@ export const styles = css`
 export const screenStyles = screenCss({
   sm: css`
     legend {
-      ${headingUtil(HeadingTag.Subtitle, '0 20px')}
+      ${headingUtil(HeadingTag.Subtitle, { margin: '0 0 20px' })}
     }
 
     .content {

--- a/libs/base/ui/form/input-list/src/input-list.styles.ts
+++ b/libs/base/ui/form/input-list/src/input-list.styles.ts
@@ -41,9 +41,7 @@ export const styles = css`
 export const screenStyles = screenCss({
   sm: css`
     legend {
-      ${headingUtil(HeadingTag.Subtitle)}
-
-      margin-block-end: 20px;
+      ${headingUtil(HeadingTag.Subtitle, '0 20px')}
     }
 
     .content {

--- a/libs/base/ui/structure/heading/src/styles/index.ts
+++ b/libs/base/ui/structure/heading/src/styles/index.ts
@@ -1,3 +1,3 @@
 export * from './base.styles';
 export * from './screen.styles';
-export * from './utility';
+export * from './util';

--- a/libs/base/ui/structure/heading/src/styles/util.spec.ts
+++ b/libs/base/ui/structure/heading/src/styles/util.spec.ts
@@ -23,6 +23,10 @@ describe('headingUtil', () => {
           `line-height: var(--oryx-typography-${tag}-line)`
         );
       });
+
+      it('should end with semi-column', () => {
+        expect(style.cssText.trim().endsWith(';')).to.eq(true);
+      });
     });
 
     describe('when margin is not provided', () => {

--- a/libs/base/ui/structure/heading/src/styles/util.spec.ts
+++ b/libs/base/ui/structure/heading/src/styles/util.spec.ts
@@ -1,0 +1,52 @@
+import { HeadingTag } from '../heading.model';
+import { headingUtil } from './util';
+
+describe('headingUtil', () => {
+  [HeadingTag.H1, HeadingTag.H2, HeadingTag.Small].forEach((tag) => {
+    describe('when tag is ' + tag, () => {
+      const style = headingUtil(tag);
+
+      it('should contain font-size', () => {
+        expect(style.cssText).toContain(
+          `font-size: var(--oryx-typography-${tag}-size)`
+        );
+      });
+
+      it('should contain font-weight', () => {
+        expect(style.cssText).toContain(
+          `font-weight: var(--oryx-typography-${tag}-weight)`
+        );
+      });
+
+      it('should contain line-height', () => {
+        expect(style.cssText).toContain(
+          `line-height: var(--oryx-typography-${tag}-line)`
+        );
+      });
+    });
+
+    describe('when margin is not provided', () => {
+      const style = headingUtil(tag);
+
+      it('should have zero margin by default', () => {
+        expect(style.cssText).toContain(`margin: 0`);
+      });
+    });
+
+    describe('when margin is provided', () => {
+      const style = headingUtil(tag, { margin: '0 0 10px' });
+
+      it('should have the give margin', () => {
+        expect(style.cssText).toContain(`margin: 0 0 10px`);
+      });
+    });
+
+    describe('when margin is undefined', () => {
+      const style = headingUtil(tag, {});
+
+      it('should not have a margin', () => {
+        expect(style.cssText).not.toContain(`margin:`);
+      });
+    });
+  });
+});

--- a/libs/base/ui/structure/heading/src/styles/util.ts
+++ b/libs/base/ui/structure/heading/src/styles/util.ts
@@ -14,7 +14,7 @@ export const headingUtil = (
   tag: HeadingTag,
   options: { margin?: string } = { margin: '0' }
 ): CSSResult => {
-  const margin = !options?.margin ? `` : `margin: ${options.margin}`;
+  const margin = !options?.margin ? `` : `margin: ${options.margin};`;
 
   return unsafeCSS(`
     font-size: var(--oryx-typography-${tag}-size);

--- a/libs/base/ui/structure/heading/src/styles/util.ts
+++ b/libs/base/ui/structure/heading/src/styles/util.ts
@@ -1,5 +1,5 @@
 import { CSSResult, unsafeCSS } from 'lit';
-import { HeadingTag } from '../heading.model';
+import { HeadingTag } from '../heading.model.js';
 
 /**
  * Heading utility function to generate heading styles base on the
@@ -12,11 +12,9 @@ import { HeadingTag } from '../heading.model';
  */
 export const headingUtil = (
   tag: HeadingTag,
-  options?: { marginBlock?: string }
+  options: { margin?: string } = { margin: '0' }
 ): CSSResult => {
-  const margin = options?.marginBlock
-    ? `margin-block: ${options.marginBlock}`
-    : 'margin-block: 0';
+  const margin = !options?.margin ? `` : `margin: ${options.margin}`;
 
   return unsafeCSS(`
     font-size: var(--oryx-typography-${tag}-size);

--- a/libs/base/ui/structure/heading/src/styles/utility.ts
+++ b/libs/base/ui/structure/heading/src/styles/utility.ts
@@ -7,14 +7,21 @@ import { HeadingTag } from '../heading.model';
  * but can be overridden by passing a string.
  *
  * ```ts
- * headingUtil(HeadingTag.H1, '0 8px');
+ * headingUtil(HeadingTag.H1, { margin: { block:'0 8px'}});
  * ```
  */
-export const headingUtil = (tag: HeadingTag, marginBlock = '0'): CSSResult => {
+export const headingUtil = (
+  tag: HeadingTag,
+  options?: { marginBlock?: string }
+): CSSResult => {
+  const margin = options?.marginBlock
+    ? `margin-block: ${options.marginBlock}`
+    : 'margin-block: 0';
+
   return unsafeCSS(`
     font-size: var(--oryx-typography-${tag}-size);
     font-weight: var(--oryx-typography-${tag}-weight);
     line-height: var(--oryx-typography-${tag}-line);
-    margin-block: ${marginBlock};
+    ${margin}
   `);
 };

--- a/libs/base/ui/structure/heading/src/styles/utility.ts
+++ b/libs/base/ui/structure/heading/src/styles/utility.ts
@@ -1,17 +1,20 @@
 import { CSSResult, unsafeCSS } from 'lit';
 import { HeadingTag } from '../heading.model';
 
-export const headingUtil = (tag: HeadingTag): CSSResult =>
-  unsafeCSS(`
+/**
+ * Heading utility function to generate heading styles base on the
+ * Design System tokens. The block margin for heading styles defaults to 0px,
+ * but can be overridden by passing a string.
+ *
+ * ```ts
+ * headingUtil(HeadingTag.H1, '0 8px');
+ * ```
+ */
+export const headingUtil = (tag: HeadingTag, marginBlock = '0'): CSSResult => {
+  return unsafeCSS(`
     font-size: var(--oryx-typography-${tag}-size);
     font-weight: var(--oryx-typography-${tag}-weight);
     line-height: var(--oryx-typography-${tag}-line);
-    margin:0;
+    margin: ${marginBlock};
   `);
-
-export const headingNoMarginUtil = (tag: HeadingTag): CSSResult =>
-  unsafeCSS(`
-    font-size: var(--oryx-typography-${tag}-size);
-    font-weight: var(--oryx-typography-${tag}-weight);
-    line-height: var(--oryx-typography-${tag}-line);
-  `);
+};

--- a/libs/base/ui/structure/heading/src/styles/utility.ts
+++ b/libs/base/ui/structure/heading/src/styles/utility.ts
@@ -15,6 +15,6 @@ export const headingUtil = (tag: HeadingTag, marginBlock = '0'): CSSResult => {
     font-size: var(--oryx-typography-${tag}-size);
     font-weight: var(--oryx-typography-${tag}-weight);
     line-height: var(--oryx-typography-${tag}-line);
-    margin: ${marginBlock};
+    margin-block: ${marginBlock};
   `);
 };

--- a/libs/domain/cart/coupon/coupon.styles.ts
+++ b/libs/domain/cart/coupon/coupon.styles.ts
@@ -1,14 +1,9 @@
-import {
-  HeadingTag,
-  headingNoMarginUtil,
-  headingUtil,
-} from '@spryker-oryx/ui/heading';
+import { HeadingTag, headingUtil } from '@spryker-oryx/ui/heading';
 import { css } from 'lit';
 
 export const couponStyles = css`
   h3 {
-    margin-block-end: 8px;
-    ${headingNoMarginUtil(HeadingTag.H5)};
+    ${headingUtil(HeadingTag.H5, '0 8px')};
   }
 
   section {

--- a/libs/domain/cart/coupon/coupon.styles.ts
+++ b/libs/domain/cart/coupon/coupon.styles.ts
@@ -3,7 +3,7 @@ import { css } from 'lit';
 
 export const couponStyles = css`
   h3 {
-    ${headingUtil(HeadingTag.H5, '0 8px')};
+    ${headingUtil(HeadingTag.H5, { margin: '0 0 8px' })};
   }
 
   section {

--- a/libs/domain/cart/entries/src/entries.styles.ts
+++ b/libs/domain/cart/entries/src/entries.styles.ts
@@ -7,9 +7,7 @@ const deprecatedHeadingStyles = css`
   }
 
   h1 {
-    ${headingUtil(HeadingTag.H3)}
-
-    margin-block-end: 20px;
+    ${headingUtil(HeadingTag.H3, '0 20px')}
   }
 `;
 

--- a/libs/domain/cart/entries/src/entries.styles.ts
+++ b/libs/domain/cart/entries/src/entries.styles.ts
@@ -7,7 +7,7 @@ const deprecatedHeadingStyles = css`
   }
 
   h1 {
-    ${headingUtil(HeadingTag.H3, '0 20px')}
+    ${headingUtil(HeadingTag.H3, { margin: '0 0 20px' })}
   }
 `;
 

--- a/libs/domain/cart/totals/src/totals.styles.ts
+++ b/libs/domain/cart/totals/src/totals.styles.ts
@@ -3,7 +3,7 @@ import { css } from 'lit';
 
 export const totalStyles = css`
   h2 {
-    ${headingUtil(HeadingTag.H3, '0 var(--oryx-space-4)')};
+    ${headingUtil(HeadingTag.H3, { margin: '0 0 var(--oryx-space-4)' })};
 
     display: var(--oryx-screen-small-hide, block);
   }

--- a/libs/domain/cart/totals/src/totals.styles.ts
+++ b/libs/domain/cart/totals/src/totals.styles.ts
@@ -3,9 +3,8 @@ import { css } from 'lit';
 
 export const totalStyles = css`
   h2 {
-    ${headingUtil(HeadingTag.H3)};
+    ${headingUtil(HeadingTag.H3, '0 var(--oryx-space-4)')};
 
-    margin-block-end: var(--oryx-space-4);
     display: var(--oryx-screen-small-hide, block);
   }
 

--- a/libs/domain/checkout/orchestrator/orchestrator.styles.ts
+++ b/libs/domain/checkout/orchestrator/orchestrator.styles.ts
@@ -15,7 +15,7 @@ export const checkoutOrchestratorStyles = css`
   }
 
   h2 {
-    ${headingUtil(HeadingTag.H5, '0 12px')};
+    ${headingUtil(HeadingTag.H5, { margin: '0 0 12px' })};
 
     display: flex;
     align-items: center;

--- a/libs/domain/checkout/orchestrator/orchestrator.styles.ts
+++ b/libs/domain/checkout/orchestrator/orchestrator.styles.ts
@@ -15,11 +15,10 @@ export const checkoutOrchestratorStyles = css`
   }
 
   h2 {
-    ${headingUtil(HeadingTag.H5)};
+    ${headingUtil(HeadingTag.H5, '0 12px')};
 
     display: flex;
     align-items: center;
-    margin-block-end: 12px;
     justify-content: space-between;
   }
 `;

--- a/libs/domain/order/totals/totals.styles.ts
+++ b/libs/domain/order/totals/totals.styles.ts
@@ -3,9 +3,8 @@ import { css } from 'lit';
 
 export const orderTotalStyles = css`
   h2 {
-    ${headingUtil(HeadingTag.H3)};
+    ${headingUtil(HeadingTag.H3, '0 var(--oryx-space-4)')};
 
-    margin-block-end: var(--oryx-space-4);
     display: var(--oryx-screen-small-hide, block);
   }
 

--- a/libs/domain/order/totals/totals.styles.ts
+++ b/libs/domain/order/totals/totals.styles.ts
@@ -3,7 +3,7 @@ import { css } from 'lit';
 
 export const orderTotalStyles = css`
   h2 {
-    ${headingUtil(HeadingTag.H3, '0 var(--oryx-space-4)')};
+    ${headingUtil(HeadingTag.H3, { margin: '0 0 var(--oryx-space-4)' })};
 
     display: var(--oryx-screen-small-hide, block);
   }

--- a/libs/domain/search/box/box.styles.ts
+++ b/libs/domain/search/box/box.styles.ts
@@ -41,7 +41,7 @@ export const searchBoxStyles = css`
   }
 
   h5 {
-    ${headingUtil(HeadingTag.Subtitle, '0 6px')}
+    ${headingUtil(HeadingTag.Subtitle, { margin: '0 0 6px' })}
 
     text-transform: uppercase;
     display: flex;

--- a/libs/domain/search/box/box.styles.ts
+++ b/libs/domain/search/box/box.styles.ts
@@ -41,13 +41,12 @@ export const searchBoxStyles = css`
   }
 
   h5 {
-    ${headingUtil(HeadingTag.Subtitle)}
+    ${headingUtil(HeadingTag.Subtitle, '0 6px')}
 
     text-transform: uppercase;
     display: flex;
     align-items: center;
     gap: 10px;
-    margin-block-end: 6px;
   }
 
   h5:not(:first-child) {


### PR DESCRIPTION
Improved the heading margin so that we can provide custom block margin. The block margin defaults to `0`.