### PR TITLE
fix(experience): route.split error in pre 1.4 compatibility mode

### DIFF
--- a/libs/platform/experience/src/services/resolvers/content-page-meta.resolver.ts
+++ b/libs/platform/experience/src/services/resolvers/content-page-meta.resolver.ts
@@ -1,6 +1,7 @@
 import { ElementResolver, PageMetaResolver } from '@spryker-oryx/core';
 import { inject } from '@spryker-oryx/di';
 import { RouteWithParams, RouterService } from '@spryker-oryx/router';
+import { RouteConfig } from '@spryker-oryx/router/lit';
 import { featureVersion } from '@spryker-oryx/utilities';
 import { Observable, combineLatest, map, of, switchMap } from 'rxjs';
 import {
@@ -19,7 +20,11 @@ export class ContentPageMetaResolver implements PageMetaResolver {
   protected experienceData = this.experienceDataService.getData();
   protected getMeta$ = this.router.current().pipe(
     switchMap((routeConfig) => {
-      const staticMeta = this.getData(routeConfig);
+      const staticMeta = this.getData(
+        featureVersion >= '1.4'
+          ? routeConfig
+          : (routeConfig as RouteConfig).path ?? ''
+      );
 
       if (staticMeta) {
         return of(staticMeta);

--- a/libs/platform/experience/src/services/resolvers/content-page-meta.resolver.ts
+++ b/libs/platform/experience/src/services/resolvers/content-page-meta.resolver.ts
@@ -1,7 +1,7 @@
 import { ElementResolver, PageMetaResolver } from '@spryker-oryx/core';
 import { inject } from '@spryker-oryx/di';
 import { RouteWithParams, RouterService } from '@spryker-oryx/router';
-import { RouteConfig } from '@spryker-oryx/router/lit';
+import { PathRouteConfig } from '@spryker-oryx/router/lit';
 import { featureVersion } from '@spryker-oryx/utilities';
 import { Observable, combineLatest, map, of, switchMap } from 'rxjs';
 import {
@@ -19,12 +19,11 @@ export class ContentPageMetaResolver implements PageMetaResolver {
 
   protected experienceData = this.experienceDataService.getData();
   protected getMeta$ = this.router.current().pipe(
-    switchMap((routeConfig) => {
-      const staticMeta = this.getData(
+    switchMap((routeConfig: RouteWithParams) => {
+      const staticMeta =
         featureVersion >= '1.4'
-          ? routeConfig
-          : (routeConfig as RouteConfig).path ?? ''
-      );
+          ? this.getData(routeConfig)
+          : this.getData((routeConfig as PathRouteConfig).path ?? '');
 
       if (staticMeta) {
         return of(staticMeta);


### PR DESCRIPTION
Closes [HRZ-90970](https://spryker.atlassian.net/browse/HRZ-90970)


[HRZ-90970]: https://spryker.atlassian.net/browse/HRZ-90970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ