### PR TITLE
fix(router): same routes duplication

### DIFF
--- a/libs/platform/router/src/services/default-router.service.spec.ts
+++ b/libs/platform/router/src/services/default-router.service.spec.ts
@@ -3,6 +3,7 @@ import { createInjector, destroyInjector } from '@spryker-oryx/di';
 import { RouteConfig } from '@spryker-oryx/router/lit';
 import { of } from 'rxjs';
 import 'urlpattern-polyfill';
+import { SpyInstance } from 'vitest';
 import { DefaultRouterService } from './default-router.service';
 import { RouterEventType, RouterService } from './router.service';
 
@@ -202,6 +203,20 @@ describe('DefaultRouterService', () => {
   it('should return undefined for uncorrected pathId', () => {
     service.navigate('/id/id2/id3');
     expect(service.getPathId('mock')).toBe(undefined);
+  });
+
+  describe('when navigate multiple times to the same route', () => {
+    let spy: SpyInstance;
+    beforeEach(() => {
+      spy = vi.spyOn(service, 'go');
+      service.navigate('/mock');
+      service.navigate('/mock');
+      service.navigate('/mock');
+    });
+
+    it('should call go method only once', () => {
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('should return proper url', () => {

--- a/libs/platform/router/src/services/default-router.service.ts
+++ b/libs/platform/router/src/services/default-router.service.ts
@@ -51,13 +51,7 @@ export class DefaultRouterService implements RouterService {
     const queryParams =
       extras?.queryParams ?? this.getURLSearchParams(url[1]) ?? {};
 
-    if (
-      this.router$.value === url[0] &&
-      JSON.stringify(this.urlSearchParams$.value) ===
-        JSON.stringify(queryParams)
-    ) {
-      return;
-    }
+    if (this.isSameRoute(route, extras)) return;
 
     this.storageService.set(
       PREVIOUS_PAGE,
@@ -76,6 +70,8 @@ export class DefaultRouterService implements RouterService {
 
       return;
     }
+
+    if (this.isSameRoute(route)) return;
 
     globalThis.history.pushState({}, '', route);
     this.go(route);
@@ -210,6 +206,18 @@ export class DefaultRouterService implements RouterService {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           routes.find((r) => getPattern(r).test({ pathname }))!
       )
+    );
+  }
+
+  protected isSameRoute(route: string, extras?: NavigationExtras): boolean {
+    const url = route.split('?');
+    const queryParams =
+      extras?.queryParams ?? this.getURLSearchParams(url[1]) ?? {};
+
+    return (
+      this.router$.value === url[0] &&
+      JSON.stringify(this.urlSearchParams$.value) ===
+        JSON.stringify(queryParams)
     );
   }
 }

--- a/libs/platform/router/src/services/default-router.service.ts
+++ b/libs/platform/router/src/services/default-router.service.ts
@@ -47,11 +47,11 @@ export class DefaultRouterService implements RouterService {
   protected storageService = inject(StorageService);
 
   go(route: string, extras?: NavigationExtras): void {
+    if (this.isSameRoute(route, extras)) return;
+
     const url = route.split('?');
     const queryParams =
       extras?.queryParams ?? this.getURLSearchParams(url[1]) ?? {};
-
-    if (this.isSameRoute(route, extras)) return;
 
     this.storageService.set(
       PREVIOUS_PAGE,
@@ -65,13 +65,13 @@ export class DefaultRouterService implements RouterService {
   }
 
   navigate(route: string): void {
+    if (this.isSameRoute(route)) return;
+
     if (route === RouteType.NotFound) {
       this.router$.next(RouteType.NotFound);
 
       return;
     }
-
-    if (this.isSameRoute(route)) return;
 
     globalThis.history.pushState({}, '', route);
     this.go(route);
@@ -210,12 +210,12 @@ export class DefaultRouterService implements RouterService {
   }
 
   protected isSameRoute(route: string, extras?: NavigationExtras): boolean {
-    const url = route.split('?');
+    const [url, search = ''] = route.split('?');
     const queryParams =
-      extras?.queryParams ?? this.getURLSearchParams(url[1]) ?? {};
+      extras?.queryParams ?? this.getURLSearchParams(search) ?? {};
 
     return (
-      this.router$.value === url[0] &&
+      this.router$.value === url &&
       JSON.stringify(this.urlSearchParams$.value) ===
         JSON.stringify(queryParams)
     );


### PR DESCRIPTION
`navigate` method of the router service is pushing the state to the browser history on each call, even if it pushes the same route multiple times. The fix adds the check that prevent navigation when prev and current routes are the same

closes: [HRZ-90436](https://spryker.atlassian.net/browse/HRZ-90436)


[HRZ-90436]: https://spryker.atlassian.net/browse/HRZ-90436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ