### PR TITLE
test: commented parallel tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,10 +131,11 @@ jobs:
   test-e2e-storefront:
     runs-on: ubuntu-latest
     needs: [test-format, test-lint, test-stylelint, test-tsconfig]
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        parallelism: [1, 2, 3]
+#    # Commented out while we are still having long unit test runs
+#    strategy:
+#      matrix:
+#        os: [ubuntu-latest]
+#        parallelism: [1, 2, 3]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,11 +131,11 @@ jobs:
   test-e2e-storefront:
     runs-on: ubuntu-latest
     needs: [test-format, test-lint, test-stylelint, test-tsconfig]
-#    # Commented out while we are still having long unit test runs
-#    strategy:
-#      matrix:
-#        os: [ubuntu-latest]
-#        parallelism: [1, 2, 3]
+    #    # Commented out while we are still having long unit test runs
+    #    strategy:
+    #      matrix:
+    #        os: [ubuntu-latest]
+    #        parallelism: [1, 2, 3]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Disabled parallelism for storefront e2e tests as long as we still have issues with chrome updates and our unit tests are running for about 10 minutes, so we are not saving time here at all.
