### PR TITLE
chore: use current year in static data

### DIFF
--- a/libs/template/labs/src/articles/article-page.ts
+++ b/libs/template/labs/src/articles/article-page.ts
@@ -12,7 +12,7 @@ export const experienceArticlePages = [
     components: [
       {
         type: 'oryx-content-text',
-        content: { data: { text: `©️ 2023 Spryker` } },
+        content: { data: { text: `©️ ${new Date().getFullYear()} Spryker` } },
       },
       {
         type: 'oryx-content-list',

--- a/libs/template/presets/storefront/experience/footer.ts
+++ b/libs/template/presets/storefront/experience/footer.ts
@@ -32,7 +32,7 @@ const legalLinks: ExperienceComponent = {
   components: [
     {
       type: 'oryx-content-text',
-      content: { data: { text: `©️ 2023 Spryker` } },
+      content: { data: { text: `©️ ${new Date().getFullYear()} Spryker` } },
     },
     link('Imprint', '/faq/imprint'),
     link('Terms & conditions', '/article/terms-and-conditions'),
@@ -290,12 +290,13 @@ export const FooterTemplate: ExperienceComponent = {
             : 'flex',
         top: '100%',
         background: 'var(--oryx-color-neutral-3)',
-        padding: '30 0',
+        padding: '30px 0',
         typography: 'small',
         style: 'line-height: 24px;',
         ...(featureVersion >= '1.2'
           ? {}
           : { divider: true, bleed: true, sticky: true }),
+        ...(featureVersion >= '1.4' ? { gap: 0 } : {}),
       },
     ],
   },


### PR DESCRIPTION
We use the current year in the static sample data, so that it's fresh in every new year.

closes: [HRZ-90986](https://spryker.atlassian.net/browse/HRZ-90986)

[HRZ-90986]: https://spryker.atlassian.net/browse/HRZ-90986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ