### PR TITLE
chore: remove CMS content

### DIFF
--- a/libs/template/presets/storefront/experience/pages/home-page.ts
+++ b/libs/template/presets/storefront/experience/pages/home-page.ts
@@ -24,27 +24,27 @@ export const homePage: ExperienceComponent = {
   },
   components: [
     featureVersion >= '1.2' ? { ref: 'header' } : {},
-    {
-      type: 'oryx-composition',
-      options: {
-        context: {
-          article: {
-            id: 'Gift Guide Tue',
-          },
-          entity: 'article',
-        },
-      },
-      components: [
-        {
-          type: 'oryx-data-text',
-          options: { field: 'content' },
-        },
-        {
-          type: 'oryx-data-image',
-          options: { field: 'picture', rules: [] },
-        },
-      ],
-    },
+    // {
+    //   type: 'oryx-composition',
+    //   options: {
+    //     context: {
+    //       article: {
+    //         id: 'Gift Guide Tue',
+    //       },
+    //       entity: 'article',
+    //     },
+    //   },
+    //   components: [
+    //     {
+    //       type: 'oryx-data-text',
+    //       options: { field: 'content' },
+    //     },
+    //     {
+    //       type: 'oryx-data-image',
+    //       options: { field: 'picture', rules: [] },
+    //     },
+    //   ],
+    // },
     {
       type: 'oryx-composition',
       id: 'home-hero',
@@ -170,7 +170,7 @@ export const homePage: ExperienceComponent = {
         brand('HP'),
         brand('TomTom'),
         brand('DELL'),
-        brand('Fujitsu', [{ padding: '0 0 2px' }]),
+        brand('Fujitsu'),
         brand('Asus'),
         brand('Acer'),
       ],

--- a/libs/template/presets/storefront/experience/pages/home-page.ts
+++ b/libs/template/presets/storefront/experience/pages/home-page.ts
@@ -24,27 +24,6 @@ export const homePage: ExperienceComponent = {
   },
   components: [
     featureVersion >= '1.2' ? { ref: 'header' } : {},
-    // {
-    //   type: 'oryx-composition',
-    //   options: {
-    //     context: {
-    //       article: {
-    //         id: 'Gift Guide Tue',
-    //       },
-    //       entity: 'article',
-    //     },
-    //   },
-    //   components: [
-    //     {
-    //       type: 'oryx-data-text',
-    //       options: { field: 'content' },
-    //     },
-    //     {
-    //       type: 'oryx-data-image',
-    //       options: { field: 'picture', rules: [] },
-    //     },
-    //   ],
-    // },
     {
       type: 'oryx-composition',
       id: 'home-hero',


### PR DESCRIPTION
Some demo content accidentally sneaked into our experience data (only visible if you had set up some CMS integration). 