### PR TITLE
feat: Added dropdown behaviour on hover

### DIFF
--- a/libs/base/ui/overlays/dropdown/dropdown.component.spec.ts
+++ b/libs/base/ui/overlays/dropdown/dropdown.component.spec.ts
@@ -63,22 +63,32 @@ describe('DropdownComponent', () => {
       expect(element).not.toContainElement('oryx-popover[show]');
     });
 
-    describe('and mouseover event dispatched', () => {
+    describe('and mouseenter event dispatched', () => {
       beforeEach(async () => {
-        element.dispatchEvent(new MouseEvent('mouseover'));
+        element.dispatchEvent(new MouseEvent('mouseenter'));
       });
 
       it('should show the popover', async () => {
         expect(element).toContainElement('oryx-popover[show]');
       });
 
-      describe('and mouseout event dispatched', () => {
+      describe('and mouseleave event dispatched', () => {
         beforeEach(async () => {
-          element.dispatchEvent(new MouseEvent('mouseout'));
+          element.dispatchEvent(new MouseEvent('mouseleave'));
         });
 
         it('should not yet hide the popover', async () => {
           expect(element).toContainElement('oryx-popover[show]');
+        });
+
+        describe('but when 99ms have passed', () => {
+          beforeEach(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 99));
+          });
+
+          it('should still show the popover', async () => {
+            expect(element).toContainElement('oryx-popover[show]');
+          });
         });
 
         describe('but when 100ms have passed', () => {

--- a/libs/base/ui/overlays/dropdown/dropdown.component.spec.ts
+++ b/libs/base/ui/overlays/dropdown/dropdown.component.spec.ts
@@ -52,6 +52,48 @@ describe('DropdownComponent', () => {
     });
   });
 
+  describe('when openOnHover property is assigned', () => {
+    beforeEach(async () => {
+      element = await fixture(
+        html`<oryx-dropdown openOnHover></oryx-dropdown>`
+      );
+    });
+
+    it('should hide the popover', async () => {
+      expect(element).not.toContainElement('oryx-popover[show]');
+    });
+
+    describe('and mouseover event dispatched', () => {
+      beforeEach(async () => {
+        element.dispatchEvent(new MouseEvent('mouseover'));
+      });
+
+      it('should show the popover', async () => {
+        expect(element).toContainElement('oryx-popover[show]');
+      });
+
+      describe('and mouseout event dispatched', () => {
+        beforeEach(async () => {
+          element.dispatchEvent(new MouseEvent('mouseout'));
+        });
+
+        it('should not yet hide the popover', async () => {
+          expect(element).toContainElement('oryx-popover[show]');
+        });
+
+        describe('but when 100ms have passed', () => {
+          beforeEach(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+          });
+
+          it('should hide the popover', async () => {
+            expect(element).not.toContainElement('oryx-popover[show]');
+          });
+        });
+      });
+    });
+  });
+
   // describe('when "oryx.close" event dispatched', () => {
   //   let input: HTMLInputElement | null | undefined;
 

--- a/libs/base/ui/overlays/dropdown/dropdown.component.spec.ts
+++ b/libs/base/ui/overlays/dropdown/dropdown.component.spec.ts
@@ -74,7 +74,12 @@ describe('DropdownComponent', () => {
 
       describe('and mouseleave event dispatched', () => {
         beforeEach(async () => {
+          vi.useFakeTimers();
           element.dispatchEvent(new MouseEvent('mouseleave'));
+        });
+
+        afterEach(() => {
+          vi.clearAllTimers();
         });
 
         it('should not yet hide the popover', async () => {
@@ -83,7 +88,7 @@ describe('DropdownComponent', () => {
 
         describe('but when 99ms have passed', () => {
           beforeEach(async () => {
-            await new Promise((resolve) => setTimeout(resolve, 99));
+            vi.advanceTimersByTime(99);
           });
 
           it('should still show the popover', async () => {
@@ -93,7 +98,7 @@ describe('DropdownComponent', () => {
 
         describe('but when 100ms have passed', () => {
           beforeEach(async () => {
-            await new Promise((resolve) => setTimeout(resolve, 100));
+            vi.advanceTimersByTime(100);
           });
 
           it('should hide the popover', async () => {

--- a/libs/base/ui/overlays/dropdown/dropdown.component.ts
+++ b/libs/base/ui/overlays/dropdown/dropdown.component.ts
@@ -23,15 +23,13 @@ export class DropdownComponent
   /**
    * @deprecated not needed to keep a reference to the controller.
    */
-  protected controller?: PopoverController =
-    featureVersion >= '1.4'
-      ? undefined
-      : new PopoverController(this, {
-          boundingElement: this,
-        });
+  protected controller?: PopoverController = new PopoverController(this, {
+    boundingElement: this,
+  });
 
   @property({ reflect: true, type: Boolean }) open?: boolean;
   @property({ type: Boolean }) showOnFocus?: boolean;
+  @property({ type: Boolean }) openOnHover?: boolean;
   @property({ reflect: true }) position?: Position;
   @property({ type: Boolean, attribute: 'vertical-align' })
   verticalAlign?: boolean;
@@ -41,16 +39,6 @@ export class DropdownComponent
    * @deprecated since version 1.4 use the i18n token 'ui.toggle-dropdown' instead
    */
   @property() toggleButtonAriaLabel = 'Toggle dropdown';
-
-  connectedCallback(): void {
-    if (featureVersion >= '1.4') {
-      new PopoverController(this, {
-        boundingElement: this,
-        showOnFocus: this.showOnFocus,
-      });
-    }
-    super.connectedCallback();
-  }
 
   protected override render(): TemplateResult {
     return html`

--- a/libs/base/ui/overlays/dropdown/dropdown.model.ts
+++ b/libs/base/ui/overlays/dropdown/dropdown.model.ts
@@ -45,7 +45,14 @@ export interface DropdownProperties {
   triggerIconSize?: Size;
 
   /**
+   * Indicates that the popover will be opened on hover. The keyboard user will have a similarly
+   * experience when the focus is moved to the trigger element.
+   */
+  openOnHover?: boolean;
+
+  /**
    * Indicates that the popover will be opened on focus.
+   * @deprecated since version 1.4 use openOnHover instead
    */
   showOnFocus?: boolean;
 }

--- a/libs/base/ui/overlays/dropdown/stories/demo.stories.ts
+++ b/libs/base/ui/overlays/dropdown/stories/demo.stories.ts
@@ -15,7 +15,7 @@ export default {
     triggerIconSize: Size.Md,
     content: 'options',
     customTrigger: false,
-    showOnFocus: false,
+    openOnHover: false,
   },
   argTypes: {
     position: {
@@ -91,7 +91,7 @@ const Template: Story<Props> = (props: Props): TemplateResult => {
         <oryx-dropdown
           position=${props.position}
           ?vertical-align=${props.verticalAlign}
-          ?showOnFocus=${props.showOnFocus}
+          ?openOnHover=${props.openOnHover}
           triggerIconSize=${props.triggerIconSize}
           @oryx.close=${(): void => console.log('close')}
         >

--- a/libs/base/ui/overlays/popover/src/controllers/toggle.controller.spec.ts
+++ b/libs/base/ui/overlays/popover/src/controllers/toggle.controller.spec.ts
@@ -2,7 +2,7 @@ import { dispatchKeydown, userAgentSafariMacOsX154 } from '@/tools/testing';
 import { fixture } from '@open-wc/testing-helpers';
 import { a11yConfig } from '@spryker-oryx/utilities';
 import { clear, mockUserAgent } from 'jest-useragent-mock';
-import { html, LitElement, TemplateResult } from 'lit';
+import { LitElement, TemplateResult, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { PopoverComponent } from '../popover.component';
 import { CLOSE_EVENT } from '../popover.model';
@@ -436,10 +436,14 @@ describe('ToggleController', () => {
       </fake-popover-not-open-on-focus>`);
     });
 
-    it('should not show the popover', () => {
-      element.dispatchEvent(new Event('focusin', { bubbles: true }));
+    describe('and the focusin event is dispatched', () => {
+      beforeEach(() => {
+        element.dispatchEvent(new Event('focusin', { bubbles: true }));
+      });
 
-      expect(utils.popover()?.hasAttribute('show')).toBe(false);
+      it('should not show the popover', () => {
+        expect(utils.popover()?.hasAttribute('show')).toBe(false);
+      });
     });
   });
 

--- a/libs/base/ui/overlays/popover/src/controllers/toggle.controller.ts
+++ b/libs/base/ui/overlays/popover/src/controllers/toggle.controller.ts
@@ -1,5 +1,5 @@
 import { isSafari, nonFocusableOnClickInSafari } from '@spryker-oryx/ui';
-import { debounce, isFocusable } from '@spryker-oryx/utilities';
+import { debounce, isFocusable, throttle } from '@spryker-oryx/utilities';
 import { LitElement, ReactiveController } from 'lit';
 import { getControl } from '../../../../form/utilities';
 import { PopoverComponent } from '../popover.component';
@@ -95,6 +95,7 @@ export class ToggleController implements ReactiveController {
     this.host.removeEventListener('keyup', this.handleKeyup);
     this.host.removeEventListener('mouseenter', this.handleMouseEnter);
     this.host.removeEventListener('mouseleave', this.handleMouseLeave);
+    this.host.removeEventListener('mousemove', this.handleMouseMove);
   }
 
   protected handleBlur(): void {
@@ -340,6 +341,6 @@ export class ToggleController implements ReactiveController {
     this.handleContentCloseEvent = this.handleContentCloseEvent.bind(this);
     this.handleMouseEnter = this.handleMouseEnter.bind(this);
     this.handleMouseLeave = this.handleMouseLeave.bind(this);
-    this.handleMouseMove = this.handleMouseMove.bind(this);
+    this.handleMouseMove = throttle(this.handleMouseMove.bind(this), 50);
   }
 }

--- a/libs/base/ui/overlays/popover/src/controllers/toggle.controller.ts
+++ b/libs/base/ui/overlays/popover/src/controllers/toggle.controller.ts
@@ -70,9 +70,9 @@ export class ToggleController implements ReactiveController {
     this.host.addEventListener('keydown', this.handleKeydown);
     this.host.addEventListener('keyup', this.handleKeyup);
 
-    this.host.addEventListener('mouseenter', this.handleMouseOver);
+    this.host.addEventListener('mouseenter', this.handleMouseEnter);
     this.host.addEventListener('mousemove', this.handleMouseMove);
-    this.host.addEventListener('mouseleave', this.handleMouseOut);
+    this.host.addEventListener('mouseleave', this.handleMouseLeave);
 
     if (this.host.hasAttribute('open')) {
       //simulate first updated hook
@@ -93,8 +93,8 @@ export class ToggleController implements ReactiveController {
     this.host.removeEventListener('mouseup', this.handleMouseup);
     this.host.removeEventListener('keydown', this.handleKeydown);
     this.host.removeEventListener('keyup', this.handleKeyup);
-    this.host.removeEventListener('mouseenter', this.handleMouseOver);
-    this.host.removeEventListener('mouseleave', this.handleMouseOut);
+    this.host.removeEventListener('mouseenter', this.handleMouseEnter);
+    this.host.removeEventListener('mouseleave', this.handleMouseLeave);
   }
 
   protected handleBlur(): void {
@@ -125,7 +125,7 @@ export class ToggleController implements ReactiveController {
     this.focusShouldBeFocusedMaybe();
   }
 
-  protected handleMouseOver(): void {
+  protected handleMouseEnter(): void {
     if (!this.host.openOnHover) return;
     this.host.dispatchEvent(new Event('focusin'));
   }
@@ -134,51 +134,16 @@ export class ToggleController implements ReactiveController {
     this.lastMouseMove = Date.now();
   }
 
-  /**
-   * Handle mouse out event when the host is configured to open on hover.
-   * The popover should be closed when the mouse is out of the host and the popover,
-   * but not when the mouse is out of the host and over the popover.
-   *
-   * The popover should be closed after a delay to allow the user to move the mouse
-   * from the host to the popover. During this time the mouse coordinates are tracked.
-   */
-  protected handleMouseOut(): void {
+  protected handleMouseLeave(): void {
     if (!this.host.openOnHover) return;
+
     const currentTimestamp = Date.now();
 
     debounce(() => {
       if (currentTimestamp > this.lastMouseMove) {
         this.host.dispatchEvent(new Event('focusout'));
       }
-    }, 300)();
-
-    // let mouseX: number, mouseY: number;
-    // const syncMouseCoordinates = (e: MouseEvent) => {
-    //   mouseX = e.clientX;
-    //   mouseY = e.clientY;
-    // };
-
-    // document.addEventListener('mousemove', syncMouseCoordinates);
-
-    // setTimeout(() => {
-    //   document.removeEventListener('mousemove', syncMouseCoordinates);
-    //   const triggerBox = this.host!.getBoundingClientRect();
-    //   const dropdownBox = this.element!.getBoundingClientRect();
-    //   const isInHost =
-    //     mouseX >= triggerBox.left &&
-    //     mouseX <= triggerBox.right &&
-    //     mouseY >= triggerBox.top &&
-    //     mouseY <= triggerBox.bottom;
-    //   const isInPopover =
-    //     mouseX >= dropdownBox.left &&
-    //     mouseX <= dropdownBox.right &&
-    //     mouseY >= dropdownBox.top &&
-    //     mouseY <= dropdownBox.bottom;
-
-    //   if (!isInHost && !isInPopover) {
-    //     this.toggle(false);
-    //   }
-    // }, 100);
+    }, 100)();
   }
 
   protected handleMousedown(e: MouseEvent): void {
@@ -373,8 +338,8 @@ export class ToggleController implements ReactiveController {
     this.handleKeydown = this.handleKeydown.bind(this);
     this.handleKeyup = this.handleKeyup.bind(this);
     this.handleContentCloseEvent = this.handleContentCloseEvent.bind(this);
-    this.handleMouseOver = this.handleMouseOver.bind(this);
-    this.handleMouseOut = this.handleMouseOut.bind(this);
+    this.handleMouseEnter = this.handleMouseEnter.bind(this);
+    this.handleMouseLeave = this.handleMouseLeave.bind(this);
     this.handleMouseMove = this.handleMouseMove.bind(this);
   }
 }

--- a/libs/base/ui/overlays/popover/src/popover.controller.ts
+++ b/libs/base/ui/overlays/popover/src/popover.controller.ts
@@ -115,7 +115,10 @@ export class PopoverController implements ReactiveController {
     );
   }
 
-  constructor(protected host: LitElement, protected options?: PopoverOptions) {
+  constructor(
+    protected host: LitElement & { openOnHover?: boolean },
+    protected options?: PopoverOptions
+  ) {
     this.host.addController(this);
     this.toggleController = new ToggleController(host, {
       elementSelector: this.popoverSelector,

--- a/libs/base/ui/overlays/popover/src/popover.model.ts
+++ b/libs/base/ui/overlays/popover/src/popover.model.ts
@@ -6,6 +6,8 @@ export interface PopoverOptions {
    * using either the mousedown or enter/space keys.
    *
    * Defaults to false.
+   *
+   * @deprecated since version 1.4 use openOnHover on the host element instead
    */
   showOnFocus?: boolean;
 

--- a/libs/platform/experience/src/services/layout/plugins/types/dropdown/dropdown.model.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/dropdown/dropdown.model.ts
@@ -10,6 +10,11 @@ declare global {
 
   export interface LayoutProperty {
     /**
+     * Show the dropdown on hover instead of click.
+     */
+    dropdownOnHover?: boolean;
+
+    /**
      * Horizontal position of the dropdown.
      */
     dropdownPosition?: Position;

--- a/libs/platform/experience/src/services/layout/plugins/types/dropdown/dropdown.plugin.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/dropdown/dropdown.plugin.ts
@@ -39,6 +39,7 @@ export class DropdownLayoutPlugin implements LayoutPlugin {
             outer: html`<oryx-dropdown
               .position=${options.dropdownPosition}
               vertical-align
+              ?openOnHover=${options.dropdownOnHover}
             >
               ${renderLabelSlot(data, 'trigger')}
 

--- a/libs/platform/experience/src/services/layout/plugins/types/dropdown/dropdown.schema.ts
+++ b/libs/platform/experience/src/services/layout/plugins/types/dropdown/dropdown.schema.ts
@@ -1,5 +1,25 @@
 import { ContentComponentSchema } from '@spryker-oryx/experience';
+import { Position } from '@spryker-oryx/ui';
 export const schema: ContentComponentSchema = {
   name: 'dropdown',
   group: 'layout',
+  options: {
+    dropdownPosition: {
+      key: '',
+      label: 'Position',
+      type: 'select',
+      options: [
+        {
+          value: Position.Start,
+        },
+        {
+          value: Position.End,
+        },
+      ],
+    },
+    dropdownOnHover: {
+      label: 'Show on hover',
+      type: 'boolean',
+    },
+  },
 };


### PR DESCRIPTION
Some dropdown components require the popover to show on hover (and focus) rather than click. For example, when the trigger elements contains a link. 

closes: [HRZ-90988](https://spryker.atlassian.net/browse/HRZ-90988)

[HRZ-90988]: https://spryker.atlassian.net/browse/HRZ-90988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ