### PR TITLE
fix: fixed partial matching of routes

### DIFF
--- a/libs/domain/site/src/services/link/default-link.service.spec.ts
+++ b/libs/domain/site/src/services/link/default-link.service.spec.ts
@@ -183,9 +183,20 @@ describe('DefaultLinkService', () => {
       });
     });
 
-    describe('when the current route starts with the provided URL', () => {
+    describe('when the current route overlaps another URL', () => {
       beforeEach(() => {
         mockRouterService.currentRoute.mockReturnValue(of('/about-us'));
+        service.isCurrent('/about').subscribe(callback);
+      });
+
+      it('should resolve to false', () => {
+        expect(callback).toHaveBeenCalledWith(false);
+      });
+    });
+
+    describe('when the current route starts with the provided URL', () => {
+      beforeEach(() => {
+        mockRouterService.currentRoute.mockReturnValue(of('/about/us'));
         service.isCurrent('/about').subscribe(callback);
       });
 

--- a/libs/domain/site/src/services/link/default-link.service.ts
+++ b/libs/domain/site/src/services/link/default-link.service.ts
@@ -52,11 +52,9 @@ export class DefaultLinkService implements LinkService {
 
         const currentUrl = `${this.baseRoute}${currentRoute}`;
 
-        if (exactMatch) {
-          return of(currentUrl === url);
-        } else {
-          return of(currentUrl.startsWith(url));
-        }
+        return of(
+          currentUrl === url || exactMatch || currentUrl.startsWith(`${url}/`)
+        );
       })
     );
   }


### PR DESCRIPTION
Partial routing was broken for links that include that overlap other routes (e.g. `/category/23` and `/category/2`).

closes: [HRZ-90696](https://spryker.atlassian.net/browse/HRZ-90696)

[HRZ-90696]: https://spryker.atlassian.net/browse/HRZ-90696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ