### PR TITLE
feat(product): Added canonical url for product pages.

### DIFF
--- a/libs/domain/product/src/services/product.providers.ts
+++ b/libs/domain/product/src/services/product.providers.ts
@@ -87,7 +87,11 @@ import {
   ProductRelationsListAdapter,
   ProductRelationsListService,
 } from './related';
-import { ProductDetailsBreadcrumb, ProductListBreadcrumb } from './resolvers';
+import {
+  ProductDetailsBreadcrumb,
+  ProductListBreadcrumb,
+  ProductPageCanonicalUrlResolver,
+} from './resolvers';
 import { ProductPageDescriptionMetaResolver } from './resolvers/product-page-description-meta.resolver';
 import { ProductPageTitleMetaResolver } from './resolvers/product-page-title-meta.resolver';
 import { productRoutes } from './routes';
@@ -199,6 +203,10 @@ export const productProviders: Provider[] = [
   {
     provide: PageMetaResolver,
     useClass: ProductPageDescriptionMetaResolver,
+  },
+  {
+    provide: PageMetaResolver,
+    useClass: ProductPageCanonicalUrlResolver,
   },
   {
     provide: CategoryIdNormalizer,

--- a/libs/domain/product/src/services/resolvers/index.ts
+++ b/libs/domain/product/src/services/resolvers/index.ts
@@ -1,3 +1,4 @@
 export * from './breadcrumb';
+export * from './product-page-canonical-url-meta.resolver';
 export * from './product-page-description-meta.resolver';
 export * from './product-page-title-meta.resolver';

--- a/libs/domain/product/src/services/resolvers/product-page-canonical-url-meta.resolver.spec.ts
+++ b/libs/domain/product/src/services/resolvers/product-page-canonical-url-meta.resolver.spec.ts
@@ -1,0 +1,98 @@
+import { ContextService } from '@spryker-oryx/core';
+import { createInjector, destroyInjector } from '@spryker-oryx/di';
+import {
+  PRODUCT,
+  ProductPageCanonicalUrlResolver,
+} from '@spryker-oryx/product';
+import { LinkService, RouterService } from '@spryker-oryx/router';
+import { of } from 'rxjs';
+
+const mockContextService = {
+  get: vi.fn(),
+};
+
+const mockRouterService = {
+  currentRoute: vi.fn(),
+};
+
+const mockLinkService = {
+  get: vi.fn(),
+};
+
+describe('ProductPageCanonicalUrlResolver', () => {
+  let service: ProductPageCanonicalUrlResolver;
+  let linkService: LinkService;
+
+  beforeEach(() => {
+    const testInjector = createInjector({
+      providers: [
+        {
+          provide: ProductPageCanonicalUrlResolver,
+          useClass: ProductPageCanonicalUrlResolver,
+        },
+        {
+          provide: ContextService,
+          useValue: mockContextService,
+        },
+        {
+          provide: RouterService,
+          useValue: mockRouterService,
+        },
+        {
+          provide: LinkService,
+          useValue: mockLinkService,
+        },
+      ],
+    });
+
+    service = testInjector.inject(ProductPageCanonicalUrlResolver);
+    linkService = testInjector.inject(LinkService);
+  });
+
+  afterEach(() => {
+    destroyInjector();
+    vi.resetAllMocks();
+  });
+
+  describe('getScore', () => {
+    it('should return proper value if product exist', () => {
+      const callback = vi.fn();
+      mockContextService.get.mockReturnValue(of('sku'));
+      mockRouterService.currentRoute.mockReturnValue(of('/product/saf'));
+      service.getScore().subscribe(callback);
+      expect(callback).toHaveBeenCalledWith(['sku', true]);
+    });
+
+    it('should return proper value if product is not exist', () => {
+      const callback = vi.fn();
+      mockContextService.get.mockReturnValue(of(undefined));
+      mockRouterService.currentRoute.mockReturnValue(of(''));
+
+      service.getScore().subscribe(callback);
+      expect(callback).toHaveBeenCalledWith([undefined, false]);
+    });
+  });
+
+  const callback = vi.fn();
+
+  describe('when the qualifier contains other fields', () => {
+    beforeEach(() => {
+      mockContextService.get.mockReturnValue(of({ sku: '123', offer: 'abc' }));
+      mockLinkService.get.mockReturnValue(of('/my-url'));
+      service.resolve().subscribe(callback);
+    });
+
+    it('should request the link for the SKU only', () => {
+      expect(linkService.get).toHaveBeenCalledWith({
+        type: PRODUCT,
+        qualifier: { sku: '123' },
+      });
+    });
+
+    it('should resolve the link in the canonical field', () => {
+      expect(callback).toHaveBeenCalledWith({
+        canonical: 'http://localhost:3000/my-url',
+      });
+    });
+  });
+});

--- a/libs/domain/product/src/services/resolvers/product-page-canonical-url-meta.resolver.ts
+++ b/libs/domain/product/src/services/resolvers/product-page-canonical-url-meta.resolver.ts
@@ -1,0 +1,40 @@
+import {
+  ContextService,
+  ElementResolver,
+  PageMetaResolver,
+} from '@spryker-oryx/core';
+import { inject } from '@spryker-oryx/di';
+import { LinkService, RouterService } from '@spryker-oryx/router';
+import { Observable, combineLatest, map, of, switchMap } from 'rxjs';
+import { PRODUCT } from '../../entity';
+
+export class ProductPageCanonicalUrlResolver implements PageMetaResolver {
+  protected context = inject(ContextService);
+  protected router = inject(RouterService);
+  protected linkService = inject(LinkService);
+
+  getScore(): Observable<unknown[]> {
+    return combineLatest([
+      this.context.get(null, PRODUCT),
+      this.router
+        .currentRoute()
+        .pipe(map((route) => route.includes('product'))),
+    ]);
+  }
+
+  resolve(): Observable<ElementResolver> {
+    return this.context.get(null, PRODUCT).pipe(
+      switchMap((qualifier) => {
+        if (!qualifier) return of({});
+
+        return this.linkService
+          .get({ type: PRODUCT, qualifier: { sku: qualifier.sku } })
+          .pipe(
+            map((link) => ({
+              canonical: `${globalThis.location.origin}${link}`,
+            }))
+          );
+      })
+    );
+  }
+}

--- a/libs/platform/core/server/services/page-meta/server-page-meta.service.ts
+++ b/libs/platform/core/server/services/page-meta/server-page-meta.service.ts
@@ -13,18 +13,13 @@ export class ServerPageMetaService extends DefaultPageMetaService {
 
     for (const meta of metas) {
       const preload = this.getPreload(meta);
-
-      if (preload) {
-        metas.push(preload);
-      }
+      if (preload) metas.push(preload);
 
       const duplicate = this.metas.find(
         (_meta) => JSON.stringify(_meta) === JSON.stringify(meta)
       );
 
-      if (!duplicate) {
-        this.metas.push(meta);
-      }
+      if (!duplicate) this.metas.push(meta);
     }
   }
 
@@ -93,6 +88,12 @@ export class ServerPageMetaService extends DefaultPageMetaService {
 
       if (tag === 'meta' && name !== 'meta') {
         attrs.name = name;
+      }
+
+      if (name === 'canonical') {
+        attrs.rel = 'canonical';
+        attrs.href = attrs.content;
+        delete attrs.content;
       }
 
       stream[type] += `\n<${tag}${this.setAttributes(attrs)} />`;

--- a/libs/platform/core/src/services/page-meta/default-page-meta.service.spec.ts
+++ b/libs/platform/core/src/services/page-meta/default-page-meta.service.spec.ts
@@ -54,6 +54,36 @@ describe('DefaultPageMetaService', () => {
       expect(charsetMeta).toHaveProperty('content', 'b');
     });
 
+    describe('when a canonical link is added', () => {
+      beforeEach(() => {
+        service.add({
+          name: 'canonical',
+          attrs: { content: 'https://example.com' },
+        });
+      });
+
+      it('should add canonical link to the head of document', () => {
+        expect(document.head).toContainElement(
+          'link[rel="canonical"][href="https://example.com"]'
+        );
+      });
+
+      describe('when the canonical link is removed', () => {
+        beforeEach(() => {
+          service.remove({
+            name: 'canonical',
+            attrs: { content: 'https://example.com' },
+          });
+        });
+
+        it('should no longer have the canonical link in the head of document', () => {
+          expect(document.head).not.toContainElement(
+            'link[rel="canonical"][href="https://example.com"]'
+          );
+        });
+      });
+    });
+
     it('should escape quote symbol', () => {
       service.add([
         {

--- a/libs/platform/core/src/services/page-meta/default-page-meta.service.ts
+++ b/libs/platform/core/src/services/page-meta/default-page-meta.service.ts
@@ -85,6 +85,7 @@ export class DefaultPageMetaService implements PageMetaService {
   }
 
   protected getTagName(name: string): string {
+    if (name === 'canonical') return 'link';
     return ['link', 'style', 'title', 'script', 'html', 'meta'].includes(name)
       ? name
       : 'meta';
@@ -110,6 +111,12 @@ export class DefaultPageMetaService implements PageMetaService {
     const name = this.getTagName(definition.name);
     const element = document.createElement(name);
 
+    if (definition.name === 'canonical') {
+      definition.attrs.rel = 'canonical';
+      definition.attrs.href = definition.attrs.content;
+      delete definition.attrs.content;
+    }
+
     if (name === 'meta' && definition.name !== 'meta') {
       definition.attrs.name = definition.name;
     }
@@ -120,6 +127,12 @@ export class DefaultPageMetaService implements PageMetaService {
 
   protected get(definition: ElementDefinition): HTMLElement | null {
     let attrs = '';
+
+    if (definition.name === 'canonical') {
+      return this.getContainer(definition).querySelector(
+        `link[rel="canonical"]`
+      );
+    }
 
     for (const [key, value] of Object.entries(definition.attrs)) {
       if (key === 'text') {


### PR DESCRIPTION
Product pages can be used in different contexts. To avoid duplicates by crawlers, and potential penalties, a canonical URL is added in the head for the product page. 

Product pages for different (marketplace) offers, for example, have the same canonical URL.

closes:[HRZ-91061](https://spryker.atlassian.net/browse/HRZ-91061)

[HRZ-91061]: https://spryker.atlassian.net/browse/HRZ-91061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ