### PR TITLE
feat(ui): accessible collapsible component

### DIFF
--- a/apps/storefront-e2e/src/support/test-data/storages/product.storage.ts
+++ b/apps/storefront-e2e/src/support/test-data/storages/product.storage.ts
@@ -19,7 +19,7 @@ const products: Product[] = [
   },
   // product with product references
   {
-    id: '138_30657838',
+    id: '138_30046855',
     title: 'Acer TravelMate P258-M',
     originalPrice: '264.32',
   },

--- a/apps/storefront-e2e/src/support/test-data/storages/product.storage.ts
+++ b/apps/storefront-e2e/src/support/test-data/storages/product.storage.ts
@@ -19,7 +19,7 @@ const products: Product[] = [
   },
   // product with product references
   {
-    id: '138_30046855',
+    id: '138_30657838',
     title: 'Acer TravelMate P258-M',
     originalPrice: '264.32',
   },

--- a/libs/base/ui/form/checkbox/src/checkbox.styles.ts
+++ b/libs/base/ui/form/checkbox/src/checkbox.styles.ts
@@ -1,6 +1,6 @@
 import { featureVersion } from '@spryker-oryx/utilities';
 
-import { css } from 'lit';
+import { css, unsafeCSS } from 'lit';
 
 const focusStyles =
   featureVersion >= '1.4'
@@ -11,7 +11,7 @@ const focusStyles =
           border-radius: 1px;
         }
       `
-    : (`` as any);
+    : unsafeCSS(``);
 
 export const checkboxStyles = css`
   :host([disabled]) {

--- a/libs/base/ui/form/checkbox/src/checkbox.styles.ts
+++ b/libs/base/ui/form/checkbox/src/checkbox.styles.ts
@@ -1,4 +1,17 @@
+import { featureVersion } from '@spryker-oryx/utilities';
+
 import { css } from 'lit';
+
+const focusStyles =
+  featureVersion >= '1.4'
+    ? css`
+        ::slotted(input:focus-visible)::after {
+          outline: solid 1px var(--oryx-color-focus);
+          outline-offset: 4px;
+          border-radius: 1px;
+        }
+      `
+    : (`` as any);
 
 export const checkboxStyles = css`
   :host([disabled]) {
@@ -30,6 +43,8 @@ export const checkboxStyles = css`
     inset-block-start: 0;
     inset-inline-start: 0;
   }
+
+  ${focusStyles}
 
   ::slotted(input:not(:disabled))::after {
     cursor: pointer;

--- a/libs/base/ui/form/radio/src/radio.styles.ts
+++ b/libs/base/ui/form/radio/src/radio.styles.ts
@@ -1,5 +1,5 @@
 import { featureVersion, screenCss } from '@spryker-oryx/utilities';
-import { css } from 'lit';
+import { css, unsafeCSS } from 'lit';
 
 const focusStyles =
   featureVersion >= '1.4'
@@ -10,7 +10,7 @@ const focusStyles =
           border-radius: 1px;
         }
       `
-    : (`` as any);
+    : unsafeCSS(``);
 
 export const baseStyles = css`
   :host {

--- a/libs/base/ui/form/radio/src/radio.styles.ts
+++ b/libs/base/ui/form/radio/src/radio.styles.ts
@@ -1,5 +1,16 @@
-import { screenCss } from '@spryker-oryx/utilities';
+import { featureVersion, screenCss } from '@spryker-oryx/utilities';
 import { css } from 'lit';
+
+const focusStyles =
+  featureVersion >= '1.4'
+    ? css`
+        ::slotted(input:focus-visible)::after {
+          outline: solid 1px var(--oryx-color-focus);
+          outline-offset: 4px;
+          border-radius: 1px;
+        }
+      `
+    : (`` as any);
 
 export const baseStyles = css`
   :host {
@@ -40,6 +51,8 @@ export const baseStyles = css`
     inset-inline-start: 0;
     cursor: pointer;
   }
+
+  ${focusStyles}
 
   ::slotted(input:hover) {
     color: var(--oryx-color-neutral-9);

--- a/libs/base/ui/graphical/icon/src/icon.styles.ts
+++ b/libs/base/ui/graphical/icon/src/icon.styles.ts
@@ -9,6 +9,7 @@ export const styles = css`
     display: flex;
     align-items: center;
     justify-content: center;
+    user-select: none;
     height: var(--oryx-icon-size, var(--_size, 24px));
     width: var(--oryx-icon-size, var(--_size, 24px));
     color: var(--oryx-icon-color, inherit);

--- a/libs/base/ui/structure/collapsible/src/collapsible.component.spec.ts
+++ b/libs/base/ui/structure/collapsible/src/collapsible.component.spec.ts
@@ -78,6 +78,22 @@ describe('CollapsibleComponent', () => {
       const button = element.renderRoot.querySelector('oryx-button');
       expect(button).toHaveProperty('size', ButtonSize.Sm);
     });
+
+    describe('and the version >= 1.4', () => {
+      beforeEach(async () => {
+        mockFeatureVersion('1.4');
+        element = await fixture(
+          html`<oryx-collapsible
+            .appearance=${CollapsibleAppearance.Block}
+          ></oryx-collapsible>`
+        );
+      });
+
+      it('should have a medium sized oryx-icon', () => {
+        const button = element.renderRoot.querySelector('oryx-icon');
+        expect(button).toHaveProperty('size', ButtonSize.Md);
+      });
+    });
   });
 
   describe('when the appearance is inline', () => {

--- a/libs/base/ui/structure/collapsible/src/collapsible.component.ts
+++ b/libs/base/ui/structure/collapsible/src/collapsible.component.ts
@@ -43,14 +43,16 @@ export class CollapsibleComponent
         @toggle=${this.onToggle}
       >
         <summary
-          .part=${featureVersion >= '1.4' ? undefined : 'heading'}
+          part=${ifDefined(featureVersion >= '1.4' ? undefined : 'heading')}
           tabindex=${ifDefined(nonTabbable ? -1 : undefined)}
         >
-          <slot name="heading">${this.heading}</slot>
+          <slot name="heading"> ${this.heading} </slot>
           ${this.renderToggleControl()}
           <slot name="aside"></slot>
         </summary>
-        <slot .part=${featureVersion >= '1.4' ? undefined : 'content'}></slot>
+        <slot
+          name=${ifDefined(featureVersion >= '1.4' ? undefined : 'content')}
+        ></slot>
       </details>
     `;
   }

--- a/libs/base/ui/structure/collapsible/src/collapsible.component.ts
+++ b/libs/base/ui/structure/collapsible/src/collapsible.component.ts
@@ -79,7 +79,10 @@ export class CollapsibleComponent
         ? IconTypes.Minus
         : IconTypes.Add;
 
-    if (this.appearance === CollapsibleAppearance.Block) {
+    if (
+      featureVersion >= '1.4' &&
+      this.appearance === CollapsibleAppearance.Block
+    ) {
       return html`<oryx-icon .type=${icon} .size=${Size.Md}></oryx-icon>`;
     }
 

--- a/libs/base/ui/structure/collapsible/src/collapsible.def.ts
+++ b/libs/base/ui/structure/collapsible/src/collapsible.def.ts
@@ -1,23 +1,26 @@
-import { componentDef } from '@spryker-oryx/utilities';
+import { componentDef, featureVersion } from '@spryker-oryx/utilities';
 
 export const collapsibleComponent = componentDef({
   name: 'oryx-collapsible',
   impl: () =>
     import('./collapsible.component').then((m) => m.CollapsibleComponent),
-  stylesheets: [
-    {
-      theme: 'backoffice',
-      rules: () =>
-        import('./styles/themes/backoffice.styles').then(
-          (m) => m.collapsibleBackofficeUI
-        ),
-    },
-    {
-      theme: 'storefront',
-      rules: () =>
-        import('./styles/themes/storefront.styles').then(
-          (m) => m.collapsibleStorefrontUI
-        ),
-    },
-  ],
+  stylesheets:
+    featureVersion >= '1.4'
+      ? []
+      : [
+          {
+            theme: 'backoffice',
+            rules: () =>
+              import('./styles/themes/backoffice.styles').then(
+                (m) => m.collapsibleBackofficeUI
+              ),
+          },
+          {
+            theme: 'storefront',
+            rules: () =>
+              import('./styles/themes/storefront.styles').then(
+                (m) => m.collapsibleStorefrontUI
+              ),
+          },
+        ],
 });

--- a/libs/base/ui/structure/collapsible/src/collapsible.styles.ts
+++ b/libs/base/ui/structure/collapsible/src/collapsible.styles.ts
@@ -23,6 +23,19 @@ const commonStyles = css`
     justify-content: space-between;
     gap: 8px;
     align-items: center;
+    font-size: var(
+      --oryx-collapsible-text-size,
+      var(--oryx-typography-h6-size)
+    );
+    font-weight: var(
+      --oryx-collapsible-text-weight,
+      var(--oryx-typography-h6-weight)
+    );
+    line-height: var(
+      --oryx-collapsible-text-height,
+      var(--oryx-typography-h6-height)
+    );
+    text-transform: var(--oryx-collapsible-text-transform);
   }
 
   summary:focus-visible {

--- a/libs/base/ui/structure/collapsible/src/collapsible.styles.ts
+++ b/libs/base/ui/structure/collapsible/src/collapsible.styles.ts
@@ -1,0 +1,93 @@
+import { css, unsafeCSS } from 'lit';
+import { CollapsibleAppearance } from './collapsible.model';
+
+const blockSelector = unsafeCSS(`[appearance=${CollapsibleAppearance.Block}]`);
+const inlineSelector = unsafeCSS(
+  `[appearance=${CollapsibleAppearance.Inline}]`
+);
+
+const commonStyles = css`
+  :host {
+    --_radius: var(
+      --oryx-collapsible-border-radius,
+      var(--oryx-border-radius-small)
+    );
+
+    display: block;
+  }
+
+  summary {
+    border-radius: var(--_radius);
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    align-items: center;
+  }
+
+  summary:focus-visible {
+    outline: solid 1px var(--oryx-color-focus);
+  }
+`;
+
+const inlineStyles = css`
+  :host(${inlineSelector}) summary {
+    pointer-events: none;
+  }
+
+  :host(${inlineSelector}) oryx-button {
+    pointer-events: all;
+  }
+`;
+
+const blockStyles = css`
+  :host(${blockSelector}) {
+    background: var(--oryx-collapsible-background);
+    border-radius: var(--_radius);
+    border: var(
+      --oryx-collapsible-border,
+      solid 1px var(--oryx-color-neutral-6)
+    );
+  }
+
+  :host(${blockSelector}),
+  :host(${blockSelector}) summary {
+    transition: background-color var(--oryx-transition-time),
+      border var(--oryx-transition-time);
+  }
+
+  :host(${blockSelector}) summary:hover {
+    background: var(--oryx-collapsible-hover);
+  }
+
+  :host(${blockSelector}) details[open] summary:not(:focus-visible) {
+    border-block-end: var(--oryx-collapsible-divider);
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
+  }
+
+  :host(${blockSelector}:hover) {
+    border: var(
+      --oryx-collapsible-border,
+      solid 1px var(--oryx-color-neutral-9)
+    );
+  }
+
+  :host(${blockSelector}) :is(summary, summary + *) {
+    padding: 12px;
+  }
+
+  :host(${blockSelector}) slot:not([name]) {
+    display: block;
+  }
+
+  oryx-icon {
+    margin-inline-end: -4px;
+  }
+`;
+
+export const collapsibleStyles = css`
+  ${commonStyles}
+  ${blockStyles}
+  ${inlineStyles}
+`;

--- a/libs/base/ui/structure/collapsible/src/index.ts
+++ b/libs/base/ui/structure/collapsible/src/index.ts
@@ -1,3 +1,4 @@
 export * from './collapsible.component';
 export * from './collapsible.model';
+export * from './collapsible.styles';
 export * from './styles';

--- a/libs/base/ui/structure/collapsible/src/styles/base.styles.ts
+++ b/libs/base/ui/structure/collapsible/src/styles/base.styles.ts
@@ -1,13 +1,23 @@
 import { css, unsafeCSS } from 'lit';
 import { CollapsibleAppearance } from '../collapsible.model';
 
+/**
+ * @deprecated since 1.4.
+ */
 export const blockSelector = unsafeCSS(
   `[appearance=${CollapsibleAppearance.Block}]`
 );
+
+/**
+ * @deprecated since 1.4.
+ */
 export const inlineSelector = unsafeCSS(
   `[appearance=${CollapsibleAppearance.Inline}]`
 );
 
+/**
+ * @deprecated since 1.4, use `collapsibleStyles` instead.
+ */
 export const collapsibleBaseStyle = css`
   :host {
     display: block;

--- a/libs/base/ui/structure/collapsible/src/styles/themes/backoffice.styles.ts
+++ b/libs/base/ui/structure/collapsible/src/styles/themes/backoffice.styles.ts
@@ -50,6 +50,9 @@ const styles = [
   `,
 ];
 
+/**
+ * @deprecated since 1.4, use `collapsibleStyles` instead
+ */
 export const collapsibleBackofficeUI = {
   styles,
 };

--- a/libs/base/ui/structure/collapsible/src/styles/themes/storefront.styles.ts
+++ b/libs/base/ui/structure/collapsible/src/styles/themes/storefront.styles.ts
@@ -34,10 +34,9 @@ const blockAppearance = css`
     box-shadow: var(--oryx-elevation-0) var(--oryx-color-elevation);
   }
 
-  :host(${blockSelector}:active),
-  :host(${blockSelector}[open]) {
+  /* :host(${blockSelector}:active) {
     border-color: var(--oryx-color-primary-10);
-  }
+  } */
 
   :host(${blockSelector}) summary {
     padding-block: 12px;
@@ -47,9 +46,18 @@ const blockAppearance = css`
     We isolate this style for both inline/block since "storybook-addon-pseudo-states"
     doesn't support us otherwise.
   */
-  summary:focus-visible::after {
-    box-shadow: var(--oryx-box-shadow-focus);
+
+  summary:focus-visible {
+    outline: solid 1px var(--oryx-color-focus);
   }
+
+  :host([open]) summary:focus-visible {
+    /* outline-offset: -4px; */
+  }
+
+  /* summary:focus-visible::after {
+    box-shadow: var(--oryx-box-shadow-focus);
+  } */
 
   oryx-button {
     transition-duration: var(--oryx-transition-time-medium);
@@ -67,6 +75,9 @@ const blockAppearance = css`
   }
 `;
 
+/**
+ * @deprecated since 1.4, use `collapsibleStyles` instead
+ */
 export const collapsibleStorefrontUI = {
   styles: [inlineAppearance, blockAppearance],
 };

--- a/libs/base/ui/structure/collapsible/src/styles/themes/storefront.styles.ts
+++ b/libs/base/ui/structure/collapsible/src/styles/themes/storefront.styles.ts
@@ -34,9 +34,9 @@ const blockAppearance = css`
     box-shadow: var(--oryx-elevation-0) var(--oryx-color-elevation);
   }
 
-  /* :host(${blockSelector}:active) {
+  :host(${blockSelector}:active) {
     border-color: var(--oryx-color-primary-10);
-  } */
+  }
 
   :host(${blockSelector}) summary {
     padding-block: 12px;
@@ -52,12 +52,12 @@ const blockAppearance = css`
   }
 
   :host([open]) summary:focus-visible {
-    /* outline-offset: -4px; */
+    outline-offset: -4px;
   }
 
-  /* summary:focus-visible::after {
+  summary:focus-visible::after {
     box-shadow: var(--oryx-box-shadow-focus);
-  } */
+  }
 
   oryx-button {
     transition-duration: var(--oryx-transition-time-medium);

--- a/libs/domain/merchant/offer-list/offer-list.component.ts
+++ b/libs/domain/merchant/offer-list/offer-list.component.ts
@@ -95,6 +95,7 @@ export class MerchantOfferListComponent extends ProductMixin(
         aria-label=${this.i18n('merchant.link-to-<offer>', {
           offer: offer.id,
         })}
+        tabindex="-1"
       >
         <oryx-radio>
           <input

--- a/libs/domain/merchant/offer-list/offer-list.styles.ts
+++ b/libs/domain/merchant/offer-list/offer-list.styles.ts
@@ -1,13 +1,13 @@
 import { css } from 'lit';
 
 export const merchantOffersStyles = css`
-  oryx-collapsible::part(content) {
-    display: grid;
-    gap: 16px;
+  a {
+    display: block;
+    text-decoration: none;
   }
 
-  a {
-    text-decoration: none;
+  a:not(:last-of-type) {
+    margin-block-end: 16px;
   }
 
   oryx-radio {

--- a/libs/domain/search/facet-navigation/facet-navigation.styles.ts
+++ b/libs/domain/search/facet-navigation/facet-navigation.styles.ts
@@ -1,9 +1,33 @@
+import { featureVersion } from '@spryker-oryx/utilities';
 import { css } from 'lit';
 
 export const searchFacetNavigationStyles = css`
   :host {
+    --oryx-collapsible-border: none;
+
     align-items: stretch;
     max-height: 100vh;
     overflow-y: auto;
+    ${featureVersion >= '1.4'
+      ? css`
+          padding: 1px;
+        `
+      : css``}
   }
+
+  ${featureVersion >= '1.4'
+    ? css`
+        :host > * {
+          transition: background-color var(--oryx-transition-time);
+        }
+
+        :host > *:hover {
+          background: var(--oryx-color-neutral-2);
+        }
+
+        :host > *:active {
+          background: var(--oryx-color-neutral-3);
+        }
+      `
+    : css``}
 `;

--- a/libs/domain/search/facet-range/facet-range.styles.ts
+++ b/libs/domain/search/facet-range/facet-range.styles.ts
@@ -1,10 +1,17 @@
-import { screenCss } from '@spryker-oryx/utilities';
-import { css } from 'lit';
+import { featureVersion, screenCss } from '@spryker-oryx/utilities';
+import { css, unsafeCSS } from 'lit';
+
+const padding =
+  featureVersion >= '1.4'
+    ? unsafeCSS(``)
+    : css`
+        :host {
+          padding: 4px 1px;
+        }
+      `;
 
 export const searchRangeFacetStyles = css`
-  :host {
-    padding: 4px 1px;
-  }
+  ${padding}
 
   input {
     appearance: textfield;

--- a/libs/domain/search/facet-value-navigation/facet-value-navigation.styles.ts
+++ b/libs/domain/search/facet-value-navigation/facet-value-navigation.styles.ts
@@ -4,7 +4,7 @@ import { css } from 'lit';
 
 export const facetValueNavigationStyles = css`
   section {
-    ${headingUtil(HeadingTag.H6)}
+    ${featureVersion >= '1.4' ? css`` : headingUtil(HeadingTag.H6)}
 
     display: flex;
     align-items: center;

--- a/libs/domain/search/facet-value-navigation/facet-value-navigation.styles.ts
+++ b/libs/domain/search/facet-value-navigation/facet-value-navigation.styles.ts
@@ -1,17 +1,18 @@
+import { HeadingTag, headingUtil } from '@spryker-oryx/ui/heading';
 import { featureVersion } from '@spryker-oryx/utilities';
 import { css } from 'lit';
 
 export const facetValueNavigationStyles = css`
   section {
+    ${headingUtil(HeadingTag.H6)}
+
     display: flex;
     align-items: center;
     flex-grow: 1;
-    font-size: 16px;
-    font-weight: normal;
   }
 
   section oryx-button {
-    font-size: 14px;
+    font-size: 1rem;
     margin-inline-start: auto;
   }
 
@@ -38,10 +39,6 @@ export const facetValueNavigationStyles = css`
   oryx-collapsible {
     width: 100%;
     border: none;
-  }
-
-  oryx-collapsible::part(heading) {
-    padding-block: 10px;
   }
 
   slot:not([name]) {

--- a/libs/domain/search/facet/facet.styles.ts
+++ b/libs/domain/search/facet/facet.styles.ts
@@ -1,9 +1,17 @@
-import { css } from 'lit';
+import { featureVersion } from '@spryker-oryx/utilities';
+import { css, unsafeCSS } from 'lit';
+
+const padding =
+  featureVersion >= '1.4'
+    ? unsafeCSS(``)
+    : css`
+        :host {
+          padding: 4px 1px;
+        }
+      `;
 
 export const searchFacetStyles = css`
-  :host {
-    padding: 4px 1px;
-  }
+  ${padding}
 
   ul {
     display: flex;

--- a/libs/platform/experience/src/color/colors/gray/spryker-sf.ts
+++ b/libs/platform/experience/src/color/colors/gray/spryker-sf.ts
@@ -5,7 +5,7 @@ export const sprykerSfGray: Color = {
   light: {
     0: '#FFFFFF',
     1: '#FFFFFF',
-    2: '',
+    2: '#F8F8F8',
     3: '#F5F5F5',
     4: '#E7EAEE',
     5: '#E1E1E1',

--- a/libs/platform/experience/src/services/layout/plugins/properties/divider/divider.styles.ts
+++ b/libs/platform/experience/src/services/layout/plugins/properties/divider/divider.styles.ts
@@ -6,9 +6,7 @@ export const commonStyle = css`
     --_divider: var(--oryx-divider-width, 1px) var(--oryx-divider-style, solid)
       var(--oryx-divider-color, var(--oryx-color-neutral-6));
   }
-`;
 
-export const horizontalInBetweenStyles = css`
   *:not(:first-child),
   ::slotted(*:not(:first-child)) {
     position: relative;
@@ -19,6 +17,14 @@ export const horizontalInBetweenStyles = css`
     content: '';
     position: absolute;
     inset: 0;
+    pointer-events: none;
+    z-index: -1;
+  }
+`;
+
+export const horizontalInBetweenStyles = css`
+  *:not(:first-child)::before,
+  ::slotted(*:not(:first-child))::before {
     border-inline-start: var(--_divider);
     transform: translateX(
       calc(
@@ -32,16 +38,8 @@ export const horizontalInBetweenStyles = css`
 `;
 
 export const verticalInBetweenStyles = css`
-  *:not(:first-child),
-  ::slotted(*:not(:first-child)) {
-    position: relative;
-  }
-
   *:not(:first-child)::before,
   ::slotted(*:not(:first-child))::before {
-    content: '';
-    position: absolute;
-    inset: 0;
     width: 100%;
     border-block-start: var(--_divider);
     transform: translateY(

--- a/libs/template/presets/storefront/experience/pages/category-page.ts
+++ b/libs/template/presets/storefront/experience/pages/category-page.ts
@@ -37,7 +37,14 @@ export const categoryPage: ExperienceComponent = {
             rules: [
               {
                 layout:
-                  featureVersion >= '1.2'
+                  featureVersion >= '1.4'
+                    ? {
+                        type: 'list',
+                        vertical: true,
+                        divider: true,
+                        sticky: true,
+                      }
+                    : featureVersion >= '1.2'
                     ? {
                         type: 'grid',
                         divider: true,

--- a/libs/template/presets/storefront/experience/pages/search-page.ts
+++ b/libs/template/presets/storefront/experience/pages/search-page.ts
@@ -36,7 +36,14 @@ export const searchPage: ExperienceComponent = {
             rules: [
               {
                 layout:
-                  featureVersion >= '1.2'
+                  featureVersion >= '1.4'
+                    ? {
+                        type: 'list',
+                        vertical: true,
+                        divider: true,
+                        sticky: true,
+                      }
+                    : featureVersion >= '1.2'
                     ? {
                         type: 'grid',
                         divider: true,

--- a/libs/template/themes/design-tokens/src/backoffice/collapsible.token.ts
+++ b/libs/template/themes/design-tokens/src/backoffice/collapsible.token.ts
@@ -1,0 +1,12 @@
+import { DesignToken } from '@spryker-oryx/experience';
+
+export const collapsibleTokens: DesignToken[] = [
+  {
+    collapsible: {
+      background: 'var(--oryx-color-neutral-3)',
+      divider: 'solid 1px var(--oryx-color-neutral-6)',
+      hover: 'var(--oryx-color-neutral-6)',
+      border: 'none',
+    },
+  },
+];

--- a/libs/template/themes/design-tokens/src/backoffice/collapsible.token.ts
+++ b/libs/template/themes/design-tokens/src/backoffice/collapsible.token.ts
@@ -7,6 +7,12 @@ export const collapsibleTokens: DesignToken[] = [
       divider: 'solid 1px var(--oryx-color-neutral-6)',
       hover: 'var(--oryx-color-neutral-6)',
       border: 'none',
+      text: {
+        size: 'var(--oryx-typography-subtitle-small-size)',
+        weight: 'var(--oryx-typography-subtitle-small-weight)',
+        height: 'var(--oryx-typography-subtitle-small-height)',
+        transform: 'uppercase',
+      },
     },
   },
 ];

--- a/libs/template/themes/design-tokens/src/backoffice/collapsible.token.ts
+++ b/libs/template/themes/design-tokens/src/backoffice/collapsible.token.ts
@@ -10,7 +10,7 @@ export const collapsibleTokens: DesignToken[] = [
       text: {
         size: 'var(--oryx-typography-subtitle-small-size)',
         weight: 'var(--oryx-typography-subtitle-small-weight)',
-        height: 'var(--oryx-typography-subtitle-small-height)',
+        height: 'var(--oryx-typography-subtitle-small-line)',
         transform: 'uppercase',
       },
     },

--- a/libs/template/themes/design-tokens/src/backoffice/index.ts
+++ b/libs/template/themes/design-tokens/src/backoffice/index.ts
@@ -4,6 +4,7 @@ import { color } from '../color.tokens';
 import { commonTokens, commonTokensSmall } from '../common-tokens';
 import { layoutSmTokens, layoutTokens } from '../layout.tokens';
 import { buttonTokens } from './button.token';
+import { collapsibleTokens } from './collapsible.token';
 import { layoutMdTokens } from './layout.tokens';
 import { tokens } from './other.tokens';
 import {
@@ -14,6 +15,7 @@ import {
 
 export const backofficeTokens: DesignToken[] = [
   ...buttonTokens,
+  ...collapsibleTokens,
   {
     color,
     ...commonTokens,

--- a/libs/template/themes/design-tokens/src/color.tokens.ts
+++ b/libs/template/themes/design-tokens/src/color.tokens.ts
@@ -1,7 +1,11 @@
 import { ColorDesignTokens, colorPalette } from '@spryker-oryx/experience';
+import { featureVersion } from '@spryker-oryx/utilities';
 
 export const color: ColorDesignTokens = {
-  neutral: colorPalette.grays.sprykerSfGray,
+  neutral:
+    featureVersion >= '1.4'
+      ? colorPalette.grays.gray
+      : colorPalette.grays.sprykerSfGray,
   primary: colorPalette.colors.spryker,
   secondary: colorPalette.colors.amber,
 

--- a/libs/template/themes/design-tokens/src/color.tokens.ts
+++ b/libs/template/themes/design-tokens/src/color.tokens.ts
@@ -1,11 +1,7 @@
 import { ColorDesignTokens, colorPalette } from '@spryker-oryx/experience';
-import { featureVersion } from '@spryker-oryx/utilities';
 
 export const color: ColorDesignTokens = {
-  neutral:
-    featureVersion >= '1.4'
-      ? colorPalette.grays.gray
-      : colorPalette.grays.sprykerSfGray,
+  neutral: colorPalette.grays.sprykerSfGray,
   primary: colorPalette.colors.spryker,
   secondary: colorPalette.colors.amber,
 


### PR DESCRIPTION
We've added a clear outline to the summary of the collapsible components. 

closes: [HRZ-90969](https://spryker.atlassian.net/browse/HRZ-90969)

[HRZ-90969]: https://spryker.atlassian.net/browse/HRZ-90969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ