### PR TITLE
fix: offline mode image resource in fulfillment app [WIP]

### DIFF
--- a/libs/domain/picking/picker/picker.component.ts
+++ b/libs/domain/picking/picker/picker.component.ts
@@ -286,26 +286,11 @@ export class PickingPickerComponent extends I18nMixin(
   }
 
   protected renderFallback(): TemplateResult {
-    // temporary/workaround implementation to have image resource on offline mode
-    return html`
-      <section
-        class="
-        ${!this.items?.length || !this.allItemsPicked
-          ? ''
-          : 'hide-image-content'} "
-      >
-        ${this.__renderNoItemsHeading()}
-        <oryx-image resource="no-orders"></oryx-image>
-      </section>
-
-
-      <section class="${this.allItemsPicked ? '' : 'hide-image-content'} ">
-        <oryx-image resource="picking-items-processed"></oryx-image>
-        ${this.__renderFinishPickingHeading()}
-        <span>${this.i18n(`picking.processed.all`)}</span>
-      </section>
-      ${this.renderFinishButton()}
-    `;
+    if (!this.items?.length || !this.allItemsPicked) {
+      return this.renderNoItemsFallback();
+    } else {
+      return this.renderFinishPickingFallback();
+    }
   }
 
   protected get allItemsPicked(): boolean {

--- a/libs/domain/picking/picker/picker.component.ts
+++ b/libs/domain/picking/picker/picker.component.ts
@@ -286,11 +286,26 @@ export class PickingPickerComponent extends I18nMixin(
   }
 
   protected renderFallback(): TemplateResult {
-    if (!this.items?.length || !this.allItemsPicked) {
-      return this.renderNoItemsFallback();
-    } else {
-      return this.renderFinishPickingFallback();
-    }
+    // temporary/workaround implementation to have image resource on offline mode
+    return html`
+      <section
+        class="
+        ${!this.items?.length || !this.allItemsPicked
+          ? ''
+          : 'hide-image-content'} "
+      >
+        ${this.__renderNoItemsHeading()}
+        <oryx-image resource="no-orders"></oryx-image>
+      </section>
+
+
+      <section class="${this.allItemsPicked ? '' : 'hide-image-content'} ">
+        <oryx-image resource="picking-items-processed"></oryx-image>
+        ${this.__renderFinishPickingHeading()}
+        <span>${this.i18n(`picking.processed.all`)}</span>
+      </section>
+      ${this.renderFinishButton()}
+    `;
   }
 
   protected get allItemsPicked(): boolean {

--- a/libs/domain/picking/picker/picker.component.ts
+++ b/libs/domain/picking/picker/picker.component.ts
@@ -286,11 +286,25 @@ export class PickingPickerComponent extends I18nMixin(
   }
 
   protected renderFallback(): TemplateResult {
-    if (!this.items?.length || !this.allItemsPicked) {
-      return this.renderNoItemsFallback();
-    } else {
-      return this.renderFinishPickingFallback();
-    }
+    // temporary/workaround implementation to have image resource on offline mode
+    return html`
+      <section
+        class="
+        ${!this.items?.length || !this.allItemsPicked
+          ? ''
+          : 'hide-image-content'} "
+      >
+        ${this.__renderNoItemsHeading()}
+        <oryx-image resource="no-orders"></oryx-image>
+      </section>
+
+      <section class="${this.allItemsPicked ? '' : 'hide-image-content'} ">
+        <oryx-image resource="picking-items-processed"></oryx-image>
+        ${this.__renderFinishPickingHeading()}
+        <span>${this.i18n(`picking.processed.all`)}</span>
+      </section>
+      ${this.renderFinishButton()}
+    `;
   }
 
   protected get allItemsPicked(): boolean {

--- a/libs/domain/picking/picker/picker.styles.ts
+++ b/libs/domain/picking/picker/picker.styles.ts
@@ -81,4 +81,8 @@ export const pickingComponentStyles = css`
     font-size: 18px;
     font-weight: 600;
   }
+
+  .hide-image-content {
+    display: none;
+  }
 `;

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "@nrwl/storybook": "14.5.8",
         "@nrwl/web": "14.5.8",
         "@nrwl/workspace": "15.7.2",
-        "@percy/cli": "^1.27.4",
+        "@percy/cli": "^1.27.1",
         "@percy/cypress": "^3.1.2",
         "@rollup/plugin-alias": "^4.0.2",
         "@rollup/plugin-commonjs": "^24.0.0",


### PR DESCRIPTION
Workaround implementation to have image resources available when in offline mode.
Cache images resources in bootstrap of the app should be a better approach, but will take some more time to implement

closes:[HRZ-90552](https://spryker.atlassian.net/browse/HRZ-90552)


[HRZ-90552]: https://spryker.atlassian.net/browse/HRZ-90552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ