### PR TITLE
chore: use inline-block when there's no tag

### DIFF
--- a/libs/base/ui/structure/heading/src/heading.styles.ts
+++ b/libs/base/ui/structure/heading/src/heading.styles.ts
@@ -32,7 +32,7 @@ export const headingStyles = css`
     margin: 0;
   }
 
-  :host([style*='--max-lines']) > * {
+  :host([style*='--max-lines']) > *:not(style) {
     /* stylelint-disable-next-line */
     display: -webkit-box;
     -webkit-box-orient: vertical;

--- a/libs/base/ui/structure/heading/src/typography.controller.ts
+++ b/libs/base/ui/structure/heading/src/typography.controller.ts
@@ -46,9 +46,7 @@ export class TypographyController implements ReactiveController {
    * Sets the font properties for the heading, based on the provided tag and size.
    */
   protected setFont(tag?: HeadingTag | HeadingVisibility, size?: Size): void {
-    if (!tag) {
-      return;
-    }
+    if (!tag) return;
 
     this.setStyleProperty('--_s', size, `var(--oryx-typography-${tag}-size)`);
     this.setStyleProperty('--_w', size, `var(--oryx-typography-${tag}-weight)`);
@@ -63,7 +61,7 @@ export class TypographyController implements ReactiveController {
     tag?: HeadingTag | HeadingVisibility,
     size?: Size
   ): void {
-    if ((!tag && !size) || (!size && this.isInlineStyle(tag))) {
+    if (!size && (!tag || this.isInlineStyle(tag))) {
       this.setStyleProperty('--_d', undefined, 'inline-block');
     } else {
       this.setStyleProperty(

--- a/libs/base/ui/structure/heading/src/typography.controller.ts
+++ b/libs/base/ui/structure/heading/src/typography.controller.ts
@@ -102,7 +102,7 @@ export class TypographyController implements ReactiveController {
     if (value !== undefined) {
       this.host.style.setProperty(propName, String(value));
     } else {
-      this.host.style.removeProperty(propName);
+      this.host.style.removeProperty?.(propName);
     }
   }
 

--- a/libs/base/ui/structure/heading/src/typography.controller.ts
+++ b/libs/base/ui/structure/heading/src/typography.controller.ts
@@ -55,9 +55,7 @@ export class TypographyController implements ReactiveController {
 
   /**
    * Sets the display property for the heading, based on the provided tag and size.
-   * When no tag is provided, the default display is `inline`.
-   * When no size is provided, the default display is `inline-block`.
-   *
+   * When there's no tag or the tag is an inline tag, the display property is set to inline-block.
    */
   protected setDisplay(
     tag?: HeadingTag | HeadingVisibility,

--- a/libs/base/ui/structure/heading/src/typography.controller.ts
+++ b/libs/base/ui/structure/heading/src/typography.controller.ts
@@ -46,7 +46,9 @@ export class TypographyController implements ReactiveController {
    * Sets the font properties for the heading, based on the provided tag and size.
    */
   protected setFont(tag?: HeadingTag | HeadingVisibility, size?: Size): void {
-    if (!tag) return;
+    if (!tag) {
+      return;
+    }
 
     this.setStyleProperty('--_s', size, `var(--oryx-typography-${tag}-size)`);
     this.setStyleProperty('--_w', size, `var(--oryx-typography-${tag}-weight)`);
@@ -61,7 +63,7 @@ export class TypographyController implements ReactiveController {
     tag?: HeadingTag | HeadingVisibility,
     size?: Size
   ): void {
-    if (!tag || (!size && this.isInlineStyle(tag))) {
+    if ((!tag && !size) || (!size && this.isInlineStyle(tag))) {
       this.setStyleProperty('--_d', undefined, 'inline-block');
     } else {
       this.setStyleProperty(

--- a/libs/base/ui/structure/heading/src/typography.controller.ts
+++ b/libs/base/ui/structure/heading/src/typography.controller.ts
@@ -37,28 +37,52 @@ export class TypographyController implements ReactiveController {
   }
 
   protected setStyle(tag?: HeadingTag | HeadingVisibility, size?: Size): void {
+    this.setFont(tag, size);
+    this.setDisplay(tag, size);
+    this.setTransform(tag, size);
+  }
+
+  /**
+   * Sets the font properties for the heading, based on the provided tag and size.
+   */
+  protected setFont(tag?: HeadingTag | HeadingVisibility, size?: Size): void {
     if (!tag) return;
 
     this.setStyleProperty('--_s', size, `var(--oryx-typography-${tag}-size)`);
     this.setStyleProperty('--_w', size, `var(--oryx-typography-${tag}-weight)`);
     this.setStyleProperty('--_l', size, `var(--oryx-typography-${tag}-line)`);
+  }
 
-    this.setStyleProperty(
-      '--_t',
-      size,
-      tag === HeadingTag.Subtitle ? `uppercase` : undefined
-    );
-
-    if (size) {
+  /**
+   * Sets the display property for the heading, based on the provided tag and size.
+   * When no tag is provided, the default display is `inline`.
+   * When no size is provided, the default display is `inline-block`.
+   *
+   */
+  protected setDisplay(
+    tag?: HeadingTag | HeadingVisibility,
+    size?: Size
+  ): void {
+    if (!tag || (!size && this.isInlineStyle(tag))) {
+      this.setStyleProperty('--_d', undefined, 'inline-block');
+    } else {
       this.setStyleProperty(
         '--_d',
         size,
         tag === HeadingVisibility.None ? `none` : undefined
       );
-    } else {
-      if (this.isInlineStyle(tag)) {
-        this.setStyleProperty('--_d', undefined, 'inline-block');
-      }
+    }
+  }
+
+  /**
+   * Sets the text-transform property for the heading, based on the provided tag and size.
+   */
+  protected setTransform(
+    tag?: HeadingTag | HeadingVisibility,
+    size?: Size
+  ): void {
+    if (tag === HeadingTag.Subtitle) {
+      this.setStyleProperty('--_t', size, `uppercase`);
     }
   }
 


### PR DESCRIPTION
Heading elements without a tag, no longer causing a block display. 

closes: [HRZ-90720](https://spryker.atlassian.net/browse/HRZ-90720)

[HRZ-90720]: https://spryker.atlassian.net/browse/HRZ-90720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ