### PR TITLE
feat(site): Added day component

### DIFF
--- a/libs/domain/site/day/day.component.spec.ts
+++ b/libs/domain/site/day/day.component.spec.ts
@@ -44,7 +44,7 @@ describe('SiteDayComponent', () => {
 
   describe('when the component is initialised', () => {
     beforeEach(async () => {
-      element = await fixture(html`<oryx-day></oryx-day>`);
+      element = await fixture(html`<oryx-site-day></oryx-site-day>`);
     });
 
     it('should be an instance of SiteDayComponent', () => {
@@ -60,7 +60,9 @@ describe('SiteDayComponent', () => {
     describe('and the day is monday', () => {
       beforeEach(async () => {
         localeService.formatDay.mockReturnValue('formatted-date');
-        element = await fixture(html`<oryx-day .day=${'monday'}></oryx-day>`);
+        element = await fixture(
+          html`<oryx-site-day .day=${'monday'}></oryx-site-day>`
+        );
       });
 
       it('should call the locale service to format the date', () => {
@@ -82,10 +84,10 @@ describe('SiteDayComponent', () => {
     describe('and there is a day available', () => {
       beforeEach(async () => {
         element = await fixture(
-          html`<oryx-day
+          html`<oryx-site-day
             .day=${'monday'}
             i18nToken="my.custom-<day>-day"
-          ></oryx-day>`
+          ></oryx-site-day>`
         );
       });
 
@@ -99,7 +101,7 @@ describe('SiteDayComponent', () => {
     describe('and there is no day available', () => {
       beforeEach(async () => {
         element = await fixture(
-          html`<oryx-day i18nToken="my.custom-<day>-day"></oryx-day>`
+          html`<oryx-site-day i18nToken="my.custom-<day>-day"></oryx-site-day>`
         );
       });
 

--- a/libs/domain/site/day/day.component.spec.ts
+++ b/libs/domain/site/day/day.component.spec.ts
@@ -1,0 +1,111 @@
+import { fixture } from '@open-wc/testing-helpers';
+import { createInjector, destroyInjector } from '@spryker-oryx/di';
+import { LocaleService } from '@spryker-oryx/i18n';
+import { siteProviders } from '@spryker-oryx/site';
+import { useComponent } from '@spryker-oryx/utilities';
+import { html } from 'lit';
+import { of } from 'rxjs';
+import { SiteDayComponent } from './day.component';
+import { siteDayComponent } from './day.def';
+
+class MockLocaleService implements Partial<LocaleService> {
+  get = vi.fn().mockReturnValue(of('en'));
+  formatDay = vi.fn();
+}
+
+describe('SiteDayComponent', () => {
+  let element: SiteDayComponent;
+  let localeService: MockLocaleService;
+
+  beforeAll(async () => {
+    await useComponent([siteDayComponent]);
+  });
+
+  beforeEach(async () => {
+    const injector = createInjector({
+      providers: [
+        ...siteProviders,
+        {
+          provide: LocaleService,
+          useClass: MockLocaleService,
+        },
+      ],
+    });
+
+    localeService = injector.inject(
+      LocaleService
+    ) as unknown as MockLocaleService;
+  });
+
+  afterEach(() => {
+    destroyInjector();
+    vi.clearAllMocks();
+  });
+
+  describe('when the component is initialised', () => {
+    beforeEach(async () => {
+      element = await fixture(html`<oryx-day></oryx-day>`);
+    });
+
+    it('should be an instance of SiteDayComponent', () => {
+      expect(element).toBeInstanceOf(SiteDayComponent);
+    });
+  });
+
+  describe('when the current locale is "en"', () => {
+    beforeEach(async () => {
+      localeService.get.mockReturnValue(of('en'));
+    });
+
+    describe('and the day is monday', () => {
+      beforeEach(async () => {
+        localeService.formatDay.mockReturnValue('formatted-date');
+        element = await fixture(html`<oryx-day .day=${'monday'}></oryx-day>`);
+      });
+
+      it('should call the locale service to format the date', () => {
+        expect(localeService.formatDay).toHaveBeenCalledWith('monday');
+      });
+
+      it('should render the formatted date', () => {
+        expect(element.shadowRoot?.textContent?.trim()).toBe('formatted-date');
+      });
+    });
+  });
+
+  describe('when an i18n token is provided', () => {
+    beforeEach(async () => {
+      localeService.get.mockReturnValue(of('en'));
+      localeService.formatDay.mockReturnValue('formatted-date');
+    });
+
+    describe('and there is a day available', () => {
+      beforeEach(async () => {
+        element = await fixture(
+          html`<oryx-day
+            .day=${'monday'}
+            i18nToken="my.custom-<day>-day"
+          ></oryx-day>`
+        );
+      });
+
+      it('should render the token', () => {
+        expect(element.shadowRoot?.textContent?.trim()).toBe(
+          'Custom formatted-date day'
+        );
+      });
+    });
+
+    describe('and there is no day available', () => {
+      beforeEach(async () => {
+        element = await fixture(
+          html`<oryx-day i18nToken="my.custom-<day>-day"></oryx-day>`
+        );
+      });
+
+      it('should not render the token', () => {
+        expect(element.shadowRoot?.textContent?.trim()).toBe('');
+      });
+    });
+  });
+});

--- a/libs/domain/site/day/day.component.ts
+++ b/libs/domain/site/day/day.component.ts
@@ -1,0 +1,35 @@
+import { resolve } from '@spryker-oryx/di';
+import { ContentMixin } from '@spryker-oryx/experience';
+import { LocaleService } from '@spryker-oryx/i18n';
+import {
+  computed,
+  hydrate,
+  signalAware,
+  signalProperty,
+} from '@spryker-oryx/utilities';
+import { LitElement, TemplateResult, html } from 'lit';
+import { DayComponentAttributes } from './day.model';
+
+@hydrate()
+@signalAware()
+export class SiteDayComponent extends ContentMixin<DayComponentAttributes>(
+  LitElement
+) {
+  protected localeService = resolve(LocaleService);
+
+  @signalProperty() day?: string;
+  @signalProperty() i18nToken?: string;
+
+  protected $day = computed(() =>
+    this.day ? this.localeService.formatDay(this.day) : undefined
+  );
+
+  protected override render(): TemplateResult | void {
+    if (!this.$day()) return;
+    if (this.i18nToken) {
+      return html`${this.i18n(this.i18nToken, { day: this.$day() })}`;
+    } else {
+      return html`${this.$day()}`;
+    }
+  }
+}

--- a/libs/domain/site/day/day.def.ts
+++ b/libs/domain/site/day/day.def.ts
@@ -1,0 +1,7 @@
+import { componentDef } from '@spryker-oryx/utilities';
+
+export const siteDayComponent = componentDef({
+  name: 'oryx-day',
+  impl: () => import('./day.component').then((m) => m.SiteDayComponent),
+  schema: import('./day.schema').then((m) => m.siteDaySchema),
+});

--- a/libs/domain/site/day/day.def.ts
+++ b/libs/domain/site/day/day.def.ts
@@ -1,7 +1,7 @@
 import { componentDef } from '@spryker-oryx/utilities';
 
 export const siteDayComponent = componentDef({
-  name: 'oryx-day',
+  name: 'oryx-site-day',
   impl: () => import('./day.component').then((m) => m.SiteDayComponent),
   schema: import('./day.schema').then((m) => m.siteDaySchema),
 });

--- a/libs/domain/site/day/day.model.ts
+++ b/libs/domain/site/day/day.model.ts
@@ -1,0 +1,17 @@
+export interface DayComponentAttributes {
+  /**
+   * The value property represents the date in milliseconds.
+   */
+  day?: string;
+
+  /**
+   * The i18n token can be used to generate a day inside a text. The i18n token
+   * comes with a default token context parameter ("day"), which will generate the following
+   * i18n syntax:
+   *
+   * ```
+   * i18n('my.token-<day>', {day: 'monday'})
+   * ```
+   */
+  i18nToken?: string;
+}

--- a/libs/domain/site/day/day.schema.ts
+++ b/libs/domain/site/day/day.schema.ts
@@ -1,0 +1,8 @@
+import { ContentComponentSchema } from '@spryker-oryx/experience';
+import { SiteDayComponent } from './day.component';
+
+export const siteDaySchema: ContentComponentSchema<SiteDayComponent> = {
+  name: 'Day',
+  group: 'Site',
+  icon: 'event',
+};

--- a/libs/domain/site/day/index.ts
+++ b/libs/domain/site/day/index.ts
@@ -1,0 +1,3 @@
+export * from './day.component';
+export * from './day.model';
+export * from './day.schema';

--- a/libs/domain/site/day/stories/demo.stories.ts
+++ b/libs/domain/site/day/stories/demo.stories.ts
@@ -31,10 +31,10 @@ export default {
 const Template: Story<DayComponentAttributes> = (
   props: DayComponentAttributes
 ): TemplateResult => {
-  return html`<oryx-day
+  return html`<oryx-site-day
     .day=${props.day}
     .i18nToken=${props.i18nToken}
-  ></oryx-date>`;
+  ></oryx-site-date>`;
 };
 
 export const Demo = Template.bind({});

--- a/libs/domain/site/day/stories/demo.stories.ts
+++ b/libs/domain/site/day/stories/demo.stories.ts
@@ -1,0 +1,40 @@
+import { Story } from '@storybook/web-components';
+import { TemplateResult, html } from 'lit';
+import { storybookPrefix } from '../../.constants';
+import { DayComponentAttributes } from '../day.model';
+
+export default {
+  title: `${storybookPrefix}/day`,
+  args: {
+    day: 'monday',
+  },
+  argTypes: {
+    day: {
+      control: {
+        type: 'select',
+        options: [
+          'sunday',
+          'monday',
+          'tuesday',
+          'wednesday',
+          'thursday',
+          'friday',
+          'saturday',
+        ],
+      },
+    },
+    i18nToken: { control: { type: 'text' } },
+  },
+  parameters: { chromatic: { disableSnapshot: true } },
+};
+
+const Template: Story<DayComponentAttributes> = (
+  props: DayComponentAttributes
+): TemplateResult => {
+  return html`<oryx-day
+    .day=${props.day}
+    .i18nToken=${props.i18nToken}
+  ></oryx-date>`;
+};
+
+export const Demo = Template.bind({});

--- a/libs/domain/site/day/stories/static.stories.ts
+++ b/libs/domain/site/day/stories/static.stories.ts
@@ -1,0 +1,29 @@
+import { Story } from '@storybook/web-components';
+import { TemplateResult, html } from 'lit';
+import { storybookPrefix } from '../../.constants';
+
+export default {
+  title: `${storybookPrefix}/day`,
+};
+
+const Template: Story = (): TemplateResult => {
+  return html`
+    <oryx-day day="monday"></oryx-day>
+    <oryx-day .day=${'tuesday'}></oryx-day>
+    <oryx-day day="wednesday"></oryx-day>
+    <oryx-day day="thursday"></oryx-day>
+    <oryx-day day="friday"></oryx-day>
+    <oryx-day day="saturday"></oryx-day>
+    <oryx-day day="sunday"></oryx-day>
+    <h3>Inside token</h3>
+    <oryx-day day="monday" .i18nToken=${'before-<day>-after'}></oryx-day>
+
+    <style>
+      oryx-day {
+        display: block;
+      }
+    </style>
+  `;
+};
+
+export const Static = Template.bind({});

--- a/libs/domain/site/day/stories/static.stories.ts
+++ b/libs/domain/site/day/stories/static.stories.ts
@@ -8,18 +8,21 @@ export default {
 
 const Template: Story = (): TemplateResult => {
   return html`
-    <oryx-day day="monday"></oryx-day>
-    <oryx-day .day=${'tuesday'}></oryx-day>
-    <oryx-day day="wednesday"></oryx-day>
-    <oryx-day day="thursday"></oryx-day>
-    <oryx-day day="friday"></oryx-day>
-    <oryx-day day="saturday"></oryx-day>
-    <oryx-day day="sunday"></oryx-day>
+    <oryx-site-day day="monday"></oryx-site-day>
+    <oryx-site-day .day=${'tuesday'}></oryx-site-day>
+    <oryx-site-day day="wednesday"></oryx-site-day>
+    <oryx-site-day day="thursday"></oryx-site-day>
+    <oryx-site-day day="friday"></oryx-site-day>
+    <oryx-site-day day="saturday"></oryx-site-day>
+    <oryx-site-day day="sunday"></oryx-site-day>
     <h3>Inside token</h3>
-    <oryx-day day="monday" .i18nToken=${'before-<day>-after'}></oryx-day>
+    <oryx-site-day
+      day="monday"
+      .i18nToken=${'before-<day>-after'}
+    ></oryx-site-day>
 
     <style>
-      oryx-day {
+      oryx-site-day {
         display: block;
       }
     </style>

--- a/libs/domain/site/src/components.ts
+++ b/libs/domain/site/src/components.ts
@@ -1,6 +1,7 @@
 export * from '../breadcrumb/breadcrumb.def';
 export * from '../currency-selector/currency-selector.def';
 export * from '../date/date.def';
+export * from '../day/day.def';
 export * from '../locale-selector/locale-selector.def';
 export * from '../navigation-button/navigation-button.def';
 export * from '../navigation-item/navigation-item.def';

--- a/libs/platform/i18n/src/lib/locale/default-locale.service.spec.ts
+++ b/libs/platform/i18n/src/lib/locale/default-locale.service.spec.ts
@@ -1,6 +1,6 @@
 import { QueryService } from '@spryker-oryx/core';
 import { inject, Injector } from '@spryker-oryx/di';
-import { EMPTY, from, of } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 import { LocaleAdapter } from './adapter';
 import { DefaultLocaleService } from './default-locale.service';
 import { LocaleChanged } from './state';
@@ -130,6 +130,15 @@ describe('DefaultLocaleService', () => {
           year: 'numeric',
         }).format(date)
       );
+    });
+
+    it('should return a locale formatted day', () => {
+      const day = 'monday';
+      const cb = vi.fn();
+
+      getService().formatDay(day).subscribe(cb);
+
+      expect(cb).toHaveBeenCalled();
     });
   });
 });

--- a/libs/platform/i18n/src/lib/locale/default-locale.service.ts
+++ b/libs/platform/i18n/src/lib/locale/default-locale.service.ts
@@ -24,6 +24,7 @@ export class DefaultLocaleService implements LocaleService {
   protected dateFormat$: Observable<Intl.DateTimeFormat>;
   protected timeFormat$: Observable<Intl.DateTimeFormat>;
   protected dateTimeFormat$: Observable<Intl.DateTimeFormat>;
+  protected weekDayFormat$: Observable<Intl.DateTimeFormat>;
 
   constructor(
     protected adapter = inject(LocaleAdapter, null) ??
@@ -70,6 +71,16 @@ export class DefaultLocaleService implements LocaleService {
       ),
       shareReplay({ refCount: true, bufferSize: 1 })
     );
+
+    this.weekDayFormat$ = this.get().pipe(
+      map((locale) =>
+        Intl.DateTimeFormat(locale.replace('_', '-'), {
+          weekday: 'long',
+          timeZone: 'UTC',
+        })
+      ),
+      shareReplay({ refCount: true, bufferSize: 1 })
+    );
   }
 
   getAll(): Observable<Locale[]> {
@@ -110,6 +121,30 @@ export class DefaultLocaleService implements LocaleService {
       map((dateTimeFormat) =>
         dateTimeFormat.format(stamp instanceof Date ? stamp : new Date(stamp))
       )
+    );
+  }
+
+  formatDay(dayName: string): Observable<string> {
+    return this.weekDayFormat$.pipe(
+      map((formatter) => {
+        const date = new Date();
+        const now = date.getDay();
+        const days = [
+          'sunday',
+          'monday',
+          'tuesday',
+          'wednesday',
+          'thursday',
+          'friday',
+          'saturday',
+        ];
+        const day = days.indexOf(dayName.toLowerCase());
+
+        let diff = day - now;
+        diff = diff < 1 ? 7 + diff : diff;
+
+        return formatter.format(date.setDate(date.getDate() + diff));
+      })
     );
   }
 }

--- a/libs/platform/i18n/src/lib/locale/locale.service.ts
+++ b/libs/platform/i18n/src/lib/locale/locale.service.ts
@@ -6,6 +6,7 @@ export interface LocaleService {
   get(): Observable<string>;
   set(value: string): void;
   formatDate(stamp: string | number | Date): Observable<string>;
+  formatDay(day: string): Observable<string>;
   formatTime(stamp: string | number | Date): Observable<string>;
   formatDateTime(stamp: string | number | Date): Observable<string>;
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -261,6 +261,7 @@
         "libs/domain/site/currency-selector/index.ts"
       ],
       "@spryker-oryx/site/date": ["libs/domain/site/date/index.ts"],
+      "@spryker-oryx/site/day": ["libs/domain/site/day/index.ts"],
       "@spryker-oryx/site/locale-selector": [
         "libs/domain/site/locale-selector/index.ts"
       ],


### PR DESCRIPTION
The day component takes the english weekday as an input and creates the localised variation for the current locale. 

closes: [HRZ-90756](https://spryker.atlassian.net/browse/HRZ-90756)

[HRZ-90756]: https://spryker.atlassian.net/browse/HRZ-90756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ