### PR TITLE
refactor: coupon UI improvements

### DIFF
--- a/apps/storefront-e2e/src/support/page-objects/cart.page.ts
+++ b/apps/storefront-e2e/src/support/page-objects/cart.page.ts
@@ -33,7 +33,7 @@ export class CartPage extends AbstractSFPage {
   getCouponInputError = () =>
     this.getCouponComponent().find('oryx-error-message');
   getCouponBtn = () => this.getCouponComponent().find('oryx-button');
-  getCouponCode = () => this.getCouponComponent().find('li');
+  getCouponCode = () => this.getCouponComponent().find('div');
   getCouponDate = () => this.getCouponComponent().find('oryx-date');
   getCouponNotification = () => cy.get('oryx-notification');
 

--- a/libs/domain/cart/coupon/coupon.component.spec.ts
+++ b/libs/domain/cart/coupon/coupon.component.spec.ts
@@ -86,7 +86,7 @@ describe('CouponComponent', () => {
     });
 
     it('should render the coupon list', async () => {
-      const couponElements = element.shadowRoot?.querySelectorAll('li');
+      const couponElements = element.shadowRoot?.querySelectorAll('div');
       expect(couponElements?.length).toBe(coupons.length);
 
       couponElements?.forEach((couponElement, index) => {
@@ -105,26 +105,41 @@ describe('CouponComponent', () => {
     });
 
     it('should not render the coupon list', async () => {
-      const couponElements = element.shadowRoot?.querySelectorAll('li');
+      const couponElements = element.shadowRoot?.querySelectorAll('div');
       expect(couponElements?.length).toBe(0);
     });
   });
 
-  describe('when applying coupon successfully', () => {
+  describe('when a valid coupon is added', () => {
+    const couponCode = '12grVfg';
     beforeEach(async () => {
       service.addCoupon = vi.fn().mockReturnValue(of());
       element = await fixture(html`<oryx-cart-coupon></oryx-cart-coupon>`);
+      element.coupon!.value = couponCode;
     });
 
-    it('should call addCoupon', async () => {
-      const couponCode = '12grVfg';
-      element.coupon!.value = couponCode;
+    describe('and the button is clicked', () => {
+      beforeEach(async () => {
+        const button =
+          element.shadowRoot?.querySelector<HTMLElement>('oryx-button');
+        button?.click();
+      });
 
-      const button =
-        element.shadowRoot?.querySelector<HTMLElement>('oryx-button');
-      button?.click();
+      it('should call addCoupon', async () => {
+        expect(service.addCoupon).toHaveBeenCalledWith({ code: couponCode });
+      });
+    });
 
-      expect(service.addCoupon).toHaveBeenCalledWith({ code: couponCode });
+    describe('and the enter key is used', () => {
+      beforeEach(async () => {
+        const input =
+          element.shadowRoot?.querySelector<HTMLInputElement>('input');
+        input?.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }));
+      });
+
+      it('should call addCoupon', async () => {
+        expect(service.addCoupon).toHaveBeenCalledWith({ code: couponCode });
+      });
     });
   });
 

--- a/libs/domain/cart/coupon/coupon.component.ts
+++ b/libs/domain/cart/coupon/coupon.component.ts
@@ -109,10 +109,7 @@ export class CouponComponent extends CartComponentMixin(
 
         this.coupon!.value = '';
       },
-      error: (e) => {
-        console.log(e);
-        this.hasError = true;
-      },
+      error: () => (this.hasError = true),
     });
   }
 }

--- a/libs/domain/cart/coupon/coupon.component.ts
+++ b/libs/domain/cart/coupon/coupon.component.ts
@@ -20,69 +20,72 @@ export class CouponComponent extends CartComponentMixin(
 
   @state() hasError = false;
 
-  @query('input[name=coupon]') coupon?: HTMLInputElement;
+  @query('input') coupon?: HTMLInputElement;
 
   protected cartService = resolve(CartService);
   protected notificationService = resolve(NotificationService);
 
   protected override render(): TemplateResult | void {
-    if (this.$isEmpty()) {
-      return;
-    }
+    if (this.$isEmpty()) return;
 
     return html`
-      <oryx-layout>
-        <h3>${this.i18n('coupon.have-a-coupon')}</h3>
+      <oryx-input
+        ?hasError="${this.hasError}"
+        .errorMessage="${this.hasError
+          ? `${
+              !this.coupon?.value
+                ? this.i18n('coupon.insert')
+                : this.i18n('coupon.invalid')
+            }`
+          : ''}"
+      >
+        <input
+          placeholder=${this.i18n('coupon.have-a-coupon')}
+          @keyup=${this.onKeyup}
+        />
+        <oryx-button
+          slot="suffix"
+          .type="${ButtonType.Solid}"
+          .color="${ColorType.Neutral}"
+          .size=${ButtonSize.Sm}
+          @click=${this.onSubmit}
+        >
+          ${this.i18n('coupon.apply')}
+        </oryx-button>
+      </oryx-input>
 
-        <section>
-          <oryx-input
-            ?hasError="${this.hasError}"
-            .errorMessage="${this.hasError
-              ? `${
-                  !this.coupon?.value
-                    ? this.i18n('coupon.insert')
-                    : this.i18n('coupon.invalid')
-                }`
-              : ''}"
-          >
-            <input
-              placeholder="${this.i18n('coupon.coupon-code')}"
-              name="coupon"
-            />
-          </oryx-input>
-          <oryx-button
-            .type="${ButtonType.Outline}"
-            .color="${ColorType.Neutral}"
-            .size=${ButtonSize.Md}
-            @click=${this.onSubmit}
-          >
-            ${this.i18n('coupon.apply')}
-          </oryx-button>
-        </section>
-      </oryx-layout>
-
-      <ul>
-        ${repeat(
-          this.$coupons(),
-          (coupon) => coupon.code,
-          (coupon) => {
-            return html`
-              <li>
-                <oryx-icon .type="${IconTypes.Check}"></oryx-icon>
-                <span class="code">${coupon.code} </span>
-                <span class="name">
-                  ${coupon.displayName}
-                  <oryx-date
-                    .stamp=${coupon.expirationDateTime}
-                    .i18nToken=${'coupon.(valid-till-<date>)'}
-                  ></oryx-date>
-                </span>
-              </li>
-            `;
-          }
-        )}
-      </ul>
+      ${this.renderCoupons()}
     `;
+  }
+
+  protected renderCoupons(): TemplateResult | void {
+    return html`
+      ${repeat(
+        this.$coupons(),
+        (coupon) => coupon.code,
+        (coupon) => {
+          return html`
+            <div>
+              <oryx-icon .type="${IconTypes.Check}"></oryx-icon>
+              <span class="code">${coupon.code} </span>
+              <span class="name">
+                ${coupon.displayName}
+                <oryx-date
+                  .stamp=${coupon.expirationDateTime}
+                  .i18nToken=${'coupon.valid-till-<date>'}
+                ></oryx-date>
+              </span>
+            </div>
+          `;
+        }
+      )}
+    `;
+  }
+
+  protected onKeyup(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      this.onSubmit();
+    }
   }
 
   protected onSubmit(): void {
@@ -91,7 +94,6 @@ export class CouponComponent extends CartComponentMixin(
 
     if (!coupon) {
       this.hasError = true;
-
       return;
     }
 
@@ -107,7 +109,8 @@ export class CouponComponent extends CartComponentMixin(
 
         this.coupon!.value = '';
       },
-      error: () => {
+      error: (e) => {
+        console.log(e);
         this.hasError = true;
       },
     });

--- a/libs/domain/cart/coupon/coupon.schema.ts
+++ b/libs/domain/cart/coupon/coupon.schema.ts
@@ -3,4 +3,5 @@ import { ContentComponentSchema } from '@spryker-oryx/experience';
 export const couponComponentSchema: ContentComponentSchema = {
   name: 'Coupon',
   group: 'Cart',
+  icon: 'sell',
 };

--- a/libs/domain/cart/coupon/coupon.styles.ts
+++ b/libs/domain/cart/coupon/coupon.styles.ts
@@ -2,29 +2,16 @@ import { HeadingTag, headingUtil } from '@spryker-oryx/ui/heading';
 import { css } from 'lit';
 
 export const couponStyles = css`
-  h3 {
-    ${headingUtil(HeadingTag.H5, { margin: '0 0 8px' })};
-  }
-
-  section {
+  :host {
     display: grid;
-    grid-template-columns: 1fr min-content;
-    gap: 20px;
-    align-items: start;
+    gap: 8px;
   }
 
-  ul {
-    list-style-type: none;
-    padding: 0;
-    margin: 10px 0 0;
-    grid-column: 1;
-  }
-
-  li {
+  div {
     display: grid;
     column-gap: 10px;
     align-items: center;
-    grid-template-columns: max-content 1fr max-content;
+    grid-template-columns: max-content 1fr;
   }
 
   .code {
@@ -38,5 +25,12 @@ export const couponStyles = css`
 
   oryx-icon {
     color: var(--oryx-color-success-9);
+  }
+
+  oryx-button {
+    --_height: 24px;
+
+    padding: 7px;
+    margin-inline-end: 0;
   }
 `;

--- a/libs/domain/cart/coupon/index.ts
+++ b/libs/domain/cart/coupon/index.ts
@@ -1,2 +1,3 @@
 export * from './coupon.component';
+export * from './coupon.schema';
 export * from './coupon.styles';

--- a/libs/template/presets/storefront/experience/pages/cart-page.ts
+++ b/libs/template/presets/storefront/experience/pages/cart-page.ts
@@ -71,11 +71,7 @@ export const cartPage: ExperienceComponent = {
               ],
             },
             { type: 'oryx-checkout-link' },
-            featureVersion >= '1.4'
-              ? {
-                  type: 'oryx-cart-coupon',
-                }
-              : {},
+            featureVersion >= '1.4' ? { type: 'oryx-cart-coupon' } : {},
           ],
           options: {
             rules: [


### PR DESCRIPTION
- add coupon by enter key
- slim UI: integrated button in the coupon UI, dropped coupon heading

closes: [HRZ-90987](https://spryker.atlassian.net/browse/HRZ-90987)

[HRZ-90987]: https://spryker.atlassian.net/browse/HRZ-90987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ