### PR TITLE
feat(experience): Layout Transition Property Plugin

### DIFF
--- a/apps/storybook/.storybook/global.css
+++ b/apps/storybook/.storybook/global.css
@@ -1,6 +1,11 @@
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap');
 
 :root {
+  --_container-width: min(
+    var(--oryx-container-width),
+    calc(100vw - (2 * var(--oryx-container-bleed, 0px)))
+  );
+
   font-family: var(--oryx-typography-body-font);
   font-size: 14px;
   font-weight: var(--oryx-typography-body-weight);

--- a/libs/platform/experience/layout/stories/static/examples/product-images.stories.ts
+++ b/libs/platform/experience/layout/stories/static/examples/product-images.stories.ts
@@ -30,19 +30,19 @@ const Template: Story = (): TemplateResult => {
 
     <h2>Navigation at the top</h2>
     <div class="page">
-      <oryx-layout layout="list">
+      <oryx-layout layout="grid">
         ${generateThumbs('carousel', 'thumbs')}
         ${generateThumbs('carousel', 'main')}
       </oryx-layout>
-      <oryx-layout layout="list">
+      <oryx-layout layout="grid">
         ${generateThumbs('grid', 'thumbs')}
         ${generateThumbs('carousel', 'main')}
       </oryx-layout>
-      <oryx-layout layout="list" layout-overlap>
+      <oryx-layout layout="grid" layout-overlap>
         ${generateThumbs('carousel', 'main')}
         ${generateThumbs('carousel', 'thumbs', false, 'place-self:start;')}
       </oryx-layout>
-      <oryx-layout layout="list" layout-overlap>
+      <oryx-layout layout="grid" layout-overlap>
         ${generateThumbs('carousel', 'main')}
         ${generateThumbs('grid', 'thumbs', false, 'place-self:start;')}
       </oryx-layout>
@@ -70,19 +70,19 @@ const Template: Story = (): TemplateResult => {
 
     <h2>Navigation at the bottom</h2>
     <div class="page">
-      <oryx-layout layout="list">
+      <oryx-layout layout="grid">
         ${generateThumbs('carousel', 'main')}
         ${generateThumbs('carousel', 'thumbs')}
       </oryx-layout>
-      <oryx-layout layout="list">
+      <oryx-layout layout="grid">
         ${generateThumbs('carousel', 'main')}
         ${generateThumbs('grid', 'thumbs')}
       </oryx-layout>
-      <oryx-layout layout="list" layout-overlap>
+      <oryx-layout layout="grid" layout-overlap>
         ${generateThumbs('carousel', 'main')}
         ${generateThumbs('carousel', 'thumbs', false, 'place-self:end;')}
       </oryx-layout>
-      <oryx-layout layout="list" layout-overlap>
+      <oryx-layout layout="grid" layout-overlap>
         ${generateThumbs('carousel', 'main')}
         ${generateThumbs('grid', 'thumbs', false, 'place-self:end;')}
       </oryx-layout>
@@ -110,7 +110,7 @@ const Template: Story = (): TemplateResult => {
 
     <h2>Navigation vertical</h2>
     <div class="page">
-      <oryx-layout layout="list">
+      <oryx-layout layout="grid">
         ${generateThumbs('carousel', 'thumbs')}
         ${generateThumbs('carousel', 'main', true)}
       </oryx-layout>
@@ -118,7 +118,7 @@ const Template: Story = (): TemplateResult => {
         ${generateThumbs('carousel', 'thumbs', true)}
         ${generateThumbs('carousel', 'main', true)}
       </oryx-layout>
-      <oryx-layout layout="list" layout-overlap>
+      <oryx-layout layout="grid" layout-overlap>
         ${generateThumbs('carousel', 'main', true)}
         ${generateThumbs('carousel', 'thumbs', false, 'place-self:start;')}
       </oryx-layout>

--- a/libs/platform/experience/layout/stories/static/util.ts
+++ b/libs/platform/experience/layout/stories/static/util.ts
@@ -65,7 +65,7 @@ export const generateNestedLayout = (
     <li>⚠️ The border breaks the flow of <i>nested</i> layouts.</li>
   </ul>
 
-  <oryx-layout layout=${layout} style="align-items: center">
+  <oryx-layout layout=${layout} style="--align: center">
     <div style="height: 300px">1 (height: 300px)</div>
     <oryx-layout
       layout="grid"

--- a/libs/platform/experience/src/services/layout/plugins/base.styles.ts
+++ b/libs/platform/experience/src/services/layout/plugins/base.styles.ts
@@ -1,6 +1,7 @@
+import { featureVersion } from '@spryker-oryx/utilities';
 import { css } from 'lit';
 
-export const styles = css`
+export const pre1_4_styles = css`
   :host {
     --_container-width: min(
       var(--oryx-container-width),
@@ -11,6 +12,8 @@ export const styles = css`
     column-gap: var(--column-gap, var(--oryx-column-gap, 0));
     row-gap: var(--row-gap, var(--oryx-row-gap));
     margin-inline: auto;
+    gap: var(--row-gap, var(--oryx-row-gap))
+      var(--column-gap, var(--oryx-column-gap, 0));
     width: min(100%, calc(var(--_container-width)));
   }
 
@@ -19,3 +22,14 @@ export const styles = css`
     transition: all var(--oryx-transition-time);
   }
 `;
+
+export const v1_4_styles = css`
+  :host {
+    margin-inline: auto;
+    gap: var(--row-gap, var(--oryx-row-gap))
+      var(--column-gap, var(--oryx-column-gap, 0));
+    width: min(100%, calc(var(--_container-width)));
+  }
+`;
+
+export const styles = featureVersion >= '1.4' ? v1_4_styles : pre1_4_styles;

--- a/libs/platform/experience/src/services/layout/plugins/layout-plugins.providers.ts
+++ b/libs/platform/experience/src/services/layout/plugins/layout-plugins.providers.ts
@@ -5,6 +5,7 @@ import {
   DividerLayoutPluginToken,
   OverlapLayoutPluginToken,
   StickyLayoutPluginToken,
+  TransitionLayoutPluginToken,
 } from './properties';
 import {
   CarouselLayoutPluginToken,
@@ -127,6 +128,13 @@ export const layoutPluginsProviders: Provider[] = [
     asyncClass: () =>
       import('./properties/overlap/overlap-layout.plugin').then(
         (m) => m.OverlapLayoutPlugin
+      ),
+  },
+  {
+    provide: TransitionLayoutPluginToken,
+    asyncClass: () =>
+      import('./properties/transition/transition.plugin').then(
+        (m) => m.TransitionLayoutPlugin
       ),
   },
 ];

--- a/libs/platform/experience/src/services/layout/plugins/layout-plugins.providers.ts
+++ b/libs/platform/experience/src/services/layout/plugins/layout-plugins.providers.ts
@@ -11,6 +11,7 @@ import {
   ColumnLayoutPluginToken,
   FlexLayoutPluginToken,
   GridLayoutPluginToken,
+  ListLayoutPluginToken,
   NavigationLayoutPluginToken,
   SplitLayoutPluginToken,
   TextLayoutPluginToken,
@@ -56,6 +57,11 @@ export const layoutPluginsProviders: Provider[] = [
     provide: GridLayoutPluginToken,
     asyncClass: () =>
       import('./types/grid/grid-layout.plugin').then((m) => m.GridLayoutPlugin),
+  },
+  {
+    provide: ListLayoutPluginToken,
+    asyncClass: () =>
+      import('./types/list/list.plugin').then((m) => m.ListLayoutPlugin),
   },
   {
     provide: CarouselLayoutPluginToken,

--- a/libs/platform/experience/src/services/layout/plugins/properties/index.ts
+++ b/libs/platform/experience/src/services/layout/plugins/properties/index.ts
@@ -2,3 +2,4 @@ export * from './bleed';
 export * from './divider';
 export * from './overlap';
 export * from './sticky';
+export * from './transition';

--- a/libs/platform/experience/src/services/layout/plugins/properties/transition/index.ts
+++ b/libs/platform/experience/src/services/layout/plugins/properties/transition/index.ts
@@ -1,0 +1,1 @@
+export * from './transition.model';

--- a/libs/platform/experience/src/services/layout/plugins/properties/transition/transition.model.ts
+++ b/libs/platform/experience/src/services/layout/plugins/properties/transition/transition.model.ts
@@ -1,0 +1,9 @@
+import { LayoutPropertyPlugin } from '../../layout.plugin';
+
+export const TransitionLayoutPluginToken = `${LayoutPropertyPlugin}transition`;
+
+declare global {
+  export interface LayoutProperty {
+    transition?: boolean;
+  }
+}

--- a/libs/platform/experience/src/services/layout/plugins/properties/transition/transition.plugin.spec.ts
+++ b/libs/platform/experience/src/services/layout/plugins/properties/transition/transition.plugin.spec.ts
@@ -1,0 +1,33 @@
+import { lastValueFrom } from 'rxjs';
+import { TransitionLayoutPlugin } from './transition.plugin';
+
+describe('TransitionLayoutPlugin', () => {
+  let plugin: TransitionLayoutPlugin;
+
+  beforeEach(() => {
+    plugin = new TransitionLayoutPlugin();
+  });
+
+  describe('getStyles', () => {
+    it('should return an Observable of LayoutStyles', async () => {
+      const styles = await import('./transition.styles').then(
+        (module) => module.styles
+      );
+      const result = await lastValueFrom(plugin.getStyles());
+
+      expect(result).toEqual(styles);
+    });
+  });
+
+  describe('getConfig', () => {
+    it('should return proper schema in the object', async () => {
+      const schema = await import('./transition.schema').then(
+        (module) => module.schema
+      );
+      const config = await lastValueFrom(plugin.getConfig?.());
+      const result = await (config.schema as () => unknown)();
+
+      expect(result).toEqual(schema);
+    });
+  });
+});

--- a/libs/platform/experience/src/services/layout/plugins/properties/transition/transition.plugin.ts
+++ b/libs/platform/experience/src/services/layout/plugins/properties/transition/transition.plugin.ts
@@ -1,0 +1,16 @@
+import { ssrAwaiter } from '@spryker-oryx/core/utilities';
+import { Observable, of } from 'rxjs';
+import { LayoutStyles } from '../../../layout.model';
+import { LayoutPlugin, LayoutPluginConfig } from '../../layout.plugin';
+
+export class TransitionLayoutPlugin implements LayoutPlugin {
+  getStyles(): Observable<LayoutStyles> {
+    return ssrAwaiter(import('./transition.styles').then((m) => m.styles));
+  }
+
+  getConfig(): Observable<LayoutPluginConfig> {
+    return of({
+      schema: () => import('./transition.schema').then((m) => m.schema),
+    });
+  }
+}

--- a/libs/platform/experience/src/services/layout/plugins/properties/transition/transition.schema.ts
+++ b/libs/platform/experience/src/services/layout/plugins/properties/transition/transition.schema.ts
@@ -1,0 +1,6 @@
+import { ContentComponentSchema } from '../../../../../models';
+
+export const schema: ContentComponentSchema = {
+  name: 'transition',
+  group: 'layout',
+};

--- a/libs/platform/experience/src/services/layout/plugins/properties/transition/transition.styles.ts
+++ b/libs/platform/experience/src/services/layout/plugins/properties/transition/transition.styles.ts
@@ -1,0 +1,11 @@
+import { css } from 'lit';
+import { LayoutStyles } from '../../../layout.model';
+
+export const styles: LayoutStyles = {
+  styles: css`
+    :host > *,
+    :host ::slotted(*) {
+      transition: all var(--oryx-transition-time);
+    }
+  `,
+};

--- a/libs/platform/experience/src/services/layout/plugins/types/index.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/index.ts
@@ -2,6 +2,7 @@ export * from './carousel';
 export * from './column';
 export * from './flex';
 export * from './grid';
+export * from './list';
 export * from './navigation';
 export * from './split';
 export * from './text';

--- a/libs/platform/experience/src/services/layout/plugins/types/list/index.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/list/index.ts
@@ -1,0 +1,1 @@
+export * from './list.model';

--- a/libs/platform/experience/src/services/layout/plugins/types/list/list.model.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/list/list.model.ts
@@ -1,0 +1,9 @@
+import { LayoutPlugin } from '../../layout.plugin';
+
+export const ListLayoutPluginToken = `${LayoutPlugin}list`;
+
+declare global {
+  export interface Layouts {
+    list: undefined;
+  }
+}

--- a/libs/platform/experience/src/services/layout/plugins/types/list/list.plugin.spec.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/list/list.plugin.spec.ts
@@ -1,0 +1,33 @@
+import { lastValueFrom } from 'rxjs';
+import { ListLayoutPlugin } from './list.plugin';
+
+describe('ListLayoutPlugin', () => {
+  let plugin: ListLayoutPlugin;
+
+  beforeEach(() => {
+    plugin = new ListLayoutPlugin();
+  });
+
+  describe('getStyles', () => {
+    it('should return an Observable of LayoutStyles', async () => {
+      const styles = await import('./list.styles').then(
+        (module) => module.styles
+      );
+      const result = await lastValueFrom(plugin.getStyles());
+
+      expect(result).toEqual(styles);
+    });
+  });
+
+  describe('getConfig', () => {
+    it('should return proper schema in the object', async () => {
+      const schema = await import('./list.schema').then(
+        (module) => module.schema
+      );
+      const config = await lastValueFrom(plugin.getConfig?.());
+      const result = await (config.schema as () => unknown)();
+
+      expect(result).toEqual(schema);
+    });
+  });
+});

--- a/libs/platform/experience/src/services/layout/plugins/types/list/list.plugin.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/list/list.plugin.ts
@@ -1,0 +1,22 @@
+import { ssrAwaiter } from '@spryker-oryx/core/utilities';
+import { Observable, of } from 'rxjs';
+import { LayoutStyles } from '../../../layout.model';
+import { LayoutPlugin, LayoutPluginConfig } from '../../layout.plugin';
+
+export class ListLayoutPlugin implements LayoutPlugin {
+  getStyles(): Observable<LayoutStyles> {
+    return ssrAwaiter(
+      import('./list.styles').then((m) => {
+        return {
+          ...m.styles,
+        };
+      })
+    );
+  }
+
+  getConfig(): Observable<LayoutPluginConfig> {
+    return of({
+      schema: () => import('./list.schema').then((m) => m.schema),
+    });
+  }
+}

--- a/libs/platform/experience/src/services/layout/plugins/types/list/list.schema.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/list/list.schema.ts
@@ -1,0 +1,6 @@
+import { ContentComponentSchema } from '../../../../../models';
+
+export const schema: ContentComponentSchema = {
+  name: 'list',
+  group: 'layout',
+};

--- a/libs/platform/experience/src/services/layout/plugins/types/list/list.styles.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/list/list.styles.ts
@@ -1,0 +1,11 @@
+import { css } from 'lit';
+import { LayoutStyles } from '../../../layout.model';
+
+export const styles: LayoutStyles = {
+  styles: css`
+    :host {
+      display: flex;
+      flex-direction: column;
+    }
+  `,
+};

--- a/libs/platform/experience/src/services/layout/plugins/types/list/list.styles.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/list/list.styles.ts
@@ -7,5 +7,10 @@ export const styles: LayoutStyles = {
       display: flex;
       flex-direction: column;
     }
+
+    *,
+    ::slotted(*) {
+      box-sizing: border-box;
+    }
   `,
 };

--- a/libs/template/application/oryx-app/oryx-app.styles.ts
+++ b/libs/template/application/oryx-app/oryx-app.styles.ts
@@ -1,7 +1,19 @@
-import { css } from 'lit';
+import { featureVersion } from '@spryker-oryx/utilities';
+import { css, unsafeCSS } from 'lit';
 
 export const styles = css`
   :host {
+    ${unsafeCSS(
+      featureVersion >= '1.4'
+        ? `
+        --_container-width: min(
+          var(--oryx-container-width),
+          calc(100vw - (2 * var(--oryx-container-bleed, 0px)))
+        );
+    `
+        : ''
+    )}
+
     display: block;
     font-family: var(--oryx-typography-body-font);
     font-weight: var(--oryx-typography-body-weight);

--- a/libs/template/presets/fulfillment/experience/pages/login-page.ts
+++ b/libs/template/presets/fulfillment/experience/pages/login-page.ts
@@ -1,4 +1,5 @@
 import { ExperienceComponent } from '@spryker-oryx/experience';
+import { featureVersion } from '@spryker-oryx/utilities';
 
 export const fulfillmentLoginPage: ExperienceComponent = {
   id: 'fulfillment-login-page',
@@ -11,7 +12,11 @@ export const fulfillmentLoginPage: ExperienceComponent = {
   options: {
     rules: [
       {
-        layout: { type: 'flex', vertical: true },
+        layout: {
+          ...(featureVersion >= '1.4'
+            ? { type: 'list' }
+            : { type: 'flex', vertical: true }),
+        },
         gap: '30px',
         height: '100vh',
         width: 'min(440px, calc(100% - 16px))',

--- a/libs/template/presets/storefront/experience/pages/cart-page.ts
+++ b/libs/template/presets/storefront/experience/pages/cart-page.ts
@@ -81,7 +81,10 @@ export const cartPage: ExperienceComponent = {
           options: {
             rules: [
               {
-                layout: { sticky: true },
+                layout:
+                  featureVersion >= '1.4'
+                    ? { type: 'list', sticky: true }
+                    : { sticky: true },
                 top: '108px',
                 ...(featureVersion >= '1.2' ? {} : { sticky: true }),
               },

--- a/libs/template/presets/storefront/experience/pages/category-page.ts
+++ b/libs/template/presets/storefront/experience/pages/category-page.ts
@@ -57,7 +57,12 @@ export const categoryPage: ExperienceComponent = {
           id: 'category-product-listing',
           name: 'Product listing',
           options: {
-            rules: [{ layout: 'list', gap: '20px' }],
+            rules: [
+              {
+                layout: featureVersion >= '1.4' ? { type: 'list' } : 'flex',
+                gap: '20px',
+              },
+            ],
           },
           components: [
             {

--- a/libs/template/presets/storefront/experience/pages/checkout-page.ts
+++ b/libs/template/presets/storefront/experience/pages/checkout-page.ts
@@ -114,7 +114,10 @@ export const checkoutPage: ExperienceComponent = {
             rules: [
               { hideByRule: 'CART.EMPTY' },
               {
-                layout: { sticky: true },
+                layout: {
+                  ...(featureVersion >= '1.4' ? { type: 'list' } : {}),
+                  sticky: true,
+                },
                 top: '108px',
                 ...(featureVersion >= '1.2' ? {} : { sticky: true }),
               },

--- a/libs/template/presets/storefront/experience/pages/home-page.ts
+++ b/libs/template/presets/storefront/experience/pages/home-page.ts
@@ -111,7 +111,10 @@ export const homePage: ExperienceComponent = {
       options: {
         rules: [
           {
-            layout: 'grid',
+            layout: {
+              type: 'grid',
+              transition: true,
+            },
             padding: '60px 0',
             gap: '30px 0px',
             columnCount: 6,

--- a/libs/template/presets/storefront/experience/pages/login-page.ts
+++ b/libs/template/presets/storefront/experience/pages/login-page.ts
@@ -14,11 +14,7 @@ export const loginPage: ExperienceComponent = {
   ...(featureVersion >= '1.1'
     ? {
         components: [
-          featureVersion >= '1.2'
-            ? {
-                ref: 'header',
-              }
-            : {},
+          featureVersion >= '1.2' ? { ref: 'header' } : {},
           {
             type: 'oryx-composition',
             options: {

--- a/libs/template/presets/storefront/experience/pages/product-page.ts
+++ b/libs/template/presets/storefront/experience/pages/product-page.ts
@@ -71,10 +71,10 @@ export const productPage: ExperienceComponent = {
               options: {
                 rules: [
                   {
-                    layout: {
-                      vertical: true,
-                      sticky: true,
-                    },
+                    layout:
+                      featureVersion >= '1.4'
+                        ? { type: 'list', sticky: true }
+                        : { vertical: true, sticky: true },
                     top: '108px',
                     ...(featureVersion >= '1.2'
                       ? {}

--- a/libs/template/presets/storefront/experience/pages/search-page.ts
+++ b/libs/template/presets/storefront/experience/pages/search-page.ts
@@ -58,7 +58,9 @@ export const searchPage: ExperienceComponent = {
             rules: [
               {
                 layout:
-                  featureVersion >= '1.2'
+                  featureVersion >= '1.4'
+                    ? { type: 'list' }
+                    : featureVersion >= '1.2'
                     ? {
                         type: 'flex',
                         vertical: true,


### PR DESCRIPTION
The layout transition property plugin will conditionally apply a transition to the layout. Previously, this affect was applied to all layouts, which caused performance issues during the re-render of the layout. 

closes: [HRZ-90695](https://spryker.atlassian.net/browse/HRZ-90695)


[HRZ-90695]: https://spryker.atlassian.net/browse/HRZ-90695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ