### PR TITLE
feat: default entity type context

### DIFF
--- a/libs/platform/core/src/services/entity/default-entity.service.spec.ts
+++ b/libs/platform/core/src/services/entity/default-entity.service.spec.ts
@@ -98,17 +98,26 @@ describe('DefaultEntityService', () => {
 
   describe('get method with type inference', () => {
     it('should fetch type from context and return entity data', async () => {
-      mockContextService.get.mockImplementation((element, context) => of('testType'));
-      const data = await firstValueFrom(service.get({ element: 'someElement' as any }));
-      expect(mockContextService.get).toHaveBeenCalledWith('someElement', EntityContext);
+      mockContextService.get.mockImplementation((element, context) =>
+        of('testType')
+      );
+      const data = await firstValueFrom(
+        service.get({ element: 'someElement' as any })
+      );
+      expect(mockContextService.get).toHaveBeenCalledWith(
+        'someElement',
+        EntityContext
+      );
       expect(data).toEqual(mockResult);
     });
 
     it('should throw an error when type cannot be resolved from context', async () => {
-      mockContextService.get.mockImplementation((element, context) => of(undefined as any));
+      mockContextService.get.mockImplementation((element, context) =>
+        of(undefined as any)
+      );
 
       await expect(
-        firstValueFrom(service.get({ element: 'unknownElement' as any}))
+        firstValueFrom(service.get({ element: 'unknownElement' as any }))
       ).rejects.toThrow('No type resolved and no type provided for entity');
     });
   });

--- a/libs/platform/core/src/services/entity/default-entity.service.spec.ts
+++ b/libs/platform/core/src/services/entity/default-entity.service.spec.ts
@@ -1,4 +1,4 @@
-import { provideEntity } from '@spryker-oryx/core';
+import { EntityContext, provideEntity } from '@spryker-oryx/core';
 import { createInjector, destroyInjector, getInjector } from '@spryker-oryx/di';
 import { firstValueFrom, of } from 'rxjs';
 import { ContextService } from '../context';
@@ -93,6 +93,23 @@ describe('DefaultEntityService', () => {
         service.get({ type: 'customType', qualifier: 'someQualifier' })
       );
       expect(result).toEqual({ customData: 'someQualifier' });
+    });
+  });
+
+  describe('get method with type inference', () => {
+    it('should fetch type from context and return entity data', async () => {
+      mockContextService.get.mockImplementation((element, context) => of('testType'));
+      const data = await firstValueFrom(service.get({ element: 'someElement' as any }));
+      expect(mockContextService.get).toHaveBeenCalledWith('someElement', EntityContext);
+      expect(data).toEqual(mockResult);
+    });
+
+    it('should throw an error when type cannot be resolved from context', async () => {
+      mockContextService.get.mockImplementation((element, context) => of(undefined as any));
+
+      await expect(
+        firstValueFrom(service.get({ element: 'unknownElement' as any}))
+      ).rejects.toThrow('No type resolved and no type provided for entity');
     });
   });
 });

--- a/libs/platform/core/src/services/entity/entity.context.ts
+++ b/libs/platform/core/src/services/entity/entity.context.ts
@@ -1,0 +1,1 @@
+export const EntityContext = 'entity';

--- a/libs/platform/core/src/services/entity/index.ts
+++ b/libs/platform/core/src/services/entity/index.ts
@@ -1,3 +1,4 @@
 export * from './default-entity.service';
 export * from './entity-provider';
+export * from './entity.context';
 export * from './entity.service';

--- a/libs/platform/router/src/feature.ts
+++ b/libs/platform/router/src/feature.ts
@@ -1,12 +1,13 @@
-import { AppFeature } from '@spryker-oryx/core';
+import { AppFeature, ContextFallback, EntityContext } from '@spryker-oryx/core';
 import { Provider } from '@spryker-oryx/di';
 import { featureVersion } from '@spryker-oryx/utilities';
 import {
   DefaultLinkService,
   DefaultRouterService,
   LinkService,
-  routerHydration,
   RouterService,
+  routeEntityContextFallbackFactory,
+  routerHydration,
 } from './services';
 
 export class RouterFeature implements AppFeature {
@@ -19,6 +20,10 @@ export class RouterFeature implements AppFeature {
         ? [{ provide: LinkService, useClass: DefaultLinkService }]
         : []),
       routerHydration,
+      {
+        provide: `${ContextFallback}${EntityContext}`,
+        useFactory: routeEntityContextFallbackFactory,
+      },
     ];
   }
 }

--- a/libs/platform/router/src/services/index.ts
+++ b/libs/platform/router/src/services/index.ts
@@ -3,3 +3,4 @@ export * from './default-router.service';
 export * from './link';
 export * from './router-hydration';
 export * from './router.service';
+export * from './route-entity-context-fallback';

--- a/libs/platform/router/src/services/index.ts
+++ b/libs/platform/router/src/services/index.ts
@@ -1,6 +1,6 @@
 export * from './base-route';
 export * from './default-router.service';
 export * from './link';
+export * from './route-entity-context-fallback';
 export * from './router-hydration';
 export * from './router.service';
-export * from './route-entity-context-fallback';

--- a/libs/platform/router/src/services/route-entity-context-fallback.ts
+++ b/libs/platform/router/src/services/route-entity-context-fallback.ts
@@ -1,0 +1,9 @@
+import { inject } from '@spryker-oryx/di';
+import { map, Observable } from 'rxjs';
+import { RouterService } from './router.service';
+
+export function routeEntityContextFallbackFactory(
+  router = inject(RouterService)
+): Observable<string | undefined> {
+  return router.current().pipe(map((route) => route.type ?? undefined));
+}


### PR DESCRIPTION
Introduces:
- EntityContext used to resolve default entity type in EntityService
- RouteEntityContextFallback that resolves default entity type from the route type

Closes [HRZ-9081](https://spryker.atlassian.net/browse/HRZ-90811)