### PR TITLE
feat(experience): link support for entity text

### DIFF
--- a/libs/domain/merchant/src/services/merchant.context.ts
+++ b/libs/domain/merchant/src/services/merchant.context.ts
@@ -22,10 +22,10 @@ function merchantContextFallbackFactory(
   context = inject(ContextService),
   product = inject(ProductService)
 ): Observable<unknown> {
-  return router.currentParams().pipe(
-    switchMap((params) =>
-      params?.merchant
-        ? context.deserialize(MerchantContext.ID, params?.merchant as string)
+  return router.current().pipe(
+    switchMap((route) =>
+      route.type === 'merchant'
+        ? of(route.params)
         : context.get<ProductQualifier>(null, ProductContext.SKU).pipe(
             switchMap((qualifier: ProductQualifier | undefined) =>
               qualifier ? product.get(qualifier) : of(undefined)

--- a/libs/platform/core/src/services/entity/default-entity.service.spec.ts
+++ b/libs/platform/core/src/services/entity/default-entity.service.spec.ts
@@ -133,7 +133,7 @@ describe('DefaultEntityService', () => {
           element: 'someElement' as any,
         })
       );
-      expect(qualifier).toBe('mockContext');
+      expect(qualifier).toEqual({ type: 'testType', qualifier: 'mockContext' });
       expect(mockContextService.get).toHaveBeenCalledTimes(1);
       expect(mockContextService.get).toHaveBeenCalledWith(
         'someElement',
@@ -146,7 +146,7 @@ describe('DefaultEntityService', () => {
         of(context === 'entity' ? 'testType' : 'mockContext')
       );
       const qualifier = await firstValueFrom(service.getQualifier({}));
-      expect(qualifier).toBe('mockContext');
+      expect(qualifier).toEqual({ type: 'testType', qualifier: 'mockContext' });
       expect(mockContextService.get).toHaveBeenCalledTimes(2);
       expect(mockContextService.get).toHaveBeenCalledWith(null, 'entity');
       expect(mockContextService.get).toHaveBeenCalledWith(null, 'mockContext');

--- a/libs/platform/core/src/services/entity/default-entity.service.spec.ts
+++ b/libs/platform/core/src/services/entity/default-entity.service.spec.ts
@@ -121,4 +121,56 @@ describe('DefaultEntityService', () => {
       ).rejects.toThrow('No type resolved and no type provided for entity');
     });
   });
+
+  describe('getQualifier method', () => {
+    it('should return the correct qualifier', async () => {
+      mockContextService.get.mockImplementation((element, context) =>
+        of('mockContext')
+      );
+      const qualifier = await firstValueFrom(
+        service.getQualifier({
+          type: 'testType',
+          element: 'someElement' as any,
+        })
+      );
+      expect(qualifier).toBe('mockContext');
+      expect(mockContextService.get).toHaveBeenCalledTimes(1);
+      expect(mockContextService.get).toHaveBeenCalledWith(
+        'someElement',
+        'mockContext'
+      );
+    });
+
+    it('should return the correct qualifier inferring type', async () => {
+      mockContextService.get.mockImplementation((element, context) =>
+        of(context === 'entity' ? 'testType' : 'mockContext')
+      );
+      const qualifier = await firstValueFrom(service.getQualifier({}));
+      expect(qualifier).toBe('mockContext');
+      expect(mockContextService.get).toHaveBeenCalledTimes(2);
+      expect(mockContextService.get).toHaveBeenCalledWith(null, 'entity');
+      expect(mockContextService.get).toHaveBeenCalledWith(null, 'mockContext');
+    });
+
+    it('should throw an error if type is missing and cannot be resolved', async () => {
+      mockContextService.get.mockImplementation((element, context) =>
+        of(undefined as any)
+      );
+
+      await expect(
+        firstValueFrom(
+          service.getQualifier({ element: 'unknownElement' as any })
+        )
+      ).rejects.toThrow('No type resolved and no type provided for entity');
+    });
+
+    it('should throw an error if context is missing for the qualifier', async () => {
+      // Assuming there is no context defined for 'typeWithoutContext'
+      await expect(
+        firstValueFrom(service.getQualifier({ type: 'typeWithoutContext' }))
+      ).rejects.toThrow(
+        'No entity provider found for entity typeWithoutContext'
+      );
+    });
+  });
 });

--- a/libs/platform/core/src/services/entity/default-entity.service.ts
+++ b/libs/platform/core/src/services/entity/default-entity.service.ts
@@ -46,10 +46,15 @@ export class DefaultEntityService implements EntityService {
   getQualifier<E = unknown, Q = unknown>({
     element,
     type,
-  }: Omit<EntityQualifier<Q>, 'qualifier'>): Observable<Q | undefined> {
+  }: Omit<EntityQualifier<Q>, 'qualifier'>): Observable<{
+    type: string;
+    qualifier: Q | undefined;
+  }> {
     return this.resolveConfig<E, Q>({ element, type }).pipe(
       switchMap(({ config, type }) => {
-        return this.resolveQualifier({ type, element }, config);
+        return this.resolveQualifier({ type, element }, config).pipe(
+          map((qualifier) => ({ type, qualifier }))
+        );
       })
     );
   }

--- a/libs/platform/core/src/services/entity/default-entity.service.ts
+++ b/libs/platform/core/src/services/entity/default-entity.service.ts
@@ -18,46 +18,11 @@ export class DefaultEntityService implements EntityService {
     element,
     type,
   }: EntityQualifier<Q>): Observable<E | undefined> {
-    let type$: Observable<string | undefined>;
-
-    if (!type) {
-      type$ = this.context.get<string>(element ?? null, EntityContext);
-    } else {
-      type$ = of(type);
-    }
-
-    return type$.pipe(
-      switchMap((resolvedType) => {
-        if (!resolvedType) {
-          return throwError(
-            () => new Error(`No type resolved and no type provided for entity`)
-          );
-        }
-
-        const config = this.getConfig<E, Q>(resolvedType);
-
-        if (!config) {
-          return throwError(
-            () =>
-              new Error(`No entity provider found for entity ${resolvedType}`)
-          );
-        }
-
-        let qualifier$: Observable<Q | undefined>;
-
-        if (!qualifier) {
-          if (!config.context) {
-            return throwError(
-              () =>
-                new Error(
-                  `No context or qualifier provided for entity ${resolvedType}`
-                )
-            );
-          }
-          qualifier$ = this.context.get<Q>(element ?? null, config.context);
-        } else {
-          qualifier$ = of(qualifier);
-        }
+    return this.resolveConfig<E, Q>({ element, type }).pipe(
+      switchMap(({ config, type }) => {
+        const qualifier$: Observable<Q | undefined> = qualifier
+          ? of(qualifier)
+          : this.resolveQualifier({ type, element }, config);
 
         return qualifier$.pipe(
           switchMap((qualifier) =>
@@ -78,8 +43,62 @@ export class DefaultEntityService implements EntityService {
     );
   }
 
+  getQualifier<E = unknown, Q = unknown>({
+    element,
+    type,
+  }: Omit<EntityQualifier<Q>, 'qualifier'>): Observable<Q | undefined> {
+    return this.resolveConfig<E, Q>({ element, type }).pipe(
+      switchMap(({ config, type }) => {
+        return this.resolveQualifier({ type, element }, config);
+      })
+    );
+  }
+
   getContextKey(type: string): Observable<string | null> {
     return of(this.injector.inject(`${EntityProvider}${type}`, null)?.context);
+  }
+
+  protected resolveConfig<E = unknown, Q = unknown>({
+    element,
+    type,
+  }: Pick<EntityQualifier<Q>, 'element' | 'type'>): Observable<{
+    config: EntityProvider<E, Q>;
+    type: string;
+  }> {
+    let type$: Observable<string | undefined>;
+
+    if (!type) {
+      type$ = this.context.get<string>(element ?? null, EntityContext);
+    } else {
+      type$ = of(type);
+    }
+
+    return type$.pipe(
+      map((type) => {
+        if (!type) {
+          throw new Error(`No type resolved and no type provided for entity`);
+        }
+
+        const config = this.getConfig<E, Q>(type);
+
+        if (!config) {
+          throw new Error(`No entity provider found for entity ${type}`);
+        }
+        return { config, type };
+      })
+    );
+  }
+
+  protected resolveQualifier<E = unknown, Q = unknown>(
+    { type, element }: Pick<EntityQualifier<Q>, 'type' | 'element'>,
+    { context }: EntityProvider<E, Q>
+  ): Observable<Q | undefined> {
+    if (!context) {
+      return throwError(
+        () => new Error(`No context or qualifier provided for entity ${type}`)
+      );
+    }
+    return this.context.get<Q>(element ?? null, context);
   }
 
   protected getConfig<E, Q>(type: string): EntityProvider<E, Q> {

--- a/libs/platform/core/src/services/entity/entity.service.ts
+++ b/libs/platform/core/src/services/entity/entity.service.ts
@@ -22,6 +22,9 @@ export interface EntityService {
   getField<T = unknown>(
     entity: EntityFieldQualifier<T>
   ): Observable<T | undefined>;
+  getQualifier<T = unknown>(
+    entity: Omit<EntityQualifier<T>, 'qualifier'>
+  ): Observable<T | undefined>;
   getContextKey(type: string): Observable<string | null>;
 }
 

--- a/libs/platform/core/src/services/entity/entity.service.ts
+++ b/libs/platform/core/src/services/entity/entity.service.ts
@@ -24,7 +24,7 @@ export interface EntityService {
   ): Observable<T | undefined>;
   getQualifier<T = unknown>(
     entity: Omit<EntityQualifier<T>, 'qualifier'>
-  ): Observable<T | undefined>;
+  ): Observable<{ type: string; qualifier: T | undefined }>;
   getContextKey(type: string): Observable<string | null>;
 }
 

--- a/libs/platform/experience/entity-text/entity-text.component.ts
+++ b/libs/platform/experience/entity-text/entity-text.component.ts
@@ -35,13 +35,12 @@ export class EntityTextComponent extends TextMixin(
     const { entity: type } = this.$options();
 
     return this.entityService.getQualifier({ element: this, type }).pipe(
-      switchMap(({ type, qualifier }) => {
-        console.log(qualifier, type);
-        return this.linkService.get({
+      switchMap(({ type, qualifier }) =>
+        this.linkService.get({
           type,
           qualifier,
-        });
-      }),
+        })
+      ),
       catchError(() => of())
     );
   });

--- a/libs/platform/experience/entity-text/entity-text.component.ts
+++ b/libs/platform/experience/entity-text/entity-text.component.ts
@@ -1,4 +1,4 @@
-import { ContextService, EntityService } from '@spryker-oryx/core';
+import { EntityService } from '@spryker-oryx/core';
 import { resolve } from '@spryker-oryx/di';
 import { ContentMixin } from '@spryker-oryx/experience';
 import { LinkService } from '@spryker-oryx/router';
@@ -17,7 +17,6 @@ export class EntityTextComponent extends TextMixin(
 ) {
   protected entityService = resolve(EntityService);
   protected linkService = resolve(LinkService);
-  protected contextService = resolve(ContextService);
 
   protected $data = computed<string | undefined>(() => {
     const { entity: type, field } = this.$options();
@@ -42,7 +41,8 @@ export class EntityTextComponent extends TextMixin(
           type,
           qualifier,
         })
-      )
+      ),
+      catchError(() => of())
     );
   });
 

--- a/libs/platform/experience/entity-text/entity-text.component.ts
+++ b/libs/platform/experience/entity-text/entity-text.component.ts
@@ -68,7 +68,6 @@ export class EntityTextComponent extends TextMixin(
     | void {
     const text = this.$text();
     const link = this.$link();
-    console.log(link);
 
     if (!link) return text;
 

--- a/libs/platform/experience/entity-text/entity-text.component.ts
+++ b/libs/platform/experience/entity-text/entity-text.component.ts
@@ -8,7 +8,7 @@ import { LitElement, TemplateResult } from 'lit';
 import { DirectiveResult } from 'lit/directive';
 import { UnsafeHTMLDirective } from 'lit/directives/unsafe-html';
 import { html } from 'lit/static-html.js';
-import { catchError, of, switchMap } from 'rxjs';
+import { catchError, of } from 'rxjs';
 import { EntityTextOptions } from './entity-text.model';
 
 @hydrate()
@@ -31,18 +31,15 @@ export class EntityTextComponent extends TextMixin(
     return this.convertText(text);
   });
 
-  protected $link = computed(() => {
-    const { entity: type } = this.$options();
+  protected $linkQualifier = computed(() =>
+    this.entityService
+      .getQualifier({ element: this, type: this.$options().entity })
+      .pipe(catchError(() => of()))
+  );
 
-    return this.entityService.getQualifier({ element: this, type }).pipe(
-      switchMap(({ type, qualifier }) =>
-        this.linkService.get({
-          type,
-          qualifier,
-        })
-      ),
-      catchError(() => of())
-    );
+  protected $link = computed(() => {
+    const qualifier = this.$linkQualifier();
+    return qualifier ? this.linkService.get(qualifier) : undefined;
   });
 
   protected override render(): TemplateResult | void {

--- a/libs/platform/experience/entity-text/entity-text.component.ts
+++ b/libs/platform/experience/entity-text/entity-text.component.ts
@@ -33,15 +33,15 @@ export class EntityTextComponent extends TextMixin(
 
   protected $link = computed(() => {
     const { entity: type } = this.$options();
-    if (!type) return;
 
     return this.entityService.getQualifier({ element: this, type }).pipe(
-      switchMap((qualifier) =>
-        this.linkService.get({
+      switchMap(({ type, qualifier }) => {
+        console.log(qualifier, type);
+        return this.linkService.get({
           type,
           qualifier,
-        })
-      ),
+        });
+      }),
       catchError(() => of())
     );
   });
@@ -69,6 +69,7 @@ export class EntityTextComponent extends TextMixin(
     | void {
     const text = this.$text();
     const link = this.$link();
+    console.log(link);
 
     if (!link) return text;
 

--- a/libs/platform/experience/entity-text/entity-text.component.ts
+++ b/libs/platform/experience/entity-text/entity-text.component.ts
@@ -8,7 +8,7 @@ import { LitElement, TemplateResult } from 'lit';
 import { DirectiveResult } from 'lit/directive';
 import { UnsafeHTMLDirective } from 'lit/directives/unsafe-html';
 import { html } from 'lit/static-html.js';
-import { catchError, of } from 'rxjs';
+import { catchError, of, switchMap } from 'rxjs';
 import { EntityTextOptions } from './entity-text.model';
 
 @hydrate()
@@ -33,14 +33,17 @@ export class EntityTextComponent extends TextMixin(
   });
 
   protected $link = computed(() => {
-    const { entity, field } = this.$options();
-    if (!entity || !field) return;
+    const { entity: type } = this.$options();
+    if (!type) return;
 
-    const qualifier = this.contextService.get(this, field);
-    return this.linkService.get({
-      type: entity,
-      qualifier,
-    });
+    return this.entityService.getQualifier({ element: this, type }).pipe(
+      switchMap((qualifier) =>
+        this.linkService.get({
+          type,
+          qualifier,
+        })
+      )
+    );
   });
 
   protected override render(): TemplateResult | void {
@@ -54,12 +57,10 @@ export class EntityTextComponent extends TextMixin(
   protected renderContent(): TemplateResult | void {
     const text = this.$text();
     if (!text) return;
-    // const { link } = this.$options();
-    // const content = html`${this.renderPrefix()}${link
-    //   ? this.renderLink()
-    //   : this.$text()} `;
-
-    return html`${this.renderPrefix()}${this.$text()}`;
+    const { link } = this.$options();
+    return html`${this.renderPrefix()}${link
+      ? this.renderLink()
+      : this.$text()} `;
   }
 
   protected renderLink():

--- a/libs/platform/experience/entity-text/entity-text.model.ts
+++ b/libs/platform/experience/entity-text/entity-text.model.ts
@@ -4,5 +4,5 @@ import { EntityFieldOptions } from '../src/models';
 export interface EntityTextOptions extends EntityFieldOptions {
   tag?: HeadingTag;
   prefix?: string;
-  // link?: boolean;
+  link?: boolean;
 }

--- a/libs/template/presets/storefront/experience/pages/merchant-page.ts
+++ b/libs/template/presets/storefront/experience/pages/merchant-page.ts
@@ -6,7 +6,7 @@ export const merchantPage: ExperienceComponent = {
   type: 'Page',
   meta: {
     title: 'Merchant',
-    route: '/merchant/:merchant',
+    route: '/merchant/:id',
     routeType: 'merchant',
     description: 'Default Merchant Page Description',
   },


### PR DESCRIPTION
Includes:
- link support for oryx-entity-text component
- ability to resolve entity qualifier from EntityService

closes [HRZ-90347](https://spryker.atlassian.net/browse/HRZ-90347)

[HRZ-90347]: https://spryker.atlassian.net/browse/HRZ-90347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ