### PR TITLE
feat: apply e2e test to remove coupon

### DIFF
--- a/apps/storefront-e2e/src/integration/cart.cy.ts
+++ b/apps/storefront-e2e/src/integration/cart.cy.ts
@@ -299,6 +299,36 @@ describe('Cart suite', () => {
           });
         });
       });
+
+      describe('when removing coupon from a cart', () => {
+        beforeEach(() => {
+          user.addProductWithCoupon();
+          user.goToCart();
+
+          cartPage.getCouponInput().type(coupon[0].code);
+          cartPage.getCouponBtn().click();
+          cy.scrollTo('top');
+        });
+
+        it('it should update cart totals', () => {
+          cartPage.getCartTotals().checkTotals({
+            subTotal: '€366.00',
+            discountsTotal: '-€202.48',
+            taxTotal: '€26.11',
+            totalPrice: '€163.52',
+          });
+
+          cartPage.getRemoveCouponBtn().click();
+          cy.scrollTo('top');
+
+          cartPage.getCartTotals().checkTotals({
+            subTotal: '€366.00',
+            discountsTotal: '-€102.48',
+            taxTotal: '€42.07',
+            totalPrice: '€263.52',
+          });
+        });
+      });
     });
   });
 });

--- a/apps/storefront-e2e/src/support/page-objects/cart.page.ts
+++ b/apps/storefront-e2e/src/support/page-objects/cart.page.ts
@@ -35,6 +35,7 @@ export class CartPage extends AbstractSFPage {
   getCouponBtn = () =>
     this.getCouponComponent().find('oryx-input').find('oryx-button');
   getCouponCode = () => this.getCouponComponent().find('div');
+  getRemoveCouponBtn = () => this.getCouponCode().find('oryx-button');
   getCouponDate = () => this.getCouponComponent().find('oryx-date');
   getCouponNotification = () => cy.get('oryx-notification');
 


### PR DESCRIPTION
Update e2e tests when removing coupon

closes: [HRZ-90816](https://spryker.atlassian.net/browse/HRZ-90816)



[HRZ-90816]: https://spryker.atlassian.net/browse/HRZ-90816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ